### PR TITLE
feat: agent-native API — structured returns, replay timestamps, note_to_self

### DIFF
--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -483,20 +483,20 @@ async def rest_register(request: Request) -> JSONResponse:
     try:
         body = await request.json()
     except Exception:
-        return JSONResponse({"accepted": False, "error": "Invalid JSON body"}, 400)
+        return JSONResponse({"error": "Invalid JSON body"}, 400)
 
     task_id = body.get("task_id", "")
     persona_id = body.get("persona_id")
     if not task_id:
         return JSONResponse(
-            {"accepted": False, "error": "Missing required field: task_id"}, 400
+            {"error": "Missing required field: task_id"}, 400
         )
 
     logger.info("[REST] register task_id=%s persona=%s", task_id, persona_id or "auto")
     state = manager.create_rest_session()
     result = await asyncio.to_thread(state.register, task_id, persona_id)
 
-    if result.get("accepted"):
+    if "session_id" in result:
         manager.register_rest_session(state)
         logger.info(
             "[REST] registered session=%s task=%s persona=%s",

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -593,7 +593,11 @@ async def rest_tool_call(request: Request) -> JSONResponse:
         result = await asyncio.to_thread(state.call_domain_tool, name, **body)
     result_preview = str(result)[:150]
     logger.debug("[REST:%s] %s -> %s...", sid[:8], name, result_preview)
-    return JSONResponse({"result": result})
+    try:
+        parsed = json.loads(result)
+    except (json.JSONDecodeError, TypeError):
+        parsed = {"success": True, "output": result}
+    return JSONResponse(parsed)
 
 
 async def rest_send(request: Request) -> JSONResponse:

--- a/bench/server/api/protocol.py
+++ b/bench/server/api/protocol.py
@@ -73,6 +73,7 @@ SEND_MESSAGE_TOOL = Tool(
         "This is the ONLY way to communicate with the student. "
         "Your text output is NOT delivered to the student — "
         "only messages sent through this tool reach them. "
+        "Each call advances the conversation by one turn and cannot be undone. "
         "Returns the student's reply and session status. "
         "When status is 'completed', the session has ended."
     ),

--- a/bench/server/api/protocol.py
+++ b/bench/server/api/protocol.py
@@ -60,7 +60,8 @@ REGISTER_SESSION_TOOL = Tool(
 START_SESSION_TOOL = Tool(
     name="start_session",
     description=(
-        "Start the tutoring session. Returns the student's first message. "
+        "Start the tutoring session. Returns the session background, "
+        "the student's first message, and the list of available tools. "
         "Can only be called once after register_session."
     ),
     inputSchema={"type": "object", "properties": {}, "required": []},
@@ -103,8 +104,10 @@ SEND_MESSAGE_TOOL = Tool(
 GET_BACKGROUND_TOOL = Tool(
     name="get_background",
     description=(
-        "Session background: environment description, interaction constraints, "
-        "and available systems. Call this to re-read your operating context."
+        "Re-read the session background returned by start_session. "
+        "Contains the sandbox environment description, communication "
+        "constraints, and available systems (data directories, runtime "
+        "engines, mounted code). Returns a plain text string."
     ),
     inputSchema={"type": "object", "properties": {}, "required": []},
 )

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -251,7 +251,7 @@ class SessionState:
         try:
             task = self._load_task(task_id)
             if task is None:
-                return {"accepted": False, "error": f"Task not found: {task_id}"}
+                return {"error": f"Task not found: {task_id}"}
 
             self.task = task
             self.task_id = task_id
@@ -313,7 +313,7 @@ class SessionState:
                     SIMULATOR_DEFAULT_MODEL,
                 )
             except RuntimeError as exc:
-                return {"accepted": False, "error": str(exc)}
+                return {"error": str(exc)}
 
             sandbox_img = task.environment.sandbox_image if task.environment else ""
             series = "lean" if sandbox_img and "lean" in sandbox_img else "normal"
@@ -475,24 +475,38 @@ class SessionState:
                 self.persona_id,
                 self.use_docker,
             )
-            return {"accepted": True, "session_id": self.session_id}
+            return {"session_id": self.session_id}
         except Exception as exc:
             logger.exception("Session %s register failed", self.session_id)
             self._reset_registration_state()
-            return {"accepted": False, "error": f"Registration failed: {exc}"}
+            return {"error": f"Registration failed: {exc}"}
 
     # ------------------------------------------------------------------
     # start_session
     # ------------------------------------------------------------------
 
     def start(self) -> dict:
-        """Handle ``start_session()`` — return student opening."""
+        """Handle ``start_session()`` — return student opening + available tools.
+
+        After phase transitions to IN_SESSION, the full tool list is
+        included so the agent can start working without an extra
+        list_tools round-trip.
+        """
         if self._closed:
             return {"error": "Session is closed"}
         result = self.session.handle_start_session()
         self.phase = SessionPhase.IN_SESSION
         logger.info("Session %s started.", self.session_id)
-        return json.loads(result)
+        data = json.loads(result)
+        data["tools"] = [
+            {
+                "name": t.name,
+                "description": t.description or "",
+                "inputSchema": t.inputSchema,
+            }
+            for t in self.get_visible_tools()
+        ]
+        return data
 
     # ------------------------------------------------------------------
     # send_message (routed through proxy for logging)
@@ -594,7 +608,7 @@ class SessionState:
     def call_domain_tool(self, name: str, **kwargs) -> str:
         """Route a domain tool call through the proxy."""
         if self._closed:
-            return "Error: Session is closed"
+            return json.dumps({"success": False, "output": "Error: Session is closed"})
         return self.proxy.call_tool(name, **kwargs)
 
     # ------------------------------------------------------------------
@@ -690,7 +704,7 @@ class SessionState:
             task_id = arguments.get("task_id", "")
             persona_id = arguments.get("persona_id")
             result = await asyncio.to_thread(self.register, task_id, persona_id)
-            if result.get("accepted"):
+            if "session_id" in result:
                 await self._notify_tools_changed()
             return [TextContent(type="text", text=json.dumps(result))]
 

--- a/bench/server/core/proxy.py
+++ b/bench/server/core/proxy.py
@@ -4,6 +4,7 @@ Intercepts all tool calls from the Agent Under Test, logs them,
 forwards to real implementations, logs results, and returns to agent.
 """
 
+import json
 import os
 import re
 import time
@@ -292,7 +293,11 @@ class MCPProxy:
             emit_payload["output_files"] = log.output_files
         _emit("tool_result", emit_payload)
 
-        return log.result
+        # Session API tools (send_message) already return structured JSON.
+        # Only wrap domain tools in {"success", "output"} envelope.
+        if name == "send_message":
+            return log.result
+        return json.dumps({"success": log.success, "output": log.result})
 
     def get_logs(self) -> list[ToolCallLog]:
         """Get all recorded tool call logs."""

--- a/bench/server/core/proxy.py
+++ b/bench/server/core/proxy.py
@@ -45,6 +45,7 @@ class ToolCallLog:
 
     name: str
     args: dict
+    call_id: str = ""
     result: str = ""
     timestamp: float = 0.0
     duration_ms: float = 0.0
@@ -150,7 +151,8 @@ class MCPProxy:
 
         call_id = f"{name}_{len(self._logs)}"
         log = ToolCallLog(
-            name=name, args=kwargs, timestamp=timestamp, turn_index=self._current_turn
+            name=name, args=kwargs, call_id=call_id,
+            timestamp=timestamp, turn_index=self._current_turn,
         )
         _emit("tool_start", {"call_id": call_id, "name": name, "args": kwargs})
 

--- a/bench/server/core/session.py
+++ b/bench/server/core/session.py
@@ -398,7 +398,7 @@ class TutoringSession:
             return json.dumps({"error": "Session already started"})
 
         opening = self._get_student_opening()
-        self._conversation.append({"role": "user", "content": opening})
+        self._conversation.append({"role": "user", "content": opening, "ts": time.time()})
         self._session_info_called = True
 
         background = build_background(self._task)
@@ -491,7 +491,7 @@ class TutoringSession:
         self._last_agent_msg = text
 
         # ── Record agent message + advance turn ──
-        msg_entry: dict = {"role": "assistant", "content": text}
+        msg_entry: dict = {"role": "assistant", "content": text, "ts": time.time()}
         if resolved_attachments:
             msg_entry["attachments"] = resolved_attachments
         self._conversation.append(msg_entry)
@@ -542,7 +542,7 @@ class TutoringSession:
         if tc_met:
             closing = self._safe_closing()
             if closing:
-                self._conversation.append({"role": "user", "content": closing})
+                self._conversation.append({"role": "user", "content": closing, "ts": time.time()})
             self._done = True
             self._completion_reason = "objectives_met"
             logger.info("TC fully covered at turn %d.", self._turn)
@@ -560,7 +560,7 @@ class TutoringSession:
         if goals_met:
             closing = self._safe_closing()
             if closing:
-                self._conversation.append({"role": "user", "content": closing})
+                self._conversation.append({"role": "user", "content": closing, "ts": time.time()})
             self._done = True
             self._completion_reason = "goals_met"
             logger.info("Goals met at turn %d.", self._turn)
@@ -575,7 +575,7 @@ class TutoringSession:
             logger.info("Session timed out at turn %d.", self._turn)
             closing = self._safe_closing()
             if closing:
-                self._conversation.append({"role": "user", "content": closing})
+                self._conversation.append({"role": "user", "content": closing, "ts": time.time()})
             return self._result(closing, "completed", reason="timeout")
 
         # ── Max turns check ──  (aligned: _append_student_closing:642-678)
@@ -585,7 +585,7 @@ class TutoringSession:
             logger.info("Max turns (%d) reached.", self._max_turns)
             closing = self._safe_closing()
             if closing:
-                self._conversation.append({"role": "user", "content": closing})
+                self._conversation.append({"role": "user", "content": closing, "ts": time.time()})
             return self._result(closing, "completed", reason="max_turns")
 
         # ── Generate student reply ──  (aligned: generate_next_user_input)
@@ -602,7 +602,7 @@ class TutoringSession:
         except Exception as exc:
             logger.warning("StudentSimulator.generate_message failed: %s", exc)
             reply = _STUDENT_FALLBACK
-        self._conversation.append({"role": "user", "content": reply})
+        self._conversation.append({"role": "user", "content": reply, "ts": time.time()})
 
         return self._result(reply, "active")
 
@@ -684,7 +684,7 @@ class TutoringSession:
         ):
             closing = self._safe_closing()
             if closing:
-                self._conversation.append({"role": "user", "content": closing})
+                self._conversation.append({"role": "user", "content": closing, "ts": time.time()})
                 return closing
         return ""
 
@@ -878,7 +878,7 @@ class TutoringSession:
         agent's bootstrap prompt.
         """
         if not self._session_info_called and not self._conversation:
-            self._conversation.append({"role": "user", "content": opening})
+            self._conversation.append({"role": "user", "content": opening, "ts": time.time()})
             self._session_info_called = True
 
     def _get_student_opening(self) -> str:

--- a/bench/server/core/tools/tools.py
+++ b/bench/server/core/tools/tools.py
@@ -3263,7 +3263,7 @@ def split_walkforward_windows(
 CORE_TOOLS = {
     "shell_exec": {
         "func": shell_exec,
-        "description": "Execute a shell command in the sandbox",
+        "description": "Execute a shell command in the sandbox. Returns stdout and stderr combined. Default timeout: 30 seconds. Non-zero exit codes are appended as '[exit code]: N'.",
         "params": {
             "command": {
                 "type": "string",
@@ -3279,7 +3279,7 @@ CORE_TOOLS = {
     },
     "file_write": {
         "func": file_write,
-        "description": "Write content to a file in the workspace",
+        "description": "Write content to a file in the workspace. Creates parent directories automatically. Overwrites existing files.",
         "params": {
             "path": {
                 "type": "string",
@@ -3316,7 +3316,7 @@ CORE_TOOLS = {
     },
     "file_list": {
         "func": file_list,
-        "description": "List files in a directory",
+        "description": "List files and directories. Returns names with type indicators (/ for dirs). Default: workspace root.",
         "params": {
             "directory": {
                 "type": "string",

--- a/bench/server/core/tools/tools.py
+++ b/bench/server/core/tools/tools.py
@@ -3259,8 +3259,33 @@ def split_walkforward_windows(
     )
 
 
+# ---------------------------------------------------------------------------
+# note_to_self — agent scratchpad (no side effects, logged for analysis)
+# ---------------------------------------------------------------------------
+
+
+def note_to_self(thought: str = "") -> str:
+    """Record agent reasoning. No side effects — purely logged by the proxy."""
+    return "Noted."
+
+
 # Tool registry for the proxy layer
 CORE_TOOLS = {
+    "note_to_self": {
+        "func": note_to_self,
+        "description": (
+            "Record your reasoning, observations, or intermediate findings "
+            "for your own reference. Content is not shown to the student. "
+            "Use this to organize your thoughts before responding."
+        ),
+        "params": {
+            "thought": {
+                "type": "string",
+                "description": "Your note — reasoning, hypothesis, observation, or plan.",
+                "required": True,
+            },
+        },
+    },
     "shell_exec": {
         "func": shell_exec,
         "description": "Execute a shell command in the sandbox. Returns stdout and stderr combined. Default timeout: 30 seconds. Non-zero exit codes are appended as '[exit code]: N'.",

--- a/bench/server/tooling/catalog.py
+++ b/bench/server/tooling/catalog.py
@@ -29,6 +29,7 @@ from .spec_types import (
 )
 
 _FAMILY_BY_NAME: dict[str, ToolFamily] = {
+    "note_to_self": "foundation",
     "shell_exec": "foundation",
     "file_write": "foundation",
     "file_read": "foundation",
@@ -79,6 +80,7 @@ _FAMILY_BY_NAME: dict[str, ToolFamily] = {
 
 _LOW_LEVEL_TOOLS = frozenset(
     {
+        "note_to_self",
         "shell_exec",
         "file_write",
         "file_read",

--- a/bench/server/tooling/draft_catalog.py
+++ b/bench/server/tooling/draft_catalog.py
@@ -34,6 +34,48 @@ def _schema(
 
 
 DRAFT_TOOL_SPECS: dict[str, ToolSpec] = {
+    "note_to_self": ToolSpec(
+        name="note_to_self",
+        description=(
+            "Record your reasoning, observations, or intermediate findings "
+            "for your own reference. Content is not shown to the student. "
+            "Use this to organize your thoughts before responding."
+        ),
+        input_schema=_schema(
+            {
+                "thought": {
+                    "type": "string",
+                    "description": "Your note — reasoning, hypothesis, observation, or plan.",
+                },
+            },
+            required=["thought"],
+        ),
+        guidance=ToolGuidance(
+            family="foundation",
+            use_when=(
+                "You want to record an observation or hypothesis before acting.",
+                "You are debugging and want to track what you have tried.",
+                "You are planning a multi-step approach.",
+            ),
+            avoid_when=(
+                "The thought is trivial or obvious from context.",
+            ),
+            common_mistakes=(
+                "Writing to the student instead of to yourself — this tool is private.",
+            ),
+            returns="A short acknowledgment. The note is logged automatically.",
+            related_tools=("send_message", "shell_exec"),
+        ),
+        examples=(
+            ToolExample(
+                intent="Record a debugging hypothesis",
+                args={"thought": "The off-by-one error is likely in the rolling window size. Let me check line 3."},
+            ),
+        ),
+        benchmark_role="core",
+        domain_scope=("reasoning",),
+        abstraction_level="low",
+    ),
     "get_environment_info": ToolSpec(
         name="get_environment_info",
         description=(

--- a/bench/tests/api/test_session_lifecycle.py
+++ b/bench/tests/api/test_session_lifecycle.py
@@ -37,7 +37,6 @@ class TestRegister:
         )
         assert resp.status_code == 200
         body = resp.json()
-        assert body["accepted"] is True
         assert "session_id" in body
 
     @pytest.mark.asyncio
@@ -46,7 +45,7 @@ class TestRegister:
             "/session/register", json={"task_id": "NONEXISTENT_TASK"}
         )
         assert resp.status_code == 404
-        assert resp.json()["accepted"] is False
+        assert "error" in resp.json()
 
     @pytest.mark.asyncio
     async def test_register_missing_task_id(self, client):
@@ -60,7 +59,7 @@ class TestRegister:
             json={"task_id": DEFAULT_TASK_ID, "persona_id": "nonexistent_persona"},
         )
         assert resp.status_code == 400
-        assert resp.json()["accepted"] is False
+        assert "error" in resp.json()
 
 
 class TestStart:

--- a/bench/tests/helpers.py
+++ b/bench/tests/helpers.py
@@ -34,7 +34,7 @@ async def register_session(
     resp = await client.post("/session/register", json=payload)
     assert resp.status_code == 200, f"Register failed: {resp.text}"
     body = resp.json()
-    assert body.get("accepted") is True, f"Register not accepted: {body}"
+    assert "session_id" in body, f"Register failed: {body}"
     return body["session_id"]
 
 


### PR DESCRIPTION
## Summary

- **Structured domain tool returns**: All domain tools now return `{"success": bool, "output": "..."}` via proxy-level wrapping. Agents no longer need string matching to detect failures. `send_message` excluded (already structured).
- **start_session returns tool list**: Response now includes `{background, student_message, tools}` — agent gets the full tool catalog (name, description, inputSchema) without an extra list_tools round-trip.
- **API consistency**: Removed redundant `accepted` field from register_session. Success: `{"session_id": "..."}`. Failure: `{"error": "..."}`. Consistent with all other endpoints.
- **Replay timestamps**: Every conversation entry now includes `"ts": time.time()`. ToolCallLog persists `call_id` for request-to-response tracing.
- **note_to_self tool**: Optional agent scratchpad for recording reasoning, hypotheses, and observations. Content not shown to student, logged automatically by proxy for post-hoc analysis of agent reasoning quality.
- **Improved descriptions**: shell_exec (return format, timeout, exit codes), file_write (overwrite behavior), file_list (output format), send_message (irreversible), get_background (content and format).

## Test plan
- [x] `python -m pytest tests/unit/ tests/api/ -x -q` — 108 passed
- [ ] Manual: verify start_session response includes tools array
- [ ] Manual: verify domain tool returns `{"success": true, "output": "..."}`
- [ ] Manual: verify note_to_self appears in tool list and logs to run_state

🤖 Generated with [Claude Code](https://claude.com/claude-code)