### PR TITLE
feat: optional reasoning field on send_message tool

### DIFF
--- a/BENCHMARK_SPEC.md
+++ b/BENCHMARK_SPEC.md
@@ -128,7 +128,7 @@ env.close()
 |--------|---------|--------|
 | `env.reset(task_id, persona_id?)` | `Observation` | Creates sandbox, returns student opening + tools |
 | `env.call_tool(name, **kwargs)` | `str` | Executes tool in sandbox. **Does not advance conversation.** |
-| `env.send_message(text)` | `Observation` | Sends agent reply → student responds → TC checked |
+| `env.send_message(text, attachments?, reasoning?)` | `Observation` | Sends agent reply → student responds → TC checked. `reasoning` is an optional private rationale recorded for trace analysis (never shown to the student). |
 | `env.evaluate()` | `Scores` | Runs post-hoc evaluation on completed conversation |
 | `env.close()` | `None` | Destroys sandbox, releases resources |
 

--- a/bench/AGENT_PROTOCOL.md
+++ b/bench/AGENT_PROTOCOL.md
@@ -27,7 +27,15 @@ You have two types of tools:
 - `run_backtest`, `search_docs` (backtesting and reference)
 
 **Session tool** -- use this to talk to the student:
-- `send_message(text)` -- sends your message, returns the student's reply
+- `send_message(text, attachments?, reasoning?)` -- sends your message,
+  returns the student's reply.
+  - `text` *(required)* — the message delivered to the student.
+  - `attachments` *(optional)* — up to 3 workspace file paths to share.
+  - `reasoning` *(optional)* — your private rationale for this turn
+    (why this wording, what you expect to learn from the reply, what
+    hypothesis you are testing). It is recorded for post-hoc analysis
+    and is **never shown to the student**. Including it is encouraged
+    but not required.
 
 You decide when to research, when to code, and when to talk.
 There is no fixed order. Call domain tools as many times as you need
@@ -55,6 +63,10 @@ interaction log:
 
 - Your text responses (outside of `send_message`) are internal notes.
   Only `send_message` delivers content to the student.
+- The optional `reasoning` field on `send_message` is the recommended
+  channel for capturing your turn-level rationale alongside the
+  outgoing message. It does not affect the student's reply but is
+  available to evaluators reviewing the trace.
 - Distractor tools may be present. Calling them is not penalized
   heavily but indicates poor tool selection judgment.
 - The server records every tool call. Work as you naturally would.

--- a/bench/client/transports/base.py
+++ b/bench/client/transports/base.py
@@ -32,8 +32,17 @@ class SessionTransport(ABC):
         """Call a domain tool. Returns result string."""
 
     @abstractmethod
-    async def send_message(self, text: str, attachments: Optional[list] = None) -> dict:
-        """Send message to student. Returns {"student_message": ..., "status": ...}."""
+    async def send_message(
+        self,
+        text: str,
+        attachments: Optional[list] = None,
+        reasoning: Optional[str] = None,
+    ) -> dict:
+        """Send message to student. Returns {"student_message": ..., "status": ...}.
+
+        ``reasoning`` is an optional private rationale recorded server-side
+        for trace analysis. It is NOT delivered to the student.
+        """
 
     @abstractmethod
     async def close(self) -> None:

--- a/bench/client/transports/mcp_transport.py
+++ b/bench/client/transports/mcp_transport.py
@@ -84,10 +84,17 @@ class MCPTransport(SessionTransport):
                 parts.append(block.text)
         return "\n".join(parts) if parts else ""
 
-    async def send_message(self, text: str, attachments: Optional[list] = None) -> dict:
+    async def send_message(
+        self,
+        text: str,
+        attachments: Optional[list] = None,
+        reasoning: Optional[str] = None,
+    ) -> dict:
         args = {"text": text}
         if attachments:
             args["attachments"] = attachments
+        if reasoning:
+            args["reasoning"] = reasoning
         result = await self._mcp.call_tool("send_message", args)
         return _parse_tool_result(result)
 

--- a/bench/client/transports/rest_transport.py
+++ b/bench/client/transports/rest_transport.py
@@ -85,6 +85,7 @@ class RESTTransport(SessionTransport):
             result = await self.send_message(
                 text=arguments.get("text", ""),
                 attachments=arguments.get("attachments"),
+                reasoning=arguments.get("reasoning"),
             )
             return json.dumps(result)
 
@@ -95,10 +96,17 @@ class RESTTransport(SessionTransport):
         # REST returns parsed JSON directly; convert back to string for adapter
         return json.dumps(data)
 
-    async def send_message(self, text: str, attachments: Optional[list] = None) -> dict:
+    async def send_message(
+        self,
+        text: str,
+        attachments: Optional[list] = None,
+        reasoning: Optional[str] = None,
+    ) -> dict:
         payload = {"text": text}
         if attachments:
             payload["attachments"] = attachments
+        if reasoning:
+            payload["reasoning"] = reasoning
         resp = await self._client.post(
             f"/session/{self._session_id}/send", json=payload
         )

--- a/bench/mcp_servers/registry.py
+++ b/bench/mcp_servers/registry.py
@@ -225,7 +225,10 @@ def register_session_tools(
         description=(
             "Send a message to the student. Returns the student's reply "
             "and session status. Use this to communicate with the student "
-            "during the tutoring session."
+            "during the tutoring session. "
+            "Optionally include 'reasoning' to record your private rationale "
+            "for this turn — it is logged for analysis and is NOT shown to "
+            "the student."
         ),
         params={
             "type": "object",
@@ -233,7 +236,16 @@ def register_session_tools(
                 "text": {
                     "type": "string",
                     "description": "Your message to the student.",
-                }
+                },
+                "reasoning": {
+                    "type": "string",
+                    "description": (
+                        "Private rationale for this turn — why you chose this "
+                        "wording, what you expect to learn from the reply, or "
+                        "what hypothesis you are testing. Recorded in tool logs "
+                        "for post-hoc analysis. Not delivered to the student."
+                    ),
+                },
             },
             "required": ["text"],
         },

--- a/bench/mcp_servers/session.py
+++ b/bench/mcp_servers/session.py
@@ -200,8 +200,15 @@ class TutoringSession:
             }
         )
 
-    def handle_send_message(self, text: str) -> str:
+    def handle_send_message(
+        self, text: str, reasoning: str | None = None
+    ) -> str:
         """Process agent message, generate student reply.
+
+        ``reasoning`` is the agent's private rationale for this turn.
+        It is stored as metadata on the conversation entry for trace
+        analysis but is NEVER passed to the student simulator (which
+        only reads ``entry["content"]``).
 
         Execution order aligned with Legacy model_callback
         (simulation.py:495-637) and DeepEval _simulate_single_conversation
@@ -247,7 +254,12 @@ class TutoringSession:
         self._last_agent_msg = text
 
         # ── Record agent message + advance turn ──
-        self._conversation.append({"role": "assistant", "content": text})
+        msg_entry: dict = {"role": "assistant", "content": text}
+        # Stash private rationale on the entry for trace analysis. Student
+        # simulator reads only ``content``, so this never leaks.
+        if reasoning and reasoning.strip():
+            msg_entry["reasoning"] = reasoning.strip()
+        self._conversation.append(msg_entry)
         self._turn += 1
         self.reset_step_count()  # New turn starts with fresh step budget
 

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -884,17 +884,25 @@ async def rest_send(request: Request) -> JSONResponse:
     if len(attachments) > 3:
         return JSONResponse({"error": "Maximum 3 attachments allowed"}, 400)
 
+    reasoning = body.get("reasoning")
+    if reasoning is not None and not isinstance(reasoning, str):
+        return JSONResponse({"error": "reasoning must be a string"}, 400)
+
     logger.info(
-        "[REST:%s] send_message (turn %d, %d attachments): %s...",
+        "[REST:%s] send_message (turn %d, %d attachments, reasoning=%s): %s...",
         sid[:8],
         state.session.turn if state.session else 0,
         len(attachments),
+        "yes" if reasoning else "no",
         text[:100],
     )
     async with state._request_lock:
         state._last_activity = time.time()
         result = await asyncio.to_thread(
-            state.handle_send_message, text, attachments=attachments
+            state.handle_send_message,
+            text,
+            attachments=attachments,
+            reasoning=reasoning,
         )
     data = json.loads(result)
     logger.info(

--- a/bench/server/api/protocol.py
+++ b/bench/server/api/protocol.py
@@ -78,7 +78,9 @@ SEND_MESSAGE_TOOL = Tool(
         "only messages sent through this tool reach them. "
         "Each call advances the conversation by one turn and cannot be undone. "
         "Returns the student's reply and session status. "
-        "When status is 'completed', the session has ended."
+        "When status is 'completed', the session has ended. "
+        "Optionally include 'reasoning' to record your private rationale "
+        "for this turn — it is logged for analysis and is NOT shown to the student."
     ),
     inputSchema={
         "type": "object",
@@ -97,6 +99,15 @@ SEND_MESSAGE_TOOL = Tool(
                 ),
                 "items": {"type": "string"},
                 "maxItems": 3,
+            },
+            "reasoning": {
+                "type": "string",
+                "description": (
+                    "Private rationale for this turn — why you chose this "
+                    "wording, what you expect to learn from the reply, or "
+                    "what hypothesis you are testing. Recorded in tool logs "
+                    "for post-hoc analysis. Not delivered to the student."
+                ),
             },
         },
         "required": ["text"],

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -630,12 +630,19 @@ class SessionState:
     # ------------------------------------------------------------------
 
     def handle_send_message(
-        self, text: str, attachments: list[str] | None = None
+        self,
+        text: str,
+        attachments: list[str] | None = None,
+        reasoning: str | None = None,
     ) -> str:
-        """Handle ``send_message(text, attachments?)``.
+        """Handle ``send_message(text, attachments?, reasoning?)``.
 
         Routes through ``proxy.call_tool`` so the call is logged.
         Detects session completion and triggers result saving.
+
+        ``reasoning`` is forwarded to the proxy (which records it in the
+        tool log ``args``) and to the underlying session. It is never
+        delivered to the student.
 
         Returns:
             Raw JSON string from TutoringSession (via proxy).
@@ -643,9 +650,10 @@ class SessionState:
         if self._closed:
             return json.dumps({"error": "Session is closed", "status": "closed"})
 
-        result = self.proxy.call_tool(
-            "send_message", text=text, attachments=attachments or []
-        )
+        proxy_kwargs: dict = {"text": text, "attachments": attachments or []}
+        if reasoning:
+            proxy_kwargs["reasoning"] = reasoning
+        result = self.proxy.call_tool("send_message", **proxy_kwargs)
 
         # Check for session completion
         try:
@@ -865,6 +873,7 @@ class SessionState:
         if name == "send_message":
             text = arguments.get("text", "")
             attachments = arguments.get("attachments") or []
+            reasoning = arguments.get("reasoning")
             if not isinstance(attachments, list):
                 return [
                     TextContent(
@@ -882,14 +891,18 @@ class SessionState:
                     )
                 ]
             logger.info(
-                "[%s] send_message (turn %d, %d attachments): %s...",
+                "[%s] send_message (turn %d, %d attachments, reasoning=%s): %s...",
                 self.session_id[:8],
                 self.session.turn if self.session else 0,
                 len(attachments),
+                "yes" if reasoning else "no",
                 text[:100],
             )
             result = await asyncio.to_thread(
-                self.handle_send_message, text, attachments=attachments
+                self.handle_send_message,
+                text,
+                attachments=attachments,
+                reasoning=reasoning,
             )
             # Log student reply
             try:

--- a/bench/server/core/session.py
+++ b/bench/server/core/session.py
@@ -423,9 +423,17 @@ class TutoringSession:
         )
 
     def handle_send_message(
-        self, text: str, attachments: list[str] | None = None
+        self,
+        text: str,
+        attachments: list[str] | None = None,
+        reasoning: str | None = None,
     ) -> str:
         """Process agent message, generate student reply.
+
+        ``reasoning`` is the agent's private rationale for this turn.
+        It is stored as metadata on the conversation entry for trace
+        analysis but is NEVER passed to the student simulator (which
+        only reads ``entry["content"]``).
 
         Execution order aligned with Legacy model_callback
         (simulation.py:495-637) and DeepEval _simulate_single_conversation
@@ -506,6 +514,10 @@ class TutoringSession:
 
         # ── Record agent message + advance turn ──
         msg_entry: dict = {"role": "assistant", "content": text, "ts": time.time()}
+        # Stash private rationale on the entry for trace analysis. Student
+        # simulator reads only ``content``, so this never leaks.
+        if reasoning and reasoning.strip():
+            msg_entry["reasoning"] = reasoning.strip()
         if resolved_attachments:
             # Store metadata only — strip base64 content from images to avoid
             # unbounded memory growth in conversation history.

--- a/bench/spec/PROTOCOL.md
+++ b/bench/spec/PROTOCOL.md
@@ -97,15 +97,23 @@ REST request body = tool arguments directly (no `arguments` wrapper).
 Send a message to the student. Returns reply and session status.
 
 ```
-MCP:  send_message({text: "Let me help you debug this..."})
-REST: POST /session/{sid}/send  {"text": "Let me help you debug this..."}
+MCP:  send_message({text: "Let me help you debug this...",
+                    reasoning: "Asking what they tried first to diagnose..."})
+REST: POST /session/{sid}/send  {"text": "Let me help you debug this...",
+                                 "reasoning": "Asking what they tried first..."}
 ```
+
+**Arguments:**
+- `text` *(required, string)* — message delivered to the student.
+- `attachments` *(optional, array of ≤3 workspace paths)* — files/images shared with the student.
+- `reasoning` *(optional, string)* — private rationale for this turn (why this wording, what hypothesis you are testing). Recorded in `tool_logs[].args` for post-hoc trace analysis. **Not delivered to the student** — the student simulator only reads `text` + attachments.
 
 | Response | Body |
 |----------|------|
 | Active   | `{"student_message": "Oh I see...", "status": "active"}` |
 | Completed | `{"student_message": "Thanks!", "status": "completed", "reason": "objectives_met"}` |
 | Empty text (400) | `{"error": "Empty message. Provide text to send to the student."}` |
+| Bad reasoning type (400) | `{"error": "reasoning must be a string"}` |
 
 When `status == "completed"`, the session has ended. Stop calling tools and send_message.
 

--- a/bench/tests/unit/test_protocol.py
+++ b/bench/tests/unit/test_protocol.py
@@ -92,3 +92,16 @@ class TestToolSchema:
         required = SEND_MESSAGE_TOOL.inputSchema["required"]
         assert "attachments" not in required
         assert "text" in required
+
+    def test_send_message_has_reasoning_field(self):
+        from server.api.protocol import SEND_MESSAGE_TOOL
+
+        props = SEND_MESSAGE_TOOL.inputSchema["properties"]
+        assert "reasoning" in props
+        assert props["reasoning"]["type"] == "string"
+
+    def test_reasoning_not_required(self):
+        from server.api.protocol import SEND_MESSAGE_TOOL
+
+        required = SEND_MESSAGE_TOOL.inputSchema["required"]
+        assert "reasoning" not in required


### PR DESCRIPTION
## Summary
- Adds optional `reasoning` field to the `send_message` tool schema so agents can record their private rationale alongside each outgoing message.
- Recorded in tool logs (via existing proxy `args=kwargs` capture) for post-hoc trace analysis. Never delivered to the student simulator — `student_sim` and `tc_checker` only read `entry["content"]`, and `reasoning` is stashed on the conversation entry as a separate metadata key.
- End-to-end plumbing: schema → MCP & REST handlers → both client transports → both server session paths (new `server/core/session.py` and legacy `mcp_servers/session.py`).

## Why optional, not required
Forcing reasoning is forced chain-of-thought, which contaminates the benchmark by inflating message quality through scaffolding rather than measuring tutor skill. Optional preserves measurement integrity while still capturing rationale when the agent cooperates. Coverage can be tracked as a separate metric; if it turns out very low (<20%), worth revisiting.

## Files changed
- `bench/server/api/protocol.py` — `SEND_MESSAGE_TOOL` schema + description.
- `bench/server/core/session.py`, `bench/mcp_servers/session.py` — handler signature + metadata-only storage.
- `bench/server/api/session_api.py`, `bench/server/api/http_app.py` — extract `reasoning` from MCP arguments / REST body.
- `bench/mcp_servers/registry.py` — legacy MCP tool definition.
- `bench/client/transports/{base,mcp_transport,rest_transport}.py` — forward `reasoning` through both protocols.
- `bench/tests/unit/test_protocol.py` — schema presence + optionality assertions.

## Test plan
- [x] `bench/tests/unit/test_protocol.py` — 29 passed (incl. 2 new).
- [x] `bench/tests/unit/test_session_completion.py`, `test_attachment_helpers.py`, `test_mcp_tool_routing.py` — 66 passed.
- [x] `bench/tests/api/test_send_attachments.py`, `test_session_lifecycle.py`, `test_eval_flow.py`, `test_session_completion_api.py` — 43 passed.
- [ ] Spot-check a live benchmark run that the trace JSON shows `reasoning` in `tool_logs[].args` and that the student persona transcript does not contain it.