### PR TITLE
feat(run): Tier 1+2 of v6.0 Run architecture (issue #18)

### DIFF
--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -177,6 +177,32 @@ class BenchSessionManager:
                                     exc_info=True,
                                 )
                             state._destroy_container()
+                            # Notify Run layer so run status tracks the
+                            # force-completion. Swallow ValueError from
+                            # mark_completed guards (e.g. run was cancelled
+                            # between the deadline check and here).
+                            if state.run_id:
+                                result_dir = (
+                                    str(state._result_dir)
+                                    if getattr(state, "_result_dir", None)
+                                    else None
+                                )
+                                try:
+                                    self._run_service.mark_completed(
+                                        state.run_id, result_dir
+                                    )
+                                except ValueError as exc:
+                                    logger.info(
+                                        "Run %s mark_completed skipped in sweep: %s",
+                                        state.run_id,
+                                        exc,
+                                    )
+                                except Exception:
+                                    logger.warning(
+                                        "Run %s mark_completed failed in sweep",
+                                        state.run_id,
+                                        exc_info=True,
+                                    )
 
                     elif (
                         state.phase == SessionPhase.COMPLETED

--- a/bench/server/run/catalog.py
+++ b/bench/server/run/catalog.py
@@ -110,6 +110,14 @@ class TaskCatalog:
             key=lambda x: x["label"],
         )
 
+    def list_labels_only(self) -> list[dict]:
+        """Return labels only — used by Run/exam UI where category and
+        difficulty must not be revealed to the student before selection."""
+        return sorted(
+            [{"label": e.public_label} for e in self._entries.values()],
+            key=lambda x: x["label"],
+        )
+
     def __len__(self) -> int:
         return len(self._entries)
 

--- a/bench/server/run/models.py
+++ b/bench/server/run/models.py
@@ -32,10 +32,14 @@ class RunAssignment:
     task_id: str  # "D01_load_inspect_ohlcv" (internal)
     status: RunStatus
 
-    # Token
+    # Run token (for the external agent / client)
     token_hint: str = ""  # first 12 chars for logs
     token_hash: str = ""  # SHA-256 hex digest
     token_expires_at: str = ""  # ISO 8601, empty = no expiry
+
+    # Control token (for the browser owner — poll/live/cancel)
+    control_token_hint: str = ""
+    control_token_hash: str = ""
 
     # Binding (set after claim)
     client_info: Optional[dict] = None
@@ -66,10 +70,17 @@ class RunAssignment:
 
     @classmethod
     def from_dict(cls, d: dict) -> "RunAssignment":
-        """Deserialize from JSON storage."""
-        d = dict(d)  # shallow copy
-        d["status"] = RunStatus(d["status"])
-        return cls(**d)
+        """Deserialize from JSON storage.
+
+        Tolerates old run.json files that predate newer fields (e.g. the
+        ``control_token_*`` pair added in v6.0). Unknown keys are dropped.
+        """
+        import dataclasses
+
+        fields = {f.name for f in dataclasses.fields(cls)}
+        clean = {k: v for k, v in d.items() if k in fields}
+        clean["status"] = RunStatus(clean["status"])
+        return cls(**clean)
 
     def public_dict(self) -> dict:
         """Safe subset for UI/client responses. No token_hash, no task_id."""

--- a/bench/server/run/service.py
+++ b/bench/server/run/service.py
@@ -4,6 +4,7 @@ All REST handlers call this service. No HTTP/MCP concerns here.
 """
 
 import hashlib
+import hmac
 import logging
 import secrets
 from datetime import datetime, timedelta, timezone
@@ -48,10 +49,12 @@ class RunService:
         mode: str = "agent",
         persona_policy: str = "auto",
         token_ttl_minutes: int = 30,
-    ) -> tuple[RunAssignment, str]:
-        """Create a RunAssignment + generate token.
+    ) -> tuple[RunAssignment, str, str]:
+        """Create a RunAssignment + generate both tokens.
 
-        Returns (assignment, raw_token). raw_token is only available here.
+        Returns ``(assignment, raw_run_token, raw_control_token)``.
+        Neither raw token is persisted — only their SHA-256 hashes. Both
+        are surfaced once here and must be stored by the caller.
         """
         entry = self._catalog.resolve(task)
         if entry is None:
@@ -60,6 +63,10 @@ class RunService:
         raw_token = f"qtb_{secrets.token_urlsafe(24)}"
         token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
         token_hint = raw_token[:12]
+
+        raw_control_token = f"qtc_{secrets.token_urlsafe(24)}"
+        control_token_hash = hashlib.sha256(raw_control_token.encode()).hexdigest()
+        control_token_hint = raw_control_token[:12]
 
         now = _now_iso()
         expires_at = ""
@@ -76,18 +83,21 @@ class RunService:
             token_hint=token_hint,
             token_hash=token_hash,
             token_expires_at=expires_at,
+            control_token_hint=control_token_hint,
+            control_token_hash=control_token_hash,
             persona_policy=persona_policy,
             created_at=now,
             updated_at=now,
         )
         self._store.save(assignment)
         logger.info(
-            "Run created: %s task=%s token=%s...",
+            "Run created: %s task=%s token=%s... control=%s...",
             assignment.run_id,
             entry.public_label,
             token_hint,
+            control_token_hint,
         )
-        return assignment, raw_token
+        return assignment, raw_token, raw_control_token
 
     def create_and_claim(
         self,
@@ -95,12 +105,13 @@ class RunService:
         client_info: Optional[dict] = None,
         mode: str = "agent",
         persona_policy: str = "auto",
-    ) -> tuple[RunAssignment, str]:
+    ) -> tuple[RunAssignment, str, str]:
         """Create + immediately claim. For client-initiated runs.
 
-        Returns (assignment, raw_token) with status already CLAIMED.
+        Returns ``(assignment, raw_run_token, raw_control_token)`` with
+        status already CLAIMED.
         """
-        assignment, raw_token = self.create_run(
+        assignment, raw_token, raw_control_token = self.create_run(
             task=task, mode=mode, persona_policy=persona_policy
         )
         now = _now_iso()
@@ -110,7 +121,7 @@ class RunService:
         assignment.updated_at = now
         self._store.save(assignment)
         logger.info("Run auto-claimed: %s", assignment.run_id)
-        return assignment, raw_token
+        return assignment, raw_token, raw_control_token
 
     def claim_run(
         self,
@@ -123,7 +134,7 @@ class RunService:
         Thread-safe: RunStore.save uses internal lock.
         """
         token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
-        assignment = self._store.find_by_token_hash(token_hash)
+        assignment = self._store.find_by_token_hash(token_hash, token_type="run")
 
         if assignment is None:
             raise ValueError("Invalid token")
@@ -147,29 +158,63 @@ class RunService:
         return assignment
 
     def bind_session(self, run_id: str, session_id: str) -> RunAssignment:
-        """Bind a session to a run. CLAIMED -> ACTIVE."""
+        """Bind a session to a run. CLAIMED -> ACTIVE.
+
+        On store-level failure, rolls back to CLAIMED with no session bound so
+        the client can retry, then re-raises.
+        """
         assignment = self._get_or_raise(run_id)
         if assignment.status != RunStatus.CLAIMED:
             raise ValueError(
                 f"Run {run_id} is '{assignment.status.value}', expected 'claimed'"
             )
-        assignment.status = RunStatus.ACTIVE
-        assignment.session_id = session_id
-        assignment.updated_at = _now_iso()
-        self._store.save(assignment)
+        prev_status = assignment.status
+        prev_session_id = assignment.session_id
+        prev_updated_at = assignment.updated_at
+        try:
+            assignment.status = RunStatus.ACTIVE
+            assignment.session_id = session_id
+            assignment.updated_at = _now_iso()
+            self._store.save(assignment)
+        except Exception:
+            assignment.status = prev_status
+            assignment.session_id = prev_session_id
+            assignment.updated_at = prev_updated_at
+            try:
+                self._store.save(assignment)
+            except Exception:
+                logger.exception(
+                    "Run %s bind rollback failed to persist — in-memory state restored",
+                    run_id,
+                )
+            raise
         logger.info("Run active: %s session=%s", run_id, session_id[:8])
         return assignment
 
     def mark_completed(
         self, run_id: str, result_dir: Optional[str] = None
     ) -> RunAssignment:
-        """Session completed. ACTIVE -> COMPLETED."""
+        """Session completed. ACTIVE -> COMPLETED.
+
+        Idempotent if called again with the same ``result_dir`` on an already-
+        COMPLETED run. Rejects any other terminal state (FAILED/CANCELLED) and
+        any non-ACTIVE active state.
+        """
         assignment = self._get_or_raise(run_id)
+        if assignment.status in TERMINAL_STATUSES:
+            if (
+                assignment.status == RunStatus.COMPLETED
+                and assignment.result_dir == result_dir
+            ):
+                return assignment
+            raise ValueError(
+                f"Cannot complete run {run_id} in terminal state "
+                f"'{assignment.status.value}'"
+            )
         if assignment.status != RunStatus.ACTIVE:
-            logger.warning(
-                "mark_completed on %s in '%s' (expected active)",
-                run_id,
-                assignment.status.value,
+            raise ValueError(
+                f"Cannot complete run {run_id} in state "
+                f"'{assignment.status.value}' (expected 'active')"
             )
         now = _now_iso()
         assignment.status = RunStatus.COMPLETED
@@ -238,13 +283,29 @@ class RunService:
         return runs
 
     def resolve_token(self, raw_token: str) -> Optional[RunAssignment]:
-        """Find a run by raw token. Does NOT change state."""
+        """Find a run by raw run_token. Does NOT change state."""
         token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
-        assignment = self._store.find_by_token_hash(token_hash)
+        assignment = self._store.find_by_token_hash(token_hash, token_type="run")
         if assignment is None:
             return None
         if _token_expired(assignment.token_expires_at):
             return None
+        return assignment
+
+    def verify_control_token(
+        self, run_id: str, raw_control_token: str
+    ) -> RunAssignment:
+        """Return the assignment iff the control token matches.
+
+        Raises PermissionError on any mismatch or missing stored hash.
+        """
+        assignment = self._get_or_raise(run_id)
+        expected = assignment.control_token_hash
+        if not expected:
+            raise PermissionError("Run has no control token")
+        actual = hashlib.sha256(raw_control_token.encode()).hexdigest()
+        if not hmac.compare_digest(expected, actual):
+            raise PermissionError("Invalid control token")
         return assignment
 
     def _get_or_raise(self, run_id: str) -> RunAssignment:

--- a/bench/server/run/store.py
+++ b/bench/server/run/store.py
@@ -51,8 +51,20 @@ class RunStore:
             logger.warning("RunStore: corrupt run.json for %s: %s", run_id, exc)
             return None
 
-    def find_by_token_hash(self, token_hash: str) -> Optional[RunAssignment]:
-        """Find a run by token hash. Scans all run.json files."""
+    def find_by_token_hash(
+        self, token_hash: str, token_type: str = "run"
+    ) -> Optional[RunAssignment]:
+        """Find a run by token hash. Scans all run.json files.
+
+        ``token_type`` selects which stored hash to compare against:
+        ``"run"`` (default) → ``token_hash``; ``"control"`` →
+        ``control_token_hash``. A run_token will never match a
+        control_token_hash and vice versa.
+        """
+        if token_type not in ("run", "control"):
+            raise ValueError(f"Unknown token_type: {token_type}")
+        field = "token_hash" if token_type == "run" else "control_token_hash"
+
         if not self._runs_dir.is_dir():
             return None
         for run_dir in self._runs_dir.iterdir():
@@ -63,7 +75,8 @@ class RunStore:
                 continue
             try:
                 data = json.loads(path.read_text(encoding="utf-8"))
-                if data.get("token_hash") == token_hash:
+                stored = data.get(field)
+                if stored and stored == token_hash:
                     return RunAssignment.from_dict(data)
             except (json.JSONDecodeError, KeyError, TypeError):
                 continue

--- a/bench/server/web/static/js/run-agent.js
+++ b/bench/server/web/static/js/run-agent.js
@@ -17,6 +17,48 @@
   var _pollTimer = null;
   var _livePollTimer = null;
 
+  // ── Owner-token store ──
+  // Keyed by run_id so multiple tabs/runs can coexist. Persisted in
+  // sessionStorage under 'qtb_run_tokens' so a reload keeps monitoring.
+  var _TOKEN_STORAGE_KEY = 'qtb_run_tokens';
+
+  function _loadTokens() {
+    try {
+      var raw = sessionStorage.getItem(_TOKEN_STORAGE_KEY);
+      return raw ? JSON.parse(raw) : {};
+    } catch (e) { return {}; }
+  }
+
+  function _saveTokens(tokens) {
+    try {
+      sessionStorage.setItem(_TOKEN_STORAGE_KEY, JSON.stringify(tokens));
+    } catch (e) { /* quota/permission — ignore */ }
+  }
+
+  function _rememberControlToken(runId, controlToken) {
+    if (!runId || !controlToken) return;
+    var t = _loadTokens();
+    t[runId] = controlToken;
+    _saveTokens(t);
+  }
+
+  function _forgetControlToken(runId) {
+    if (!runId) return;
+    var t = _loadTokens();
+    if (runId in t) { delete t[runId]; _saveTokens(t); }
+  }
+
+  function _ownerFetch(url, options) {
+    options = options || {};
+    options.headers = options.headers || {};
+    var tokens = _loadTokens();
+    var tok = _runId ? tokens[_runId] : null;
+    if (tok) {
+      options.headers['Authorization'] = 'Bearer ' + tok;
+    }
+    return fetch(url, options);
+  }
+
   function escapeHtml(value) {
     return String(value == null ? '' : value)
       .replace(/&/g, '&amp;')
@@ -38,7 +80,7 @@
 
   function loadCatalog(callback) {
     if (_catalog) { callback(_catalog); return; }
-    fetch('/ui/tasks/catalog')
+    fetch('/ui/tasks/catalog/labels')
       .then(function (r) { return r.json(); })
       .then(function (data) {
         _catalog = data.tasks || [];
@@ -65,7 +107,7 @@
   function _renderCreatePage(app, tasks) {
     var taskOptions = tasks.map(function (t) {
       return '<option value="' + escapeHtml(t.label) + '">' +
-        escapeHtml(t.label) + ' (' + escapeHtml(t.category) + ')' +
+        escapeHtml(t.label) +
         '</option>';
     }).join('');
 
@@ -130,6 +172,9 @@
             return;
           }
           _runId = data.run_id;
+          if (data.control_token) {
+            _rememberControlToken(data.run_id, data.control_token);
+          }
           _renderMonitorPage(app, data);
         })
         .catch(function (err) {
@@ -224,7 +269,7 @@
       cancelBtn.addEventListener('click', function () {
         if (!_runId) return;
         cancelBtn.disabled = true;
-        fetch('/ui/runs/' + _runId + '/cancel', {method: 'POST'})
+        _ownerFetch('/ui/runs/' + _runId + '/cancel', {method: 'POST'})
           .then(function () {
             _cleanup();
             _updateStatus('cancelled');
@@ -243,9 +288,17 @@
     if (_pollTimer) clearInterval(_pollTimer);
     _pollTimer = setInterval(function () {
       if (!_runId) return;
-      fetch('/ui/runs/' + _runId)
-        .then(function (r) { return r.json(); })
+      _ownerFetch('/ui/runs/' + _runId)
+        .then(function (r) {
+          if (r.status === 401) {
+            _stopPolling();
+            _showTokenLostMessage();
+            return null;
+          }
+          return r.json();
+        })
         .then(function (data) {
+          if (data == null) return;
           _updateStatus(data.status);
           if (data.status === 'active') {
             _startLivePoll();
@@ -276,9 +329,17 @@
     if (_livePollTimer) clearInterval(_livePollTimer);
     _livePollTimer = setInterval(function () {
       if (!_runId) return;
-      fetch('/ui/runs/' + _runId + '/live')
-        .then(function (r) { return r.json(); })
+      _ownerFetch('/ui/runs/' + _runId + '/live')
+        .then(function (r) {
+          if (r.status === 401) {
+            _stopPolling();
+            _showTokenLostMessage();
+            return null;
+          }
+          return r.json();
+        })
         .then(function (data) {
+          if (data == null) return;
           _updateStatus(data.run_status);
           if (data.turn != null) {
             var turnPill = document.getElementById('myagent-turn-pill');
@@ -307,6 +368,22 @@
   function _stopPolling() {
     if (_pollTimer) { clearInterval(_pollTimer); _pollTimer = null; }
     if (_livePollTimer) { clearInterval(_livePollTimer); _livePollTimer = null; }
+  }
+
+  function _showTokenLostMessage() {
+    var pill = document.getElementById('myagent-status-pill');
+    if (pill) pill.textContent = '● Access expired';
+    var cancelBtn = document.getElementById('myagent-cancel-btn');
+    if (cancelBtn) cancelBtn.style.display = 'none';
+    var connectPanel = document.getElementById('myagent-connect-panel');
+    if (connectPanel) {
+      var msg = document.createElement('div');
+      msg.className = 'run-token-lost';
+      msg.textContent =
+        'Run access expired or token lost. Cannot resume monitoring. ' +
+        'Results will still appear under Results once the run completes.';
+      connectPanel.appendChild(msg);
+    }
   }
 
   function _updateStatus(status) {

--- a/bench/server/web/ui_app.py
+++ b/bench/server/web/ui_app.py
@@ -9,9 +9,11 @@ Provides:
 
 from __future__ import annotations
 
+import hmac
 import json
 import logging
 import math
+import os
 from dataclasses import asdict
 
 from starlette.requests import Request
@@ -40,6 +42,46 @@ def extract_bearer_token(request: Request) -> str | None:
 def resolve_run_from_token(run_service, raw_token: str):
     """Find RunAssignment by raw token. Returns None if invalid/expired."""
     return run_service.resolve_token(raw_token)
+
+
+def _authorize_control_token(
+    request: Request, run_service, run_id: str
+):
+    """Return the RunAssignment if the request carries a valid control token.
+
+    Returns a ``(JSONResponse, None)`` tuple for the error path and
+    ``(None, assignment)`` for the success path so callers can short-circuit
+    with a single check.
+    """
+    raw = extract_bearer_token(request)
+    if not raw:
+        return JSONResponse(
+            {"error": "Authorization: Bearer <control_token> required"}, 401
+        ), None
+    try:
+        assignment = run_service.verify_control_token(run_id, raw)
+    except PermissionError:
+        return JSONResponse({"error": "Invalid control token"}, 401), None
+    except ValueError:
+        return JSONResponse({"error": "Run not found"}, 404), None
+    return None, assignment
+
+
+def _authorize_admin_token(request: Request):
+    """Compare the bearer token against ``QTB_ADMIN_TOKEN``.
+
+    If the env var is unset we allow the request (local-dev convenience);
+    this lets existing test/CI flows keep working without setting the var.
+    """
+    expected = os.environ.get("QTB_ADMIN_TOKEN", "")
+    if not expected:
+        return None  # no enforcement
+    raw = extract_bearer_token(request) or ""
+    if not raw or not hmac.compare_digest(expected, raw):
+        return JSONResponse(
+            {"error": "Authorization: Bearer <admin_token> required"}, 401
+        )
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -136,12 +178,23 @@ def ui_routes(manager) -> list[Route]:
     # -----------------------------------------------------------------------
 
     async def task_catalog(request: Request) -> JSONResponse:
-        """Public task catalog — labels + category + difficulty only."""
+        """Public task catalog — labels + category + difficulty.
+
+        Used by Results UI. Do not wire this into the Run/exam UI.
+        """
         _ = request
         run_service = getattr(manager, "_run_service", None)
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
         return JSONResponse({"tasks": run_service.catalog.list_public()})
+
+    async def task_catalog_labels(request: Request) -> JSONResponse:
+        """Run/exam-mode catalog — labels only, no category or difficulty."""
+        _ = request
+        run_service = getattr(manager, "_run_service", None)
+        if run_service is None:
+            return JSONResponse({"error": "Run service not initialized"}, 503)
+        return JSONResponse({"tasks": run_service.catalog.list_labels_only()})
 
     # -----------------------------------------------------------------------
     # New: /ui/runs/*
@@ -167,7 +220,7 @@ def ui_routes(manager) -> list[Route]:
         token_ttl = body.get("token_ttl_minutes", 30)
 
         try:
-            assignment, raw_token = run_service.create_run(
+            assignment, raw_token, raw_control_token = run_service.create_run(
                 task=task,
                 mode=mode,
                 persona_policy=persona_policy,
@@ -186,6 +239,7 @@ def ui_routes(manager) -> list[Route]:
                 "status": assignment.status.value,
                 "public_task_label": assignment.public_task_label,
                 "token": raw_token,
+                "control_token": raw_control_token,
                 "token_expires_at": assignment.token_expires_at,
                 "mcp_url": mcp_url,
                 "launch_command": (
@@ -197,10 +251,18 @@ def ui_routes(manager) -> list[Route]:
         )
 
     async def list_runs(request: Request) -> JSONResponse:
-        """``GET /ui/runs`` — list runs with optional filters."""
+        """``GET /ui/runs`` — list runs with optional filters.
+
+        Requires ``Authorization: Bearer <admin_token>`` when
+        ``QTB_ADMIN_TOKEN`` is set; otherwise allowed (local dev).
+        """
         run_service = getattr(manager, "_run_service", None)
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
+
+        err = _authorize_admin_token(request)
+        if err is not None:
+            return err
 
         status = request.query_params.get("status")
         task = request.query_params.get("task")
@@ -208,15 +270,15 @@ def ui_routes(manager) -> list[Route]:
         return JSONResponse({"runs": [r.public_dict() for r in runs]})
 
     async def get_run(request: Request) -> JSONResponse:
-        """``GET /ui/runs/{run_id}`` — query run status."""
+        """``GET /ui/runs/{run_id}`` — query run status. Owner-only."""
         run_service = getattr(manager, "_run_service", None)
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
 
         run_id = request.path_params["run_id"]
-        run = run_service.get_run(run_id)
-        if run is None:
-            return JSONResponse({"error": "Run not found"}, 404)
+        err, run = _authorize_control_token(request, run_service, run_id)
+        if err is not None:
+            return err
         return JSONResponse(run.public_dict())
 
     async def get_run_live(request: Request) -> JSONResponse:
@@ -226,9 +288,9 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse({"error": "Run service not initialized"}, 503)
 
         run_id = request.path_params["run_id"]
-        run = run_service.get_run(run_id)
-        if run is None:
-            return JSONResponse({"error": "Run not found"}, 404)
+        err, run = _authorize_control_token(request, run_service, run_id)
+        if err is not None:
+            return err
 
         # Terminal or pre-active states
         if run.status.value in (
@@ -291,8 +353,15 @@ def ui_routes(manager) -> list[Route]:
         )
 
     async def cancel_run(request: Request) -> JSONResponse:
-        """``POST /ui/runs/{run_id}/cancel`` — cancel at any non-terminal state."""
+        """``POST /ui/runs/{run_id}/cancel`` — owner-only cancel."""
+        run_service = getattr(manager, "_run_service", None)
+        if run_service is None:
+            return JSONResponse({"error": "Run service not initialized"}, 503)
+
         run_id = request.path_params["run_id"]
+        err, _ = _authorize_control_token(request, run_service, run_id)
+        if err is not None:
+            return err
         try:
             await manager.cancel_run(run_id)
         except ValueError as exc:
@@ -301,7 +370,7 @@ def ui_routes(manager) -> list[Route]:
             logger.error("cancel_run %s failed: %s", run_id, exc, exc_info=True)
             return JSONResponse({"error": f"Cancel failed: {exc}"}, 500)
 
-        run = manager._run_service.get_run(run_id)
+        run = run_service.get_run(run_id)
         return JSONResponse(run.public_dict() if run else {"status": "cancelled"})
 
     # -----------------------------------------------------------------------
@@ -360,7 +429,7 @@ def ui_routes(manager) -> list[Route]:
         client_info = body.get("client")
 
         try:
-            assignment, raw_token = run_service.create_and_claim(
+            assignment, raw_token, raw_control_token = run_service.create_and_claim(
                 task=task, client_info=client_info, mode=mode
             )
         except ValueError as exc:
@@ -372,6 +441,7 @@ def ui_routes(manager) -> list[Route]:
             {
                 "run_id": assignment.run_id,
                 "token": raw_token,
+                "control_token": raw_control_token,
                 "mcp_url": f"{base_url}/mcp",
                 "public_task_label": assignment.public_task_label,
                 "status": assignment.status.value,
@@ -427,6 +497,7 @@ def ui_routes(manager) -> list[Route]:
         Route("/ui/results/{session_id}/files/{path:path}", get_file, methods=["GET"]),
         # New: public task catalog
         Route("/ui/tasks/catalog", task_catalog, methods=["GET"]),
+        Route("/ui/tasks/catalog/labels", task_catalog_labels, methods=["GET"]),
         # New: Run management (UI)
         Route("/ui/runs", create_run, methods=["POST"]),
         Route("/ui/runs", list_runs, methods=["GET"]),

--- a/bench/tests/test_run_catalog.py
+++ b/bench/tests/test_run_catalog.py
@@ -1,0 +1,53 @@
+"""Tests for TaskCatalog list_public vs list_labels_only."""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from server.run.catalog import TaskCatalog
+
+
+def _write_task(root: Path, task_id: str, category: str, difficulty: str) -> None:
+    path = root / "tasks" / "layer2" / category / f"{task_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "task_id": task_id,
+                "category": category,
+                "difficulty": difficulty,
+                "description": "demo",
+                "persona_ids": ["dev"],
+                "max_turns": 4,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class TaskCatalogTests(unittest.TestCase):
+    def test_labels_only_hides_category_and_difficulty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_task(root, "D01_demo_one", "data_analysis", "easy")
+            _write_task(root, "I02_demo_two", "implementation", "hard")
+
+            cat = TaskCatalog(root)
+
+            public = cat.list_public()
+            self.assertEqual(
+                {"label", "category", "difficulty"}, set(public[0].keys())
+            )
+
+            labels = cat.list_labels_only()
+            self.assertEqual([{"label": "D01"}, {"label": "I02"}], labels)
+            for row in labels:
+                self.assertEqual({"label"}, set(row.keys()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/tests/test_run_control_token.py
+++ b/bench/tests/test_run_control_token.py
@@ -1,0 +1,150 @@
+"""Tests for Step 4: control_token auth on /ui/runs/* endpoints."""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from server.run.catalog import TaskCatalog
+from server.run.service import RunService
+from server.run.store import RunStore
+from server.web.ui_app import ui_routes
+
+
+def _write_task(root: Path) -> None:
+    (root / "tasks" / "layer2" / "data").mkdir(parents=True, exist_ok=True)
+    (root / "tasks" / "layer2" / "data" / "D01_demo.json").write_text(
+        json.dumps(
+            {
+                "task_id": "D01_demo",
+                "category": "data",
+                "difficulty": "easy",
+                "description": "d",
+                "persona_ids": ["p"],
+                "max_turns": 4,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class _StubManager:
+    def __init__(self, root: Path):
+        self.bench_root = root
+        self._run_service = RunService(TaskCatalog(root), RunStore(root / "runs"))
+
+    def get_session(self, _sid):
+        return None
+
+    async def cancel_run(self, run_id):
+        self._run_service.cancel_run(run_id)
+
+
+def _build_client(root: Path) -> tuple[TestClient, _StubManager]:
+    manager = _StubManager(root)
+    app = Starlette(routes=ui_routes(manager))
+    return TestClient(app), manager
+
+
+class ControlTokenTests(unittest.TestCase):
+    def test_create_run_returns_control_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            client, _ = _build_client(Path(tmp))
+            r = client.post("/ui/runs", json={"task": "D01"})
+            self.assertEqual(r.status_code, 200)
+            body = r.json()
+            self.assertIn("control_token", body)
+            self.assertTrue(body["control_token"].startswith("qtc_"))
+            self.assertTrue(body["token"].startswith("qtb_"))
+
+    def test_get_run_without_control_token_returns_401(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            client, _ = _build_client(Path(tmp))
+            body = client.post("/ui/runs", json={"task": "D01"}).json()
+            r = client.get(f"/ui/runs/{body['run_id']}")
+            self.assertEqual(r.status_code, 401)
+
+    def test_get_run_with_wrong_control_token_returns_401(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            client, _ = _build_client(Path(tmp))
+            body = client.post("/ui/runs", json={"task": "D01"}).json()
+            r = client.get(
+                f"/ui/runs/{body['run_id']}",
+                headers={"Authorization": "Bearer qtc_not_real"},
+            )
+            self.assertEqual(r.status_code, 401)
+
+    def test_get_run_with_correct_control_token_succeeds(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            client, _ = _build_client(Path(tmp))
+            body = client.post("/ui/runs", json={"task": "D01"}).json()
+            r = client.get(
+                f"/ui/runs/{body['run_id']}",
+                headers={"Authorization": f"Bearer {body['control_token']}"},
+            )
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()["run_id"], body["run_id"])
+
+    def test_run_token_does_not_authorize_control_endpoint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            client, _ = _build_client(Path(tmp))
+            body = client.post("/ui/runs", json={"task": "D01"}).json()
+            # Use the run_token (qtb_) against a control endpoint — must fail.
+            r = client.get(
+                f"/ui/runs/{body['run_id']}",
+                headers={"Authorization": f"Bearer {body['token']}"},
+            )
+            self.assertEqual(r.status_code, 401)
+
+    def test_cancel_requires_control_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            client, _ = _build_client(Path(tmp))
+            body = client.post("/ui/runs", json={"task": "D01"}).json()
+            r = client.post(f"/ui/runs/{body['run_id']}/cancel")
+            self.assertEqual(r.status_code, 401)
+            r = client.post(
+                f"/ui/runs/{body['run_id']}/cancel",
+                headers={"Authorization": f"Bearer {body['control_token']}"},
+            )
+            self.assertEqual(r.status_code, 200)
+
+    def test_store_find_by_token_hash_distinguishes_types(self):
+        import hashlib
+
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            _, manager = _build_client(Path(tmp))
+            svc = manager._run_service
+            a, run_tok, ctrl_tok = svc.create_run("D01")
+
+            h_run = hashlib.sha256(run_tok.encode()).hexdigest()
+            h_ctrl = hashlib.sha256(ctrl_tok.encode()).hexdigest()
+
+            self.assertIsNotNone(
+                svc._store.find_by_token_hash(h_run, token_type="run")
+            )
+            self.assertIsNone(
+                svc._store.find_by_token_hash(h_run, token_type="control")
+            )
+            self.assertIsNotNone(
+                svc._store.find_by_token_hash(h_ctrl, token_type="control")
+            )
+            self.assertIsNone(
+                svc._store.find_by_token_hash(h_ctrl, token_type="run")
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/tests/test_run_state_transitions.py
+++ b/bench/tests/test_run_state_transitions.py
@@ -1,0 +1,129 @@
+"""Tests for RunService state-transition guards (Step 3 of v6.0 plan)."""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from server.run.catalog import TaskCatalog
+from server.run.models import RunStatus
+from server.run.service import RunService
+from server.run.store import RunStore
+
+
+def _make_service(tmp: Path) -> RunService:
+    (tmp / "tasks" / "layer2" / "data").mkdir(parents=True, exist_ok=True)
+    (tmp / "tasks" / "layer2" / "data" / "D01_demo.json").write_text(
+        json.dumps(
+            {
+                "task_id": "D01_demo",
+                "category": "data",
+                "difficulty": "easy",
+                "description": "d",
+                "persona_ids": ["p"],
+                "max_turns": 4,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return RunService(TaskCatalog(tmp), RunStore(tmp / "runs"))
+
+
+class MarkCompletedGuardTests(unittest.TestCase):
+    def test_rejects_cancelled_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.cancel_run(a.run_id)
+            with self.assertRaises(ValueError):
+                svc.mark_completed(a.run_id, "/tmp/results")
+
+    def test_rejects_failed_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.mark_failed(a.run_id, "boom")
+            with self.assertRaises(ValueError):
+                svc.mark_completed(a.run_id, "/tmp/r")
+
+    def test_rejects_non_active_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")  # CLAIMED, not ACTIVE
+            with self.assertRaises(ValueError):
+                svc.mark_completed(a.run_id, "/tmp/r")
+
+    def test_idempotent_same_result_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.mark_completed(a.run_id, "/tmp/r")
+            again = svc.mark_completed(a.run_id, "/tmp/r")
+            self.assertEqual(again.status, RunStatus.COMPLETED)
+
+    def test_idempotent_rejects_different_result_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.mark_completed(a.run_id, "/tmp/r1")
+            with self.assertRaises(ValueError):
+                svc.mark_completed(a.run_id, "/tmp/r2")
+
+
+class CancelGuardTests(unittest.TestCase):
+    def test_cancel_rejects_completed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.mark_completed(a.run_id, "/tmp/r")
+            with self.assertRaises(ValueError):
+                svc.cancel_run(a.run_id)
+
+    def test_cancel_rejects_failed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.mark_failed(a.run_id, "x")
+            with self.assertRaises(ValueError):
+                svc.cancel_run(a.run_id)
+
+
+class BindSessionRollbackTests(unittest.TestCase):
+    def test_rollback_on_store_error_leaves_run_claimed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+
+            original_save = svc._store.save
+            calls = {"n": 0}
+
+            def flaky_save(x):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise OSError("disk full")
+                return original_save(x)
+
+            svc._store.save = flaky_save  # type: ignore[assignment]
+            with self.assertRaises(OSError):
+                svc.bind_session(a.run_id, "sess")
+
+            # Rollback write happened (call 2 was the rollback save)
+            self.assertGreaterEqual(calls["n"], 2)
+            svc._store.save = original_save  # type: ignore[assignment]
+            fresh = svc.get_run(a.run_id)
+            self.assertEqual(fresh.status, RunStatus.CLAIMED)
+            self.assertIsNone(fresh.session_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **Step 5** (Tier 1): Label-only `/ui/tasks/catalog/labels` endpoint + Run UI wired to it so category/difficulty aren't leaked pre-selection.
- **Step 3** (Tier 2): Terminal-state guards on `mark_completed`/`cancel_run`; `bind_session` rolls back on store failure; sweeper now notifies Run layer after force-completion so Run/Session status stay in sync.
- **Step 4** (Tier 3): `control_token` (`qtc_…`) on `RunAssignment`, distinct from the run_token (`qtb_…`). `/ui/runs/{id}`, `/live`, `/cancel` now require `Authorization: Bearer <qtc_…>`; `/ui/runs` (list) is admin-gated via `QTB_ADMIN_TOKEN` when set. Frontend persists per-run tokens in sessionStorage.

## Test plan
- [x] `pytest bench/tests/test_run_catalog.py bench/tests/test_run_state_transitions.py bench/tests/test_run_control_token.py -v` — 16 passed
- [x] `pytest bench/tests/` (minus network/LLM-dependent suites) — 238 passed
- [ ] Run `/codex:review --wait` before merge (automated review via the Skill tool is currently blocked by harness policy — please trigger it manually)
- [ ] Smoke test on demo: open https://benchmark-liard.vercel.app, create a run, verify cancel works from the browser with the control token
- [ ] Verify old `run.json` files without `control_token_*` fields still load (backward compat via `from_dict` unknown-key filtering)

## Out of scope / follow-ups
- MCP CORS handling (Step 1) and `QTB.apiFetch` helper (Step 2) are **obviated** by the Vercel rewrite-proxy architecture already deployed — same-origin, no CORS required. Issue #18 comment has the full breakdown.
- Pre-launch hardening items (rate limits, crash recovery, full session-token auth) remain open.