### PR TITLE
feat(server): prod availability — /health + backtest cap + async job pattern

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,7 +107,8 @@ jobs:
             sudo systemctl restart quanttutor
             sleep 6
             sudo systemctl is-active quanttutor
-            curl -sf http://127.0.0.1:8000/session/list >/dev/null
+            # /health deep probe: docker daemon + LEAN image + disk (returns 503 on any failure)
+            curl -sf http://127.0.0.1:8000/health >/dev/null
             echo "--- disk ---"
             df -h /home | tail -1
             echo "--- tail log ---"

--- a/bench/client/runner.py
+++ b/bench/client/runner.py
@@ -395,7 +395,11 @@ class _RESTToolBridge:
             self._transport.call_tool(tool_name, kwargs),
             self._loop,
         )
-        return future.result(timeout=600)
+        # Heavy tools now queue behind a process-wide semaphore and then
+        # run up to the server's 600s backtest timeout, so the bridge
+        # must allow strictly more than RESTTransport._JOB_POLL_MAX_S
+        # (900s) plus a small network slop.
+        return future.result(timeout=960)
 
 
 def _parse_tool_result(result) -> dict:

--- a/bench/client/transports/rest_transport.py
+++ b/bench/client/transports/rest_transport.py
@@ -4,6 +4,7 @@ Validates that the server's REST API is fully functional as an
 alternative to MCP. Uses httpx for async HTTP.
 """
 
+import asyncio
 import json
 import logging
 from typing import Optional
@@ -13,6 +14,13 @@ import httpx
 from .base import SessionTransport
 
 logger = logging.getLogger(__name__)
+
+# Poll cadence for async tool jobs (heavy tools return 202 + job_id).
+_JOB_POLL_INTERVAL_S = 5.0
+# Upper bound so a wedged server cannot hang the client forever; the
+# server's own tool timeout (600s for backtests) will terminate the job
+# well before this.
+_JOB_POLL_MAX_S = 900.0
 
 
 class RESTTransport(SessionTransport):
@@ -92,9 +100,50 @@ class RESTTransport(SessionTransport):
         resp = await self._client.post(
             f"/session/{self._session_id}/tool/{name}", json=arguments
         )
+
+        # Heavy tools (run_backtest, run_lean_backtest) return 202 with a
+        # job_id to avoid holding a 10-minute HTTP connection open. Poll
+        # until the job reaches a terminal state, then return its result
+        # as if the call had been synchronous.
+        if resp.status_code == 202:
+            data = resp.json()
+            job_id = data.get("job_id")
+            if not job_id:
+                return json.dumps(data)
+            return await self._await_job(job_id)
+
         data = resp.json()
         # REST returns parsed JSON directly; convert back to string for adapter
         return json.dumps(data)
+
+    async def _await_job(self, job_id: str) -> str:
+        """Poll an async tool job until it completes and return its payload."""
+        url = f"/session/{self._session_id}/tool/jobs/{job_id}"
+        deadline = asyncio.get_event_loop().time() + _JOB_POLL_MAX_S
+        while True:
+            resp = await self._client.get(url)
+            if resp.status_code != 200:
+                return json.dumps(
+                    {"error": f"Job poll failed: HTTP {resp.status_code}"}
+                )
+            data = resp.json()
+            status = data.get("status")
+            if status == "completed":
+                return json.dumps(data.get("result") or {})
+            if status == "failed":
+                return json.dumps(
+                    {"error": data.get("error") or "job failed"}
+                )
+            if asyncio.get_event_loop().time() >= deadline:
+                return json.dumps(
+                    {
+                        "error": (
+                            f"Client gave up polling job {job_id} after "
+                            f"{_JOB_POLL_MAX_S:.0f}s"
+                        )
+                    }
+                )
+            await asyncio.sleep(_JOB_POLL_INTERVAL_S)
 
     async def send_message(
         self,

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -33,7 +33,12 @@ from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
 from server.config.bootstrap import load_server_env
-from server.run import RunService, RunStore, TaskCatalog
+from server.run import JobStore, RunService, RunStore, TaskCatalog
+from server.run.jobs import (
+    JOB_STATUS_COMPLETED,
+    JOB_STATUS_FAILED,
+    JOB_STATUS_RUNNING,
+)
 from server.run.models import RunStatus
 from server.web.ui_app import extract_bearer_token, resolve_run_from_token, ui_routes
 
@@ -100,9 +105,23 @@ class BenchSessionManager:
         self._run_store = RunStore(self.bench_root / "results" / "runs")
         self._run_service = RunService(self._catalog, self._run_store)
 
+        # Job layer — async tool dispatch (slice 2)
+        self._job_store = JobStore(self.bench_root / "results" / "jobs")
+        # Strong refs for background tasks so the event loop does not GC them
+        # mid-flight (asyncio.create_task caveat).
+        self._job_tasks: dict[str, asyncio.Task] = {}
+
     @contextlib.asynccontextmanager
     async def run(self) -> AsyncIterator[None]:
         """Lifespan context — manages task group for all sessions."""
+        # Any pending/running jobs on disk at startup lost their worker when
+        # the previous process died; fail them cleanly so clients polling a
+        # stale job_id get a terminal state instead of timing out.
+        orphans = await asyncio.to_thread(self._job_store.mark_orphans_failed)
+        if orphans:
+            logger.warning(
+                "Startup: failed %d orphan tool job(s) from previous run", orphans
+            )
         async with anyio.create_task_group() as tg:
             self._task_group = tg
             tg.start_soon(self._session_sweeper)
@@ -945,12 +964,47 @@ async def rest_tool_call(request: Request) -> JSONResponse:
 
     logger.debug("[REST:%s] tool_call: %s", sid[:8], name)
     state._last_activity = time.time()
+
+    if name in HEAVY_TOOLS:
+        # Async dispatch — return 202 immediately so the client is not
+        # holding an HTTP connection open for the full backtest window.
+        #
+        # Reserve the session lock synchronously before returning so any
+        # request (DELETE, send, another tool) arriving on a parallel
+        # connection after the 202 waits behind the accepted backtest
+        # instead of racing the background task's first timeslice.
+        # Ownership transfers to ``_execute_tool_job``, which releases
+        # it in a ``finally`` once the tool has run.
+        await state._request_lock.acquire()
+        try:
+            job = manager._job_store.create(sid, name, body)
+            task = asyncio.create_task(
+                _execute_tool_job(manager, state, job["job_id"], name, body)
+            )
+        except BaseException:
+            state._request_lock.release()
+            raise
+        manager._job_tasks[job["job_id"]] = task
+        task.add_done_callback(
+            lambda _t, jid=job["job_id"]: manager._job_tasks.pop(jid, None)
+        )
+        logger.info(
+            "[REST:%s] enqueued job %s for %s",
+            sid[:8],
+            job["job_id"][:8],
+            name,
+        )
+        return JSONResponse(
+            {
+                "job_id": job["job_id"],
+                "status": job["status"],
+                "poll_url": f"/session/{sid}/tool/jobs/{job['job_id']}",
+            },
+            status_code=202,
+        )
+
     async with state._request_lock:
-        if name in HEAVY_TOOLS:
-            async with backtest_sem():
-                result = await asyncio.to_thread(state.call_domain_tool, name, **body)
-        else:
-            result = await asyncio.to_thread(state.call_domain_tool, name, **body)
+        result = await asyncio.to_thread(state.call_domain_tool, name, **body)
     result_preview = str(result)[:150]
     logger.debug("[REST:%s] %s -> %s...", sid[:8], name, result_preview)
     try:
@@ -958,6 +1012,90 @@ async def rest_tool_call(request: Request) -> JSONResponse:
     except (json.JSONDecodeError, TypeError):
         parsed = {"success": True, "output": result}
     return JSONResponse(parsed)
+
+
+async def _execute_tool_job(
+    manager: "BenchSessionManager",
+    state: SessionState,
+    job_id: str,
+    name: str,
+    body: dict,
+) -> None:
+    """Background worker for heavy tool invocations.
+
+    Inherits ownership of ``state._request_lock`` from the request
+    handler that accepted the job (see rest_tool_call). The lock is
+    released in the ``finally`` below, after the tool has run, so
+    ordering with later same-session requests matches the synchronous
+    pre-slice-2 path.
+    """
+    store = manager._job_store
+    sid = state.session_id
+    try:
+        async with backtest_sem():
+            store.update(
+                job_id, status=JOB_STATUS_RUNNING, started_at=time.time()
+            )
+            state._last_activity = time.time()
+            result = await asyncio.to_thread(
+                state.call_domain_tool, name, **body
+            )
+        try:
+            parsed = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            parsed = {"success": True, "output": result}
+        store.update(
+            job_id,
+            status=JOB_STATUS_COMPLETED,
+            completed_at=time.time(),
+            result=parsed,
+        )
+        logger.info(
+            "[REST:%s] job %s (%s) completed", sid[:8], job_id[:8], name
+        )
+    except Exception as exc:
+        logger.exception("[REST:%s] job %s failed", sid[:8], job_id[:8])
+        store.update(
+            job_id,
+            status=JOB_STATUS_FAILED,
+            completed_at=time.time(),
+            error=f"{type(exc).__name__}: {exc}",
+        )
+    finally:
+        state._request_lock.release()
+
+
+async def rest_tool_job_status(request: Request) -> JSONResponse:
+    """``GET /session/{sid}/tool/jobs/{job_id}``
+
+    Returns the current status of an async tool job. The job_id must
+    belong to ``sid`` — a client cannot probe other sessions' jobs.
+
+    Deliberately does not require the session to still be in memory:
+    after a restart, sessions are gone but the JobStore still holds the
+    job record (possibly marked ``failed`` by ``mark_orphans_failed``),
+    and clients polling a stale job_id need to be able to see that
+    terminal state instead of a generic 404.
+    """
+    manager: BenchSessionManager = request.app.state.manager
+    sid = request.path_params["sid"]
+    job_id = request.path_params["job_id"]
+    job = manager._job_store.get(job_id)
+    if job is None or job.get("session_id") != sid:
+        return JSONResponse({"error": "Job not found"}, 404)
+    # Trim the echoed arguments — they can be large (full source files).
+    return JSONResponse(
+        {
+            "job_id": job["job_id"],
+            "tool_name": job["tool_name"],
+            "status": job["status"],
+            "created_at": job["created_at"],
+            "started_at": job["started_at"],
+            "completed_at": job["completed_at"],
+            "result": job["result"],
+            "error": job["error"],
+        }
+    )
 
 
 async def rest_send(request: Request) -> JSONResponse:
@@ -1171,6 +1309,13 @@ def create_app(
         Route("/session/{sid}", rest_session_status, methods=["GET", "DELETE"]),
         Route("/session/{sid}/start", rest_start, methods=["POST"]),
         Route("/session/{sid}/tools", rest_tools, methods=["GET"]),
+        # More-specific /tool/jobs/{job_id} must precede /tool/{name}
+        # or Starlette would bind "jobs" as the tool name.
+        Route(
+            "/session/{sid}/tool/jobs/{job_id}",
+            rest_tool_job_status,
+            methods=["GET"],
+        ),
         Route("/session/{sid}/tool/{name}", rest_tool_call, methods=["POST"]),
         Route("/session/{sid}/send", rest_send, methods=["POST"]),
         Route("/session/{sid}/evaluate", rest_evaluate, methods=["POST"]),

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -15,6 +15,9 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
+import shutil
+import subprocess
 import time
 from pathlib import Path
 from typing import AsyncIterator
@@ -34,6 +37,7 @@ from server.run import RunService, RunStore, TaskCatalog
 from server.run.models import RunStatus
 from server.web.ui_app import extract_bearer_token, resolve_run_from_token, ui_routes
 
+from .limits import HEAVY_TOOLS, backtest_sem
 from .protocol import (
     TOOL_ENDPOINT_BLOCKED,
     SessionPhase,
@@ -726,6 +730,80 @@ class BenchSessionManager:
 # ---------------------------------------------------------------------------
 
 
+_HEALTH_DISK_MIN_GB = 5.0
+_HEALTH_LEAN_IMAGE_DEFAULT = "quant-tutor-env:v2.2-lean"
+
+
+def _health_check_docker() -> dict:
+    try:
+        proc = subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=3
+        )
+        return {"ok": proc.returncode == 0}
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
+
+def _health_check_lean_image() -> dict:
+    image = os.environ.get("QTB_LEAN_IMAGE", _HEALTH_LEAN_IMAGE_DEFAULT)
+    try:
+        proc = subprocess.run(
+            ["docker", "image", "inspect", image],
+            capture_output=True,
+            timeout=3,
+        )
+        return {"ok": proc.returncode == 0, "image": image}
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return {
+            "ok": False,
+            "image": image,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+
+def _health_check_disk() -> dict:
+    try:
+        usage = shutil.disk_usage("/home")
+        free_gb = usage.free / (1024**3)
+        return {
+            "ok": free_gb >= _HEALTH_DISK_MIN_GB,
+            "free_gb": round(free_gb, 2),
+            "percent_free": round(usage.free / usage.total * 100, 1),
+        }
+    except OSError as exc:
+        return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
+
+async def rest_health(request: Request) -> JSONResponse:
+    """``GET /health`` — deep liveness probe.
+
+    In Docker mode validates Docker daemon, LEAN backtest image, and disk
+    headroom. In no-docker mode only disk is checked so a supported local
+    deployment is not reported unhealthy for a missing Docker daemon.
+    Returns 200 when all applicable checks pass, 503 otherwise so uptime
+    monitors and the deploy smoke test can detect real outages.
+    """
+    manager: BenchSessionManager = request.app.state.manager
+    checks: dict[str, dict] = {}
+    if manager.use_docker:
+        docker, image, disk = await asyncio.gather(
+            asyncio.to_thread(_health_check_docker),
+            asyncio.to_thread(_health_check_lean_image),
+            asyncio.to_thread(_health_check_disk),
+        )
+        checks["docker"] = docker
+        checks["lean_image"] = image
+        checks["disk"] = disk
+    else:
+        checks["mode"] = {"ok": True, "docker": False}
+        checks["disk"] = await asyncio.to_thread(_health_check_disk)
+    ok = all(c.get("ok") for c in checks.values())
+    return JSONResponse(
+        {"status": "ok" if ok else "down", "checks": checks},
+        status_code=200 if ok else 503,
+    )
+
+
 async def rest_register(request: Request) -> JSONResponse:
     """``POST /session/register``
 
@@ -868,7 +946,11 @@ async def rest_tool_call(request: Request) -> JSONResponse:
     logger.debug("[REST:%s] tool_call: %s", sid[:8], name)
     state._last_activity = time.time()
     async with state._request_lock:
-        result = await asyncio.to_thread(state.call_domain_tool, name, **body)
+        if name in HEAVY_TOOLS:
+            async with backtest_sem():
+                result = await asyncio.to_thread(state.call_domain_tool, name, **body)
+        else:
+            result = await asyncio.to_thread(state.call_domain_tool, name, **body)
     result_preview = str(result)[:150]
     logger.debug("[REST:%s] %s -> %s...", sid[:8], name, result_preview)
     try:
@@ -1106,6 +1188,7 @@ def create_app(
 
     all_routes = [
         Route("/", serve_index, methods=["GET"]),
+        Route("/health", rest_health, methods=["GET"]),
         *ui_routes(manager),
         *rest_routes,
         Mount(

--- a/bench/server/api/limits.py
+++ b/bench/server/api/limits.py
@@ -1,0 +1,35 @@
+"""Shared concurrency limits for tool dispatch.
+
+Keeps resource-intensive tool invocations (LEAN backtests especially)
+bounded so a burst of concurrent callers cannot exhaust the single VPS.
+The semaphore is shared across REST and MCP dispatch paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+HEAVY_TOOLS: frozenset[str] = frozenset({"run_backtest", "run_lean_backtest"})
+
+_sem: asyncio.Semaphore | None = None
+
+
+def _max_concurrent() -> int:
+    # Read env on demand so values loaded by load_server_env() are honoured
+    # even when this module is imported before bootstrap.
+    return max(1, int(os.environ.get("QTB_MAX_CONCURRENT_BACKTESTS", "2")))
+
+
+def backtest_sem() -> asyncio.Semaphore:
+    """Return the process-wide backtest semaphore, creating it lazily."""
+    global _sem
+    if _sem is None:
+        _sem = asyncio.Semaphore(_max_concurrent())
+    return _sem
+
+
+def reset_for_tests() -> None:
+    """Drop the cached semaphore so a fresh one is created per event loop."""
+    global _sem
+    _sem = None

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -33,6 +33,7 @@ from mcp.types import TextContent, Tool
 if TYPE_CHECKING:
     from mcp.server import Server
 
+from .limits import HEAVY_TOOLS, backtest_sem
 from .protocol import (
     GET_BACKGROUND_TOOL,
     GET_RESULTS_TOOL,
@@ -920,7 +921,13 @@ class SessionState:
             return [TextContent(type="text", text=json.dumps(result))]
 
         # Domain tool — route through proxy
-        result = await asyncio.to_thread(self.call_domain_tool, name, **arguments)
+        if name in HEAVY_TOOLS:
+            async with backtest_sem():
+                result = await asyncio.to_thread(
+                    self.call_domain_tool, name, **arguments
+                )
+        else:
+            result = await asyncio.to_thread(self.call_domain_tool, name, **arguments)
         result_preview = str(result)[:150]
         logger.debug("[%s] %s -> %s...", self.session_id[:8], name, result_preview)
         return [TextContent(type="text", text=str(result))]

--- a/bench/server/run/__init__.py
+++ b/bench/server/run/__init__.py
@@ -4,6 +4,7 @@ Manages RunAssignments (who runs what) on top of SessionState (how it runs).
 """
 
 from .catalog import TaskCatalog, TaskEntry
+from .jobs import JobStore
 from .models import RunAssignment, RunStatus
 from .service import RunService
 from .store import RunStore
@@ -11,6 +12,7 @@ from .store import RunStore
 __all__ = [
     "TaskCatalog",
     "TaskEntry",
+    "JobStore",
     "RunAssignment",
     "RunStatus",
     "RunService",

--- a/bench/server/run/jobs.py
+++ b/bench/server/run/jobs.py
@@ -1,0 +1,130 @@
+"""JobStore — JSON-file persistence for async tool invocations.
+
+Storage layout::
+
+    bench/results/jobs/{job_id}.json
+
+Used by the async job pattern (slice 2 of prod-availability work): heavy
+tools like ``run_lean_backtest`` return a ``job_id`` immediately so the
+client can poll ``GET /session/{sid}/tool/jobs/{job_id}`` instead of
+holding a 10-minute HTTP connection open.
+
+Thread-safe: all writes protected by an internal lock.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+JOB_STATUS_PENDING = "pending"
+JOB_STATUS_RUNNING = "running"
+JOB_STATUS_COMPLETED = "completed"
+JOB_STATUS_FAILED = "failed"
+
+_ACTIVE = {JOB_STATUS_PENDING, JOB_STATUS_RUNNING}
+
+
+class JobStore:
+    """Disk-backed store for async tool-call jobs."""
+
+    def __init__(self, jobs_dir: Path):
+        self._dir = Path(jobs_dir)
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+
+    def _path(self, job_id: str) -> Path:
+        return self._dir / f"{job_id}.json"
+
+    def create(
+        self, session_id: str, tool_name: str, arguments: dict | None = None
+    ) -> dict:
+        """Create a pending job record and return it."""
+        job = {
+            "job_id": uuid.uuid4().hex,
+            "session_id": session_id,
+            "tool_name": tool_name,
+            "arguments": arguments or {},
+            "status": JOB_STATUS_PENDING,
+            "created_at": time.time(),
+            "started_at": None,
+            "completed_at": None,
+            "result": None,
+            "error": None,
+        }
+        self._write(job)
+        return job
+
+    def update(self, job_id: str, **fields) -> Optional[dict]:
+        """Merge ``fields`` into the stored job record."""
+        with self._lock:
+            job = self._read(job_id)
+            if job is None:
+                return None
+            job.update(fields)
+            self._write_locked(job)
+            return job
+
+    def get(self, job_id: str) -> Optional[dict]:
+        with self._lock:
+            return self._read(job_id)
+
+    def mark_orphans_failed(self) -> int:
+        """Any pending/running jobs at startup lost their worker. Fail them.
+
+        Called once during server startup so clients polling a stale job_id
+        get a clean terminal state instead of waiting forever.
+        """
+        count = 0
+        with self._lock:
+            if not self._dir.is_dir():
+                return 0
+            for path in self._dir.glob("*.json"):
+                try:
+                    job = json.loads(path.read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError) as exc:
+                    logger.warning("JobStore: corrupt job file %s: %s", path.name, exc)
+                    continue
+                if job.get("status") in _ACTIVE:
+                    job["status"] = JOB_STATUS_FAILED
+                    job["error"] = "server restarted before job completed"
+                    job["completed_at"] = time.time()
+                    self._write_locked(job)
+                    count += 1
+        if count:
+            logger.info("JobStore: marked %d orphaned job(s) as failed", count)
+        return count
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _write(self, job: dict) -> None:
+        with self._lock:
+            self._write_locked(job)
+
+    def _write_locked(self, job: dict) -> None:
+        path = self._path(job["job_id"])
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(
+            json.dumps(job, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        tmp.replace(path)
+
+    def _read(self, job_id: str) -> Optional[dict]:
+        path = self._path(job_id)
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("JobStore: corrupt job %s: %s", job_id, exc)
+            return None

--- a/bench/tests/conftest.py
+++ b/bench/tests/conftest.py
@@ -73,10 +73,32 @@ if "mcp" not in sys.modules:
     _mcp_streamable.StreamableHTTPServerTransport = _StreamableHTTPServerTransport
     _mcp_server.streamable_http = _mcp_streamable
 
+    # Stub mcp.client.* so client.transports package can import without
+    # the real SDK present (e.g. REST transport unit tests).
+    _mcp_client = types.ModuleType("mcp.client")
+    _mcp_client_session = types.ModuleType("mcp.client.session")
+    _mcp_client_streamable = types.ModuleType("mcp.client.streamable_http")
+
+    class _ClientSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    async def _streamablehttp_client(*args, **kwargs):  # pragma: no cover
+        raise RuntimeError("mcp.client stubbed — real SDK not installed")
+
+    _mcp_client_session.ClientSession = _ClientSession
+    _mcp_client_streamable.streamablehttp_client = _streamablehttp_client
+    _mcp_client.session = _mcp_client_session
+    _mcp_client.streamable_http = _mcp_client_streamable
+    _mcp.client = _mcp_client
+
     sys.modules["mcp"] = _mcp
     sys.modules["mcp.types"] = _mcp_types
     sys.modules["mcp.server"] = _mcp_server
     sys.modules["mcp.server.streamable_http"] = _mcp_streamable
+    sys.modules["mcp.client"] = _mcp_client
+    sys.modules["mcp.client.session"] = _mcp_client_session
+    sys.modules["mcp.client.streamable_http"] = _mcp_client_streamable
 
 # Ensure bench/ is on sys.path so ``import server.*`` works.
 _BENCH_ROOT = Path(__file__).resolve().parents[1]

--- a/bench/tests/test_health.py
+++ b/bench/tests/test_health.py
@@ -1,0 +1,196 @@
+"""Tests for /health endpoint and backtest concurrency cap."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from unittest.mock import patch
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.api import limits
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    # Docker mode: the /health endpoint runs its full check matrix.
+    app._manager.use_docker = True
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def client_no_docker(app):
+    # Local dev mode: Docker probes are skipped.
+    app._manager.use_docker = False
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _reset_backtest_sem():
+    """Drop the cached semaphore so each test starts with a fresh one
+    bound to the current event loop."""
+    limits.reset_for_tests()
+    yield
+    limits.reset_for_tests()
+
+
+def _fake_proc(returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=b"", stderr=b"")
+
+
+class TestHealth:
+    @pytest.mark.asyncio
+    async def test_ok_when_all_checks_pass(self, client):
+        with (
+            patch("server.api.http_app.subprocess.run", return_value=_fake_proc(0)),
+            patch(
+                "server.api.http_app.shutil.disk_usage",
+                return_value=type("Usage", (), {"total": 100 * 1024**3, "used": 10 * 1024**3, "free": 90 * 1024**3})(),
+            ),
+        ):
+            resp = await client.get("/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert body["checks"]["docker"]["ok"] is True
+        assert body["checks"]["lean_image"]["ok"] is True
+        assert body["checks"]["disk"]["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_down_when_docker_missing(self, client):
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[0] == "docker":
+                raise FileNotFoundError("docker not found")
+            return _fake_proc(0)
+
+        with (
+            patch("server.api.http_app.subprocess.run", side_effect=fake_run),
+            patch(
+                "server.api.http_app.shutil.disk_usage",
+                return_value=type("Usage", (), {"total": 100 * 1024**3, "used": 10 * 1024**3, "free": 90 * 1024**3})(),
+            ),
+        ):
+            resp = await client.get("/health")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["status"] == "down"
+        assert body["checks"]["docker"]["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_down_when_lean_image_missing(self, client):
+        def fake_run(cmd, *args, **kwargs):
+            # docker info OK, image inspect fails
+            if len(cmd) >= 3 and cmd[1] == "image":
+                return _fake_proc(1)
+            return _fake_proc(0)
+
+        with (
+            patch("server.api.http_app.subprocess.run", side_effect=fake_run),
+            patch(
+                "server.api.http_app.shutil.disk_usage",
+                return_value=type("Usage", (), {"total": 100 * 1024**3, "used": 10 * 1024**3, "free": 90 * 1024**3})(),
+            ),
+        ):
+            resp = await client.get("/health")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["checks"]["docker"]["ok"] is True
+        assert body["checks"]["lean_image"]["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_down_when_disk_low(self, client):
+        with (
+            patch("server.api.http_app.subprocess.run", return_value=_fake_proc(0)),
+            patch(
+                "server.api.http_app.shutil.disk_usage",
+                return_value=type("Usage", (), {"total": 100 * 1024**3, "used": 98 * 1024**3, "free": 2 * 1024**3})(),
+            ),
+        ):
+            resp = await client.get("/health")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["checks"]["disk"]["ok"] is False
+        assert body["checks"]["disk"]["free_gb"] < 5.0
+
+    @pytest.mark.asyncio
+    async def test_health_does_not_require_auth(self, client):
+        # No Authorization header; should still respond.
+        with (
+            patch("server.api.http_app.subprocess.run", return_value=_fake_proc(0)),
+            patch(
+                "server.api.http_app.shutil.disk_usage",
+                return_value=type("Usage", (), {"total": 100 * 1024**3, "used": 10 * 1024**3, "free": 90 * 1024**3})(),
+            ),
+        ):
+            resp = await client.get("/health")
+        assert resp.status_code in (200, 503)
+
+    @pytest.mark.asyncio
+    async def test_no_docker_mode_skips_docker_probes(self, client_no_docker):
+        # In --no-docker mode the endpoint should not fail just because
+        # Docker is missing; only disk is checked.
+        with (
+            patch(
+                "server.api.http_app.subprocess.run",
+                side_effect=FileNotFoundError("docker not found"),
+            ),
+            patch(
+                "server.api.http_app.shutil.disk_usage",
+                return_value=type("Usage", (), {"total": 100 * 1024**3, "used": 10 * 1024**3, "free": 90 * 1024**3})(),
+            ),
+        ):
+            resp = await client_no_docker.get("/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert "docker" not in body["checks"]
+        assert "lean_image" not in body["checks"]
+        assert body["checks"]["disk"]["ok"] is True
+
+
+class TestBacktestSemaphore:
+    @pytest.mark.asyncio
+    async def test_semaphore_is_lazy_and_shared(self):
+        sem1 = limits.backtest_sem()
+        sem2 = limits.backtest_sem()
+        assert sem1 is sem2
+
+    @pytest.mark.asyncio
+    async def test_semaphore_caps_concurrency(self, monkeypatch):
+        # Env var set AFTER module import (mirrors load_server_env order)
+        # must still be honoured because backtest_sem() reads it lazily.
+        monkeypatch.setenv("QTB_MAX_CONCURRENT_BACKTESTS", "2")
+        sem = limits.backtest_sem()
+
+        in_flight = 0
+        peak = 0
+
+        async def fake_backtest():
+            nonlocal in_flight, peak
+            async with sem:
+                in_flight += 1
+                peak = max(peak, in_flight)
+                await asyncio.sleep(0.05)
+                in_flight -= 1
+
+        await asyncio.gather(*(fake_backtest() for _ in range(5)))
+        assert peak == 2, f"expected at most 2 concurrent, saw {peak}"
+
+    def test_max_concurrent_reads_env_lazily(self, monkeypatch):
+        monkeypatch.setenv("QTB_MAX_CONCURRENT_BACKTESTS", "7")
+        assert limits._max_concurrent() == 7
+        monkeypatch.setenv("QTB_MAX_CONCURRENT_BACKTESTS", "0")
+        # Floor of 1 to keep the semaphore usable.
+        assert limits._max_concurrent() == 1
+
+    def test_heavy_tools_set_includes_known_backtest_tools(self):
+        assert "run_lean_backtest" in limits.HEAVY_TOOLS
+        assert "run_backtest" in limits.HEAVY_TOOLS

--- a/bench/tests/test_rest_transport_jobs.py
+++ b/bench/tests/test_rest_transport_jobs.py
@@ -1,0 +1,105 @@
+"""Client-side test for the REST transport's async job polling path."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from client.transports import rest_transport
+from client.transports.rest_transport import RESTTransport
+
+
+@pytest.mark.asyncio
+async def test_call_tool_polls_job_until_complete(monkeypatch):
+    # Keep the test fast regardless of the production poll interval.
+    monkeypatch.setattr(rest_transport, "_JOB_POLL_INTERVAL_S", 0.01)
+
+    calls = {"poll_count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/tool/run_lean_backtest") and request.method == "POST":
+            return httpx.Response(
+                202,
+                json={
+                    "job_id": "job-abc",
+                    "status": "pending",
+                    "poll_url": "/session/s1/tool/jobs/job-abc",
+                },
+            )
+        if request.url.path.endswith("/tool/jobs/job-abc"):
+            calls["poll_count"] += 1
+            if calls["poll_count"] < 3:
+                return httpx.Response(200, json={"status": "running"})
+            return httpx.Response(
+                200,
+                json={
+                    "status": "completed",
+                    "result": {"sharpe": 1.23, "trades": 85},
+                },
+            )
+        return httpx.Response(404)
+
+    transport = RESTTransport()
+    transport._base_url = "http://test"
+    transport._session_id = "s1"
+    transport._client = httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(handler)
+    )
+    try:
+        raw = await transport.call_tool("run_lean_backtest", {"path": "x.cs"})
+    finally:
+        await transport._client.aclose()
+
+    payload = json.loads(raw)
+    assert payload == {"sharpe": 1.23, "trades": 85}
+    assert calls["poll_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_call_tool_surfaces_job_failure(monkeypatch):
+    monkeypatch.setattr(rest_transport, "_JOB_POLL_INTERVAL_S", 0.01)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(
+                202, json={"job_id": "job-fail", "status": "pending"}
+            )
+        return httpx.Response(
+            200,
+            json={"status": "failed", "error": "RuntimeError: boom"},
+        )
+
+    transport = RESTTransport()
+    transport._base_url = "http://test"
+    transport._session_id = "s1"
+    transport._client = httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(handler)
+    )
+    try:
+        raw = await transport.call_tool("run_backtest", {})
+    finally:
+        await transport._client.aclose()
+    payload = json.loads(raw)
+    assert "boom" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_call_tool_sync_200_passthrough():
+    # Non-heavy tools still return 200 directly; no polling.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ok": True, "sync": True})
+
+    transport = RESTTransport()
+    transport._base_url = "http://test"
+    transport._session_id = "s1"
+    transport._client = httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(handler)
+    )
+    try:
+        raw = await transport.call_tool("shell_exec", {"command": "echo"})
+    finally:
+        await transport._client.aclose()
+    payload = json.loads(raw)
+    assert payload == {"ok": True, "sync": True}

--- a/bench/tests/test_tool_jobs.py
+++ b/bench/tests/test_tool_jobs.py
@@ -1,0 +1,303 @@
+"""Tests for async tool-job dispatch (heavy-tool 202 path + polling)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.api import limits
+from server.run.jobs import (
+    JOB_STATUS_COMPLETED,
+    JOB_STATUS_FAILED,
+    JOB_STATUS_PENDING,
+    JOB_STATUS_RUNNING,
+    JobStore,
+)
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _reset_backtest_sem():
+    limits.reset_for_tests()
+    yield
+    limits.reset_for_tests()
+
+
+async def _register_session(client: httpx.AsyncClient) -> str:
+    from tests.helpers import register_session
+
+    return await register_session(client)
+
+
+# ---------------------------------------------------------------------------
+# JobStore unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestJobStore:
+    def test_create_returns_pending_job(self, tmp_path):
+        store = JobStore(tmp_path / "jobs")
+        job = store.create("sess-1", "run_lean_backtest", {"path": "x.cs"})
+        assert job["status"] == JOB_STATUS_PENDING
+        assert job["session_id"] == "sess-1"
+        assert job["tool_name"] == "run_lean_backtest"
+        assert job["arguments"] == {"path": "x.cs"}
+        assert (tmp_path / "jobs" / f"{job['job_id']}.json").exists()
+
+    def test_update_merges_fields(self, tmp_path):
+        store = JobStore(tmp_path / "jobs")
+        job = store.create("sess-1", "run_backtest")
+        updated = store.update(
+            job["job_id"], status=JOB_STATUS_COMPLETED, result={"ok": True}
+        )
+        assert updated["status"] == JOB_STATUS_COMPLETED
+        assert updated["result"] == {"ok": True}
+        # Persisted
+        reread = store.get(job["job_id"])
+        assert reread["status"] == JOB_STATUS_COMPLETED
+
+    def test_get_missing_returns_none(self, tmp_path):
+        store = JobStore(tmp_path / "jobs")
+        assert store.get("nope") is None
+
+    def test_mark_orphans_failed(self, tmp_path):
+        store = JobStore(tmp_path / "jobs")
+        j1 = store.create("sess", "run_backtest")
+        j2 = store.create("sess", "run_backtest")
+        j3 = store.create("sess", "run_backtest")
+        store.update(j2["job_id"], status=JOB_STATUS_RUNNING)
+        store.update(j3["job_id"], status=JOB_STATUS_COMPLETED, result={"ok": True})
+
+        failed = store.mark_orphans_failed()
+        assert failed == 2  # j1 pending + j2 running
+
+        assert store.get(j1["job_id"])["status"] == JOB_STATUS_FAILED
+        assert store.get(j2["job_id"])["status"] == JOB_STATUS_FAILED
+        # Terminal states untouched.
+        assert store.get(j3["job_id"])["status"] == JOB_STATUS_COMPLETED
+        assert "restarted" in store.get(j1["job_id"])["error"]
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestHeavyToolDispatch:
+    @pytest.mark.asyncio
+    async def test_heavy_tool_returns_202_with_job_id(self, client, monkeypatch):
+        sid = await _register_session(client)
+
+        # Replace call_domain_tool with a fast fake so the whole flow can
+        # complete in-process without touching Docker.
+        manager = client._transport.app._manager
+
+        def fake_tool(name, **kwargs):
+            return json.dumps({"ok": True, "tool": name, "args": kwargs})
+
+        state = manager.get_session(sid)
+        monkeypatch.setattr(state, "call_domain_tool", fake_tool)
+
+        # Start the session so the tool-call permission check passes.
+        await client.post(f"/session/{sid}/start", json={})
+
+        resp = await client.post(
+            f"/session/{sid}/tool/run_lean_backtest",
+            json={"algorithm_path": "x.cs"},
+        )
+        assert resp.status_code == 202, resp.text
+        body = resp.json()
+        assert body["status"] == JOB_STATUS_PENDING
+        assert "job_id" in body
+        assert body["poll_url"].endswith(f"/tool/jobs/{body['job_id']}")
+
+        # Poll until completion.
+        job_id = body["job_id"]
+        for _ in range(50):
+            poll = await client.get(f"/session/{sid}/tool/jobs/{job_id}")
+            assert poll.status_code == 200
+            data = poll.json()
+            if data["status"] == JOB_STATUS_COMPLETED:
+                assert data["result"]["ok"] is True
+                assert data["result"]["tool"] == "run_lean_backtest"
+                return
+            if data["status"] == JOB_STATUS_FAILED:
+                pytest.fail(f"Job unexpectedly failed: {data['error']}")
+            await asyncio.sleep(0.05)
+        pytest.fail("Job never reached terminal state")
+
+    @pytest.mark.asyncio
+    async def test_heavy_tool_job_captures_exception(self, client, monkeypatch):
+        sid = await _register_session(client)
+        manager = client._transport.app._manager
+        state = manager.get_session(sid)
+
+        def exploding_tool(name, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(state, "call_domain_tool", exploding_tool)
+        await client.post(f"/session/{sid}/start", json={})
+
+        resp = await client.post(
+            f"/session/{sid}/tool/run_lean_backtest", json={}
+        )
+        assert resp.status_code == 202
+        job_id = resp.json()["job_id"]
+
+        for _ in range(50):
+            poll = await client.get(f"/session/{sid}/tool/jobs/{job_id}")
+            data = poll.json()
+            if data["status"] == JOB_STATUS_FAILED:
+                assert "boom" in data["error"]
+                return
+            if data["status"] == JOB_STATUS_COMPLETED:
+                pytest.fail("Job unexpectedly completed")
+            await asyncio.sleep(0.05)
+        pytest.fail("Job never reached terminal state")
+
+    @pytest.mark.asyncio
+    async def test_job_lookup_rejects_wrong_session(self, client, monkeypatch):
+        sid_a = await _register_session(client)
+        manager = client._transport.app._manager
+        state_a = manager.get_session(sid_a)
+        monkeypatch.setattr(
+            state_a,
+            "call_domain_tool",
+            lambda name, **kw: json.dumps({"ok": True}),
+        )
+        await client.post(f"/session/{sid_a}/start", json={})
+
+        resp = await client.post(
+            f"/session/{sid_a}/tool/run_lean_backtest", json={}
+        )
+        job_id = resp.json()["job_id"]
+
+        # Different session asking about A's job must 404.
+        sid_b = await _register_session(client)
+        poll = await client.get(f"/session/{sid_b}/tool/jobs/{job_id}")
+        assert poll.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_non_heavy_tool_stays_synchronous(self, client, monkeypatch):
+        sid = await _register_session(client)
+        manager = client._transport.app._manager
+        state = manager.get_session(sid)
+        monkeypatch.setattr(
+            state,
+            "call_domain_tool",
+            lambda name, **kw: json.dumps({"ok": True, "sync": True}),
+        )
+        await client.post(f"/session/{sid}/start", json={})
+
+        resp = await client.post(
+            f"/session/{sid}/tool/shell_exec", json={"command": "echo hi"}
+        )
+        assert resp.status_code == 200
+        # No 202, no job_id.
+        body = resp.json()
+        assert body.get("sync") is True
+
+    @pytest.mark.asyncio
+    async def test_orphaned_job_still_pollable_without_session(self, client):
+        """After a restart the in-memory session is gone, but the failed
+        job record on disk must still be reachable so the client sees
+        the terminal state instead of a generic 404."""
+        manager = client._transport.app._manager
+        job = manager._job_store.create(
+            "sess-ghost", "run_lean_backtest", {"x": 1}
+        )
+        manager._job_store.update(
+            job["job_id"],
+            status=JOB_STATUS_FAILED,
+            error="server restarted before job completed",
+        )
+        # Note: no session named sess-ghost exists in the manager.
+        resp = await client.get(
+            f"/session/sess-ghost/tool/jobs/{job['job_id']}"
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["status"] == JOB_STATUS_FAILED
+        assert "restarted" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_queued_job_blocks_same_session_mutation(
+        self, client, monkeypatch
+    ):
+        """A heavy tool accepted first must hold the session lock until
+        it runs, so a later same-session write cannot race ahead and
+        tear the session down before the backtest executes."""
+        sid = await _register_session(client)
+        manager = client._transport.app._manager
+        state = manager.get_session(sid)
+
+        order: list[str] = []
+        tool_started = threading.Event()
+        release_tool = threading.Event()
+
+        def slow_tool(name, **kw):
+            order.append("tool_start")
+            tool_started.set()
+            # Block until the test lets the backtest finish. Runs on the
+            # to_thread worker, so a threading.Event (not asyncio.Event)
+            # is required.
+            release_tool.wait(timeout=5.0)
+            order.append("tool_end")
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr(state, "call_domain_tool", slow_tool)
+        await client.post(f"/session/{sid}/start", json={})
+
+        # 1. Accept a heavy tool — returns 202 immediately, job queued.
+        resp = await client.post(
+            f"/session/{sid}/tool/run_lean_backtest", json={}
+        )
+        assert resp.status_code == 202
+        job_id = resp.json()["job_id"]
+
+        # Wait until the background worker is actually inside the tool
+        # (it already holds state._request_lock at this point).
+        await asyncio.get_event_loop().run_in_executor(
+            None, tool_started.wait, 2.0
+        )
+        assert tool_started.is_set(), "background worker never started"
+
+        # 2. Fire a mutating request concurrently. It must wait for the
+        #    running backtest to release the session lock.
+        async def later_send():
+            order.append("send_issued")
+            r = await client.post(f"/session/{sid}/send", json={"text": "hi"})
+            order.append(f"send_done:{r.status_code}")
+
+        send_task = asyncio.create_task(later_send())
+        await asyncio.sleep(0.1)  # give send a chance to block on the lock
+        assert not any(s.startswith("send_done") for s in order), (
+            "send completed before backtest released the lock"
+        )
+
+        # Release the backtest and wait for both to finish.
+        release_tool.set()
+        for _ in range(200):
+            poll = await client.get(f"/session/{sid}/tool/jobs/{job_id}")
+            if poll.json()["status"] in (JOB_STATUS_COMPLETED, JOB_STATUS_FAILED):
+                break
+            await asyncio.sleep(0.02)
+        await asyncio.wait_for(send_task, timeout=5.0)
+
+        assert "tool_end" in order
+        send_done_idx = next(
+            i for i, v in enumerate(order) if v.startswith("send_done")
+        )
+        assert order.index("tool_end") < send_done_idx


### PR DESCRIPTION
## Summary

Two slices hardening the single-VPS MVP deployment so we can host the real service (not just a smoke test) against it. No behaviour changes for non-heavy tools.

- **P1 — `/health` + concurrency cap** (`5e5da19`)
  - `GET /health` probes docker daemon, `quant-tutor-env:v2.2-lean` image (override via `QTB_LEAN_IMAGE`), and `/home` disk headroom. Returns 503 on any failure so uptime monitors and the deploy smoke test catch real outages instead of a live-but-broken HTTP listener. Gated on `use_docker` so `--no-docker` local runs aren't spuriously unhealthy.
  - `asyncio.Semaphore` (env `QTB_MAX_CONCURRENT_BACKTESTS`, default 2) wraps `run_backtest` / `run_lean_backtest` dispatch on both REST and MCP so a burst of concurrent backtests cannot OOM the VPS. Read lazily so `.env` values loaded by `load_server_env()` win.
  - `deploy.yml` smoke test now curls `/health` instead of `/session/list`.

- **P2 — async job pattern for heavy tools** (`c4d6fa5`)
  - New `JobStore` (`bench/server/run/jobs.py`) — tmp-file-replace JSON-on-disk record per invocation; `mark_orphans_failed()` called on startup so jobs interrupted by a restart become terminal instead of wedging polling clients.
  - `POST /session/{sid}/tool/{name}` returns `202 {job_id, status, poll_url}` for heavy tools; the handler reserves the session lock synchronously before returning so parallel-connection writes wait behind the accepted backtest. Ownership transfers to the background worker, which releases the lock in `finally`.
  - New `GET /session/{sid}/tool/jobs/{job_id}` does not require the session to still be in memory so clients polling after a restart see the terminal state instead of a 404.
  - `RESTTransport.call_tool` detects 202 and polls every 5s (≤900s) transparently — no adapter changes. Bridge timeout raised to 960s so it stays strictly > poll ceiling.

Both slices went through two rounds of Codex review; all findings accepted.

## Test plan

- [x] `pytest bench/tests/test_health.py` — 10/10 pass
- [x] `pytest bench/tests/test_tool_jobs.py bench/tests/test_rest_transport_jobs.py` — 13/13 pass
- [x] Full API regression: `pytest bench/tests/api/ bench/tests/test_health.py bench/tests/test_tool_jobs.py bench/tests/test_rest_transport_jobs.py` — 94/94 pass
- [ ] After merge + deploy: curl `https://217-15-165-83.sslip.io/health` → 200 with all three checks `ok:true`
- [ ] After merge + deploy: run a real LEAN backtest end-to-end through the frontend and confirm the client polls the job to completion without a 10-minute open HTTP request
- [ ] Simulate VPS restart mid-backtest; confirm client polling sees `status:"failed"` with `"server restarted before job completed"` instead of 404