### PR TITLE
dev → master: prod-availability slices + issue-18 run hardening

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,7 +107,8 @@ jobs:
             sudo systemctl restart quanttutor
             sleep 6
             sudo systemctl is-active quanttutor
-            curl -sf http://127.0.0.1:8000/session/list >/dev/null
+            # /health deep probe: docker daemon + LEAN image + disk (returns 503 on any failure)
+            curl -sf http://127.0.0.1:8000/health >/dev/null
             echo "--- disk ---"
             df -h /home | tail -1
             echo "--- tail log ---"

--- a/bench/client/runner.py
+++ b/bench/client/runner.py
@@ -395,7 +395,11 @@ class _RESTToolBridge:
             self._transport.call_tool(tool_name, kwargs),
             self._loop,
         )
-        return future.result(timeout=600)
+        # Heavy tools now queue behind a process-wide semaphore and then
+        # run up to the server's 600s backtest timeout, so the bridge
+        # must allow strictly more than RESTTransport._JOB_POLL_MAX_S
+        # (900s) plus a small network slop.
+        return future.result(timeout=960)
 
 
 def _parse_tool_result(result) -> dict:

--- a/bench/client/transports/rest_transport.py
+++ b/bench/client/transports/rest_transport.py
@@ -4,6 +4,7 @@ Validates that the server's REST API is fully functional as an
 alternative to MCP. Uses httpx for async HTTP.
 """
 
+import asyncio
 import json
 import logging
 from typing import Optional
@@ -13,6 +14,13 @@ import httpx
 from .base import SessionTransport
 
 logger = logging.getLogger(__name__)
+
+# Poll cadence for async tool jobs (heavy tools return 202 + job_id).
+_JOB_POLL_INTERVAL_S = 5.0
+# Upper bound so a wedged server cannot hang the client forever; the
+# server's own tool timeout (600s for backtests) will terminate the job
+# well before this.
+_JOB_POLL_MAX_S = 900.0
 
 
 class RESTTransport(SessionTransport):
@@ -92,9 +100,50 @@ class RESTTransport(SessionTransport):
         resp = await self._client.post(
             f"/session/{self._session_id}/tool/{name}", json=arguments
         )
+
+        # Heavy tools (run_backtest, run_lean_backtest) return 202 with a
+        # job_id to avoid holding a 10-minute HTTP connection open. Poll
+        # until the job reaches a terminal state, then return its result
+        # as if the call had been synchronous.
+        if resp.status_code == 202:
+            data = resp.json()
+            job_id = data.get("job_id")
+            if not job_id:
+                return json.dumps(data)
+            return await self._await_job(job_id)
+
         data = resp.json()
         # REST returns parsed JSON directly; convert back to string for adapter
         return json.dumps(data)
+
+    async def _await_job(self, job_id: str) -> str:
+        """Poll an async tool job until it completes and return its payload."""
+        url = f"/session/{self._session_id}/tool/jobs/{job_id}"
+        deadline = asyncio.get_event_loop().time() + _JOB_POLL_MAX_S
+        while True:
+            resp = await self._client.get(url)
+            if resp.status_code != 200:
+                return json.dumps(
+                    {"error": f"Job poll failed: HTTP {resp.status_code}"}
+                )
+            data = resp.json()
+            status = data.get("status")
+            if status == "completed":
+                return json.dumps(data.get("result") or {})
+            if status == "failed":
+                return json.dumps(
+                    {"error": data.get("error") or "job failed"}
+                )
+            if asyncio.get_event_loop().time() >= deadline:
+                return json.dumps(
+                    {
+                        "error": (
+                            f"Client gave up polling job {job_id} after "
+                            f"{_JOB_POLL_MAX_S:.0f}s"
+                        )
+                    }
+                )
+            await asyncio.sleep(_JOB_POLL_INTERVAL_S)
 
     async def send_message(
         self,

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -33,7 +33,12 @@ from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
 from server.config.bootstrap import load_server_env
-from server.run import RunService, RunStore, TaskCatalog
+from server.run import JobStore, RunService, RunStore, TaskCatalog
+from server.run.jobs import (
+    JOB_STATUS_COMPLETED,
+    JOB_STATUS_FAILED,
+    JOB_STATUS_RUNNING,
+)
 from server.run.models import RunStatus
 from server.web.ui_app import extract_bearer_token, resolve_run_from_token, ui_routes
 
@@ -100,9 +105,23 @@ class BenchSessionManager:
         self._run_store = RunStore(self.bench_root / "results" / "runs")
         self._run_service = RunService(self._catalog, self._run_store)
 
+        # Job layer — async tool dispatch (slice 2)
+        self._job_store = JobStore(self.bench_root / "results" / "jobs")
+        # Strong refs for background tasks so the event loop does not GC them
+        # mid-flight (asyncio.create_task caveat).
+        self._job_tasks: dict[str, asyncio.Task] = {}
+
     @contextlib.asynccontextmanager
     async def run(self) -> AsyncIterator[None]:
         """Lifespan context — manages task group for all sessions."""
+        # Any pending/running jobs on disk at startup lost their worker when
+        # the previous process died; fail them cleanly so clients polling a
+        # stale job_id get a terminal state instead of timing out.
+        orphans = await asyncio.to_thread(self._job_store.mark_orphans_failed)
+        if orphans:
+            logger.warning(
+                "Startup: failed %d orphan tool job(s) from previous run", orphans
+            )
         async with anyio.create_task_group() as tg:
             self._task_group = tg
             tg.start_soon(self._session_sweeper)
@@ -945,12 +964,47 @@ async def rest_tool_call(request: Request) -> JSONResponse:
 
     logger.debug("[REST:%s] tool_call: %s", sid[:8], name)
     state._last_activity = time.time()
+
+    if name in HEAVY_TOOLS:
+        # Async dispatch — return 202 immediately so the client is not
+        # holding an HTTP connection open for the full backtest window.
+        #
+        # Reserve the session lock synchronously before returning so any
+        # request (DELETE, send, another tool) arriving on a parallel
+        # connection after the 202 waits behind the accepted backtest
+        # instead of racing the background task's first timeslice.
+        # Ownership transfers to ``_execute_tool_job``, which releases
+        # it in a ``finally`` once the tool has run.
+        await state._request_lock.acquire()
+        try:
+            job = manager._job_store.create(sid, name, body)
+            task = asyncio.create_task(
+                _execute_tool_job(manager, state, job["job_id"], name, body)
+            )
+        except BaseException:
+            state._request_lock.release()
+            raise
+        manager._job_tasks[job["job_id"]] = task
+        task.add_done_callback(
+            lambda _t, jid=job["job_id"]: manager._job_tasks.pop(jid, None)
+        )
+        logger.info(
+            "[REST:%s] enqueued job %s for %s",
+            sid[:8],
+            job["job_id"][:8],
+            name,
+        )
+        return JSONResponse(
+            {
+                "job_id": job["job_id"],
+                "status": job["status"],
+                "poll_url": f"/session/{sid}/tool/jobs/{job['job_id']}",
+            },
+            status_code=202,
+        )
+
     async with state._request_lock:
-        if name in HEAVY_TOOLS:
-            async with backtest_sem():
-                result = await asyncio.to_thread(state.call_domain_tool, name, **body)
-        else:
-            result = await asyncio.to_thread(state.call_domain_tool, name, **body)
+        result = await asyncio.to_thread(state.call_domain_tool, name, **body)
     result_preview = str(result)[:150]
     logger.debug("[REST:%s] %s -> %s...", sid[:8], name, result_preview)
     try:
@@ -958,6 +1012,90 @@ async def rest_tool_call(request: Request) -> JSONResponse:
     except (json.JSONDecodeError, TypeError):
         parsed = {"success": True, "output": result}
     return JSONResponse(parsed)
+
+
+async def _execute_tool_job(
+    manager: "BenchSessionManager",
+    state: SessionState,
+    job_id: str,
+    name: str,
+    body: dict,
+) -> None:
+    """Background worker for heavy tool invocations.
+
+    Inherits ownership of ``state._request_lock`` from the request
+    handler that accepted the job (see rest_tool_call). The lock is
+    released in the ``finally`` below, after the tool has run, so
+    ordering with later same-session requests matches the synchronous
+    pre-slice-2 path.
+    """
+    store = manager._job_store
+    sid = state.session_id
+    try:
+        async with backtest_sem():
+            store.update(
+                job_id, status=JOB_STATUS_RUNNING, started_at=time.time()
+            )
+            state._last_activity = time.time()
+            result = await asyncio.to_thread(
+                state.call_domain_tool, name, **body
+            )
+        try:
+            parsed = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            parsed = {"success": True, "output": result}
+        store.update(
+            job_id,
+            status=JOB_STATUS_COMPLETED,
+            completed_at=time.time(),
+            result=parsed,
+        )
+        logger.info(
+            "[REST:%s] job %s (%s) completed", sid[:8], job_id[:8], name
+        )
+    except Exception as exc:
+        logger.exception("[REST:%s] job %s failed", sid[:8], job_id[:8])
+        store.update(
+            job_id,
+            status=JOB_STATUS_FAILED,
+            completed_at=time.time(),
+            error=f"{type(exc).__name__}: {exc}",
+        )
+    finally:
+        state._request_lock.release()
+
+
+async def rest_tool_job_status(request: Request) -> JSONResponse:
+    """``GET /session/{sid}/tool/jobs/{job_id}``
+
+    Returns the current status of an async tool job. The job_id must
+    belong to ``sid`` — a client cannot probe other sessions' jobs.
+
+    Deliberately does not require the session to still be in memory:
+    after a restart, sessions are gone but the JobStore still holds the
+    job record (possibly marked ``failed`` by ``mark_orphans_failed``),
+    and clients polling a stale job_id need to be able to see that
+    terminal state instead of a generic 404.
+    """
+    manager: BenchSessionManager = request.app.state.manager
+    sid = request.path_params["sid"]
+    job_id = request.path_params["job_id"]
+    job = manager._job_store.get(job_id)
+    if job is None or job.get("session_id") != sid:
+        return JSONResponse({"error": "Job not found"}, 404)
+    # Trim the echoed arguments — they can be large (full source files).
+    return JSONResponse(
+        {
+            "job_id": job["job_id"],
+            "tool_name": job["tool_name"],
+            "status": job["status"],
+            "created_at": job["created_at"],
+            "started_at": job["started_at"],
+            "completed_at": job["completed_at"],
+            "result": job["result"],
+            "error": job["error"],
+        }
+    )
 
 
 async def rest_send(request: Request) -> JSONResponse:
@@ -1171,6 +1309,13 @@ def create_app(
         Route("/session/{sid}", rest_session_status, methods=["GET", "DELETE"]),
         Route("/session/{sid}/start", rest_start, methods=["POST"]),
         Route("/session/{sid}/tools", rest_tools, methods=["GET"]),
+        # More-specific /tool/jobs/{job_id} must precede /tool/{name}
+        # or Starlette would bind "jobs" as the tool name.
+        Route(
+            "/session/{sid}/tool/jobs/{job_id}",
+            rest_tool_job_status,
+            methods=["GET"],
+        ),
         Route("/session/{sid}/tool/{name}", rest_tool_call, methods=["POST"]),
         Route("/session/{sid}/send", rest_send, methods=["POST"]),
         Route("/session/{sid}/evaluate", rest_evaluate, methods=["POST"]),

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -177,6 +177,32 @@ class BenchSessionManager:
                                     exc_info=True,
                                 )
                             state._destroy_container()
+                            # Notify Run layer so run status tracks the
+                            # force-completion. Swallow ValueError from
+                            # mark_completed guards (e.g. run was cancelled
+                            # between the deadline check and here).
+                            if state.run_id:
+                                result_dir = (
+                                    str(state._result_dir)
+                                    if getattr(state, "_result_dir", None)
+                                    else None
+                                )
+                                try:
+                                    self._run_service.mark_completed(
+                                        state.run_id, result_dir
+                                    )
+                                except ValueError as exc:
+                                    logger.info(
+                                        "Run %s mark_completed skipped in sweep: %s",
+                                        state.run_id,
+                                        exc,
+                                    )
+                                except Exception:
+                                    logger.warning(
+                                        "Run %s mark_completed failed in sweep",
+                                        state.run_id,
+                                        exc_info=True,
+                                    )
 
                     elif (
                         state.phase == SessionPhase.COMPLETED

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -15,6 +15,9 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
+import shutil
+import subprocess
 import time
 from pathlib import Path
 from typing import AsyncIterator
@@ -34,6 +37,7 @@ from server.run import RunService, RunStore, TaskCatalog
 from server.run.models import RunStatus
 from server.web.ui_app import extract_bearer_token, resolve_run_from_token, ui_routes
 
+from .limits import HEAVY_TOOLS, backtest_sem
 from .protocol import (
     TOOL_ENDPOINT_BLOCKED,
     SessionPhase,
@@ -726,6 +730,80 @@ class BenchSessionManager:
 # ---------------------------------------------------------------------------
 
 
+_HEALTH_DISK_MIN_GB = 5.0
+_HEALTH_LEAN_IMAGE_DEFAULT = "quant-tutor-env:v2.2-lean"
+
+
+def _health_check_docker() -> dict:
+    try:
+        proc = subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=3
+        )
+        return {"ok": proc.returncode == 0}
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
+
+def _health_check_lean_image() -> dict:
+    image = os.environ.get("QTB_LEAN_IMAGE", _HEALTH_LEAN_IMAGE_DEFAULT)
+    try:
+        proc = subprocess.run(
+            ["docker", "image", "inspect", image],
+            capture_output=True,
+            timeout=3,
+        )
+        return {"ok": proc.returncode == 0, "image": image}
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return {
+            "ok": False,
+            "image": image,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+
+def _health_check_disk() -> dict:
+    try:
+        usage = shutil.disk_usage("/home")
+        free_gb = usage.free / (1024**3)
+        return {
+            "ok": free_gb >= _HEALTH_DISK_MIN_GB,
+            "free_gb": round(free_gb, 2),
+            "percent_free": round(usage.free / usage.total * 100, 1),
+        }
+    except OSError as exc:
+        return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
+
+async def rest_health(request: Request) -> JSONResponse:
+    """``GET /health`` — deep liveness probe.
+
+    In Docker mode validates Docker daemon, LEAN backtest image, and disk
+    headroom. In no-docker mode only disk is checked so a supported local
+    deployment is not reported unhealthy for a missing Docker daemon.
+    Returns 200 when all applicable checks pass, 503 otherwise so uptime
+    monitors and the deploy smoke test can detect real outages.
+    """
+    manager: BenchSessionManager = request.app.state.manager
+    checks: dict[str, dict] = {}
+    if manager.use_docker:
+        docker, image, disk = await asyncio.gather(
+            asyncio.to_thread(_health_check_docker),
+            asyncio.to_thread(_health_check_lean_image),
+            asyncio.to_thread(_health_check_disk),
+        )
+        checks["docker"] = docker
+        checks["lean_image"] = image
+        checks["disk"] = disk
+    else:
+        checks["mode"] = {"ok": True, "docker": False}
+        checks["disk"] = await asyncio.to_thread(_health_check_disk)
+    ok = all(c.get("ok") for c in checks.values())
+    return JSONResponse(
+        {"status": "ok" if ok else "down", "checks": checks},
+        status_code=200 if ok else 503,
+    )
+
+
 async def rest_register(request: Request) -> JSONResponse:
     """``POST /session/register``
 
@@ -868,7 +946,11 @@ async def rest_tool_call(request: Request) -> JSONResponse:
     logger.debug("[REST:%s] tool_call: %s", sid[:8], name)
     state._last_activity = time.time()
     async with state._request_lock:
-        result = await asyncio.to_thread(state.call_domain_tool, name, **body)
+        if name in HEAVY_TOOLS:
+            async with backtest_sem():
+                result = await asyncio.to_thread(state.call_domain_tool, name, **body)
+        else:
+            result = await asyncio.to_thread(state.call_domain_tool, name, **body)
     result_preview = str(result)[:150]
     logger.debug("[REST:%s] %s -> %s...", sid[:8], name, result_preview)
     try:
@@ -1106,6 +1188,7 @@ def create_app(
 
     all_routes = [
         Route("/", serve_index, methods=["GET"]),
+        Route("/health", rest_health, methods=["GET"]),
         *ui_routes(manager),
         *rest_routes,
         Mount(

--- a/bench/server/api/limits.py
+++ b/bench/server/api/limits.py
@@ -1,0 +1,35 @@
+"""Shared concurrency limits for tool dispatch.
+
+Keeps resource-intensive tool invocations (LEAN backtests especially)
+bounded so a burst of concurrent callers cannot exhaust the single VPS.
+The semaphore is shared across REST and MCP dispatch paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+HEAVY_TOOLS: frozenset[str] = frozenset({"run_backtest", "run_lean_backtest"})
+
+_sem: asyncio.Semaphore | None = None
+
+
+def _max_concurrent() -> int:
+    # Read env on demand so values loaded by load_server_env() are honoured
+    # even when this module is imported before bootstrap.
+    return max(1, int(os.environ.get("QTB_MAX_CONCURRENT_BACKTESTS", "2")))
+
+
+def backtest_sem() -> asyncio.Semaphore:
+    """Return the process-wide backtest semaphore, creating it lazily."""
+    global _sem
+    if _sem is None:
+        _sem = asyncio.Semaphore(_max_concurrent())
+    return _sem
+
+
+def reset_for_tests() -> None:
+    """Drop the cached semaphore so a fresh one is created per event loop."""
+    global _sem
+    _sem = None

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -33,6 +33,7 @@ from mcp.types import TextContent, Tool
 if TYPE_CHECKING:
     from mcp.server import Server
 
+from .limits import HEAVY_TOOLS, backtest_sem
 from .protocol import (
     GET_BACKGROUND_TOOL,
     GET_RESULTS_TOOL,
@@ -920,7 +921,13 @@ class SessionState:
             return [TextContent(type="text", text=json.dumps(result))]
 
         # Domain tool — route through proxy
-        result = await asyncio.to_thread(self.call_domain_tool, name, **arguments)
+        if name in HEAVY_TOOLS:
+            async with backtest_sem():
+                result = await asyncio.to_thread(
+                    self.call_domain_tool, name, **arguments
+                )
+        else:
+            result = await asyncio.to_thread(self.call_domain_tool, name, **arguments)
         result_preview = str(result)[:150]
         logger.debug("[%s] %s -> %s...", self.session_id[:8], name, result_preview)
         return [TextContent(type="text", text=str(result))]

--- a/bench/server/run/__init__.py
+++ b/bench/server/run/__init__.py
@@ -4,6 +4,7 @@ Manages RunAssignments (who runs what) on top of SessionState (how it runs).
 """
 
 from .catalog import TaskCatalog, TaskEntry
+from .jobs import JobStore
 from .models import RunAssignment, RunStatus
 from .service import RunService
 from .store import RunStore
@@ -11,6 +12,7 @@ from .store import RunStore
 __all__ = [
     "TaskCatalog",
     "TaskEntry",
+    "JobStore",
     "RunAssignment",
     "RunStatus",
     "RunService",

--- a/bench/server/run/catalog.py
+++ b/bench/server/run/catalog.py
@@ -110,6 +110,14 @@ class TaskCatalog:
             key=lambda x: x["label"],
         )
 
+    def list_labels_only(self) -> list[dict]:
+        """Return labels only — used by Run/exam UI where category and
+        difficulty must not be revealed to the student before selection."""
+        return sorted(
+            [{"label": e.public_label} for e in self._entries.values()],
+            key=lambda x: x["label"],
+        )
+
     def __len__(self) -> int:
         return len(self._entries)
 

--- a/bench/server/run/jobs.py
+++ b/bench/server/run/jobs.py
@@ -1,0 +1,130 @@
+"""JobStore — JSON-file persistence for async tool invocations.
+
+Storage layout::
+
+    bench/results/jobs/{job_id}.json
+
+Used by the async job pattern (slice 2 of prod-availability work): heavy
+tools like ``run_lean_backtest`` return a ``job_id`` immediately so the
+client can poll ``GET /session/{sid}/tool/jobs/{job_id}`` instead of
+holding a 10-minute HTTP connection open.
+
+Thread-safe: all writes protected by an internal lock.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+JOB_STATUS_PENDING = "pending"
+JOB_STATUS_RUNNING = "running"
+JOB_STATUS_COMPLETED = "completed"
+JOB_STATUS_FAILED = "failed"
+
+_ACTIVE = {JOB_STATUS_PENDING, JOB_STATUS_RUNNING}
+
+
+class JobStore:
+    """Disk-backed store for async tool-call jobs."""
+
+    def __init__(self, jobs_dir: Path):
+        self._dir = Path(jobs_dir)
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+
+    def _path(self, job_id: str) -> Path:
+        return self._dir / f"{job_id}.json"
+
+    def create(
+        self, session_id: str, tool_name: str, arguments: dict | None = None
+    ) -> dict:
+        """Create a pending job record and return it."""
+        job = {
+            "job_id": uuid.uuid4().hex,
+            "session_id": session_id,
+            "tool_name": tool_name,
+            "arguments": arguments or {},
+            "status": JOB_STATUS_PENDING,
+            "created_at": time.time(),
+            "started_at": None,
+            "completed_at": None,
+            "result": None,
+            "error": None,
+        }
+        self._write(job)
+        return job
+
+    def update(self, job_id: str, **fields) -> Optional[dict]:
+        """Merge ``fields`` into the stored job record."""
+        with self._lock:
+            job = self._read(job_id)
+            if job is None:
+                return None
+            job.update(fields)
+            self._write_locked(job)
+            return job
+
+    def get(self, job_id: str) -> Optional[dict]:
+        with self._lock:
+            return self._read(job_id)
+
+    def mark_orphans_failed(self) -> int:
+        """Any pending/running jobs at startup lost their worker. Fail them.
+
+        Called once during server startup so clients polling a stale job_id
+        get a clean terminal state instead of waiting forever.
+        """
+        count = 0
+        with self._lock:
+            if not self._dir.is_dir():
+                return 0
+            for path in self._dir.glob("*.json"):
+                try:
+                    job = json.loads(path.read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError) as exc:
+                    logger.warning("JobStore: corrupt job file %s: %s", path.name, exc)
+                    continue
+                if job.get("status") in _ACTIVE:
+                    job["status"] = JOB_STATUS_FAILED
+                    job["error"] = "server restarted before job completed"
+                    job["completed_at"] = time.time()
+                    self._write_locked(job)
+                    count += 1
+        if count:
+            logger.info("JobStore: marked %d orphaned job(s) as failed", count)
+        return count
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _write(self, job: dict) -> None:
+        with self._lock:
+            self._write_locked(job)
+
+    def _write_locked(self, job: dict) -> None:
+        path = self._path(job["job_id"])
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(
+            json.dumps(job, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        tmp.replace(path)
+
+    def _read(self, job_id: str) -> Optional[dict]:
+        path = self._path(job_id)
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("JobStore: corrupt job %s: %s", job_id, exc)
+            return None

--- a/bench/server/run/models.py
+++ b/bench/server/run/models.py
@@ -32,10 +32,14 @@ class RunAssignment:
     task_id: str  # "D01_load_inspect_ohlcv" (internal)
     status: RunStatus
 
-    # Token
+    # Run token (for the external agent / client)
     token_hint: str = ""  # first 12 chars for logs
     token_hash: str = ""  # SHA-256 hex digest
     token_expires_at: str = ""  # ISO 8601, empty = no expiry
+
+    # Control token (for the browser owner — poll/live/cancel)
+    control_token_hint: str = ""
+    control_token_hash: str = ""
 
     # Binding (set after claim)
     client_info: Optional[dict] = None
@@ -66,10 +70,17 @@ class RunAssignment:
 
     @classmethod
     def from_dict(cls, d: dict) -> "RunAssignment":
-        """Deserialize from JSON storage."""
-        d = dict(d)  # shallow copy
-        d["status"] = RunStatus(d["status"])
-        return cls(**d)
+        """Deserialize from JSON storage.
+
+        Tolerates old run.json files that predate newer fields (e.g. the
+        ``control_token_*`` pair added in v6.0). Unknown keys are dropped.
+        """
+        import dataclasses
+
+        fields = {f.name for f in dataclasses.fields(cls)}
+        clean = {k: v for k, v in d.items() if k in fields}
+        clean["status"] = RunStatus(clean["status"])
+        return cls(**clean)
 
     def public_dict(self) -> dict:
         """Safe subset for UI/client responses. No token_hash, no task_id."""

--- a/bench/server/run/service.py
+++ b/bench/server/run/service.py
@@ -4,6 +4,7 @@ All REST handlers call this service. No HTTP/MCP concerns here.
 """
 
 import hashlib
+import hmac
 import logging
 import secrets
 from datetime import datetime, timedelta, timezone
@@ -48,10 +49,12 @@ class RunService:
         mode: str = "agent",
         persona_policy: str = "auto",
         token_ttl_minutes: int = 30,
-    ) -> tuple[RunAssignment, str]:
-        """Create a RunAssignment + generate token.
+    ) -> tuple[RunAssignment, str, str]:
+        """Create a RunAssignment + generate both tokens.
 
-        Returns (assignment, raw_token). raw_token is only available here.
+        Returns ``(assignment, raw_run_token, raw_control_token)``.
+        Neither raw token is persisted — only their SHA-256 hashes. Both
+        are surfaced once here and must be stored by the caller.
         """
         entry = self._catalog.resolve(task)
         if entry is None:
@@ -60,6 +63,10 @@ class RunService:
         raw_token = f"qtb_{secrets.token_urlsafe(24)}"
         token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
         token_hint = raw_token[:12]
+
+        raw_control_token = f"qtc_{secrets.token_urlsafe(24)}"
+        control_token_hash = hashlib.sha256(raw_control_token.encode()).hexdigest()
+        control_token_hint = raw_control_token[:12]
 
         now = _now_iso()
         expires_at = ""
@@ -76,18 +83,21 @@ class RunService:
             token_hint=token_hint,
             token_hash=token_hash,
             token_expires_at=expires_at,
+            control_token_hint=control_token_hint,
+            control_token_hash=control_token_hash,
             persona_policy=persona_policy,
             created_at=now,
             updated_at=now,
         )
         self._store.save(assignment)
         logger.info(
-            "Run created: %s task=%s token=%s...",
+            "Run created: %s task=%s token=%s... control=%s...",
             assignment.run_id,
             entry.public_label,
             token_hint,
+            control_token_hint,
         )
-        return assignment, raw_token
+        return assignment, raw_token, raw_control_token
 
     def create_and_claim(
         self,
@@ -95,12 +105,13 @@ class RunService:
         client_info: Optional[dict] = None,
         mode: str = "agent",
         persona_policy: str = "auto",
-    ) -> tuple[RunAssignment, str]:
+    ) -> tuple[RunAssignment, str, str]:
         """Create + immediately claim. For client-initiated runs.
 
-        Returns (assignment, raw_token) with status already CLAIMED.
+        Returns ``(assignment, raw_run_token, raw_control_token)`` with
+        status already CLAIMED.
         """
-        assignment, raw_token = self.create_run(
+        assignment, raw_token, raw_control_token = self.create_run(
             task=task, mode=mode, persona_policy=persona_policy
         )
         now = _now_iso()
@@ -110,7 +121,7 @@ class RunService:
         assignment.updated_at = now
         self._store.save(assignment)
         logger.info("Run auto-claimed: %s", assignment.run_id)
-        return assignment, raw_token
+        return assignment, raw_token, raw_control_token
 
     def claim_run(
         self,
@@ -123,7 +134,7 @@ class RunService:
         Thread-safe: RunStore.save uses internal lock.
         """
         token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
-        assignment = self._store.find_by_token_hash(token_hash)
+        assignment = self._store.find_by_token_hash(token_hash, token_type="run")
 
         if assignment is None:
             raise ValueError("Invalid token")
@@ -147,29 +158,63 @@ class RunService:
         return assignment
 
     def bind_session(self, run_id: str, session_id: str) -> RunAssignment:
-        """Bind a session to a run. CLAIMED -> ACTIVE."""
+        """Bind a session to a run. CLAIMED -> ACTIVE.
+
+        On store-level failure, rolls back to CLAIMED with no session bound so
+        the client can retry, then re-raises.
+        """
         assignment = self._get_or_raise(run_id)
         if assignment.status != RunStatus.CLAIMED:
             raise ValueError(
                 f"Run {run_id} is '{assignment.status.value}', expected 'claimed'"
             )
-        assignment.status = RunStatus.ACTIVE
-        assignment.session_id = session_id
-        assignment.updated_at = _now_iso()
-        self._store.save(assignment)
+        prev_status = assignment.status
+        prev_session_id = assignment.session_id
+        prev_updated_at = assignment.updated_at
+        try:
+            assignment.status = RunStatus.ACTIVE
+            assignment.session_id = session_id
+            assignment.updated_at = _now_iso()
+            self._store.save(assignment)
+        except Exception:
+            assignment.status = prev_status
+            assignment.session_id = prev_session_id
+            assignment.updated_at = prev_updated_at
+            try:
+                self._store.save(assignment)
+            except Exception:
+                logger.exception(
+                    "Run %s bind rollback failed to persist — in-memory state restored",
+                    run_id,
+                )
+            raise
         logger.info("Run active: %s session=%s", run_id, session_id[:8])
         return assignment
 
     def mark_completed(
         self, run_id: str, result_dir: Optional[str] = None
     ) -> RunAssignment:
-        """Session completed. ACTIVE -> COMPLETED."""
+        """Session completed. ACTIVE -> COMPLETED.
+
+        Idempotent if called again with the same ``result_dir`` on an already-
+        COMPLETED run. Rejects any other terminal state (FAILED/CANCELLED) and
+        any non-ACTIVE active state.
+        """
         assignment = self._get_or_raise(run_id)
+        if assignment.status in TERMINAL_STATUSES:
+            if (
+                assignment.status == RunStatus.COMPLETED
+                and assignment.result_dir == result_dir
+            ):
+                return assignment
+            raise ValueError(
+                f"Cannot complete run {run_id} in terminal state "
+                f"'{assignment.status.value}'"
+            )
         if assignment.status != RunStatus.ACTIVE:
-            logger.warning(
-                "mark_completed on %s in '%s' (expected active)",
-                run_id,
-                assignment.status.value,
+            raise ValueError(
+                f"Cannot complete run {run_id} in state "
+                f"'{assignment.status.value}' (expected 'active')"
             )
         now = _now_iso()
         assignment.status = RunStatus.COMPLETED
@@ -238,13 +283,29 @@ class RunService:
         return runs
 
     def resolve_token(self, raw_token: str) -> Optional[RunAssignment]:
-        """Find a run by raw token. Does NOT change state."""
+        """Find a run by raw run_token. Does NOT change state."""
         token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
-        assignment = self._store.find_by_token_hash(token_hash)
+        assignment = self._store.find_by_token_hash(token_hash, token_type="run")
         if assignment is None:
             return None
         if _token_expired(assignment.token_expires_at):
             return None
+        return assignment
+
+    def verify_control_token(
+        self, run_id: str, raw_control_token: str
+    ) -> RunAssignment:
+        """Return the assignment iff the control token matches.
+
+        Raises PermissionError on any mismatch or missing stored hash.
+        """
+        assignment = self._get_or_raise(run_id)
+        expected = assignment.control_token_hash
+        if not expected:
+            raise PermissionError("Run has no control token")
+        actual = hashlib.sha256(raw_control_token.encode()).hexdigest()
+        if not hmac.compare_digest(expected, actual):
+            raise PermissionError("Invalid control token")
         return assignment
 
     def _get_or_raise(self, run_id: str) -> RunAssignment:

--- a/bench/server/run/store.py
+++ b/bench/server/run/store.py
@@ -51,8 +51,20 @@ class RunStore:
             logger.warning("RunStore: corrupt run.json for %s: %s", run_id, exc)
             return None
 
-    def find_by_token_hash(self, token_hash: str) -> Optional[RunAssignment]:
-        """Find a run by token hash. Scans all run.json files."""
+    def find_by_token_hash(
+        self, token_hash: str, token_type: str = "run"
+    ) -> Optional[RunAssignment]:
+        """Find a run by token hash. Scans all run.json files.
+
+        ``token_type`` selects which stored hash to compare against:
+        ``"run"`` (default) → ``token_hash``; ``"control"`` →
+        ``control_token_hash``. A run_token will never match a
+        control_token_hash and vice versa.
+        """
+        if token_type not in ("run", "control"):
+            raise ValueError(f"Unknown token_type: {token_type}")
+        field = "token_hash" if token_type == "run" else "control_token_hash"
+
         if not self._runs_dir.is_dir():
             return None
         for run_dir in self._runs_dir.iterdir():
@@ -63,7 +75,8 @@ class RunStore:
                 continue
             try:
                 data = json.loads(path.read_text(encoding="utf-8"))
-                if data.get("token_hash") == token_hash:
+                stored = data.get(field)
+                if stored and stored == token_hash:
                     return RunAssignment.from_dict(data)
             except (json.JSONDecodeError, KeyError, TypeError):
                 continue

--- a/bench/server/web/static/js/run-agent.js
+++ b/bench/server/web/static/js/run-agent.js
@@ -17,6 +17,48 @@
   var _pollTimer = null;
   var _livePollTimer = null;
 
+  // ── Owner-token store ──
+  // Keyed by run_id so multiple tabs/runs can coexist. Persisted in
+  // sessionStorage under 'qtb_run_tokens' so a reload keeps monitoring.
+  var _TOKEN_STORAGE_KEY = 'qtb_run_tokens';
+
+  function _loadTokens() {
+    try {
+      var raw = sessionStorage.getItem(_TOKEN_STORAGE_KEY);
+      return raw ? JSON.parse(raw) : {};
+    } catch (e) { return {}; }
+  }
+
+  function _saveTokens(tokens) {
+    try {
+      sessionStorage.setItem(_TOKEN_STORAGE_KEY, JSON.stringify(tokens));
+    } catch (e) { /* quota/permission — ignore */ }
+  }
+
+  function _rememberControlToken(runId, controlToken) {
+    if (!runId || !controlToken) return;
+    var t = _loadTokens();
+    t[runId] = controlToken;
+    _saveTokens(t);
+  }
+
+  function _forgetControlToken(runId) {
+    if (!runId) return;
+    var t = _loadTokens();
+    if (runId in t) { delete t[runId]; _saveTokens(t); }
+  }
+
+  function _ownerFetch(url, options) {
+    options = options || {};
+    options.headers = options.headers || {};
+    var tokens = _loadTokens();
+    var tok = _runId ? tokens[_runId] : null;
+    if (tok) {
+      options.headers['Authorization'] = 'Bearer ' + tok;
+    }
+    return fetch(url, options);
+  }
+
   function escapeHtml(value) {
     return String(value == null ? '' : value)
       .replace(/&/g, '&amp;')
@@ -38,7 +80,7 @@
 
   function loadCatalog(callback) {
     if (_catalog) { callback(_catalog); return; }
-    fetch('/ui/tasks/catalog')
+    fetch('/ui/tasks/catalog/labels')
       .then(function (r) { return r.json(); })
       .then(function (data) {
         _catalog = data.tasks || [];
@@ -65,7 +107,7 @@
   function _renderCreatePage(app, tasks) {
     var taskOptions = tasks.map(function (t) {
       return '<option value="' + escapeHtml(t.label) + '">' +
-        escapeHtml(t.label) + ' (' + escapeHtml(t.category) + ')' +
+        escapeHtml(t.label) +
         '</option>';
     }).join('');
 
@@ -130,6 +172,9 @@
             return;
           }
           _runId = data.run_id;
+          if (data.control_token) {
+            _rememberControlToken(data.run_id, data.control_token);
+          }
           _renderMonitorPage(app, data);
         })
         .catch(function (err) {
@@ -224,7 +269,7 @@
       cancelBtn.addEventListener('click', function () {
         if (!_runId) return;
         cancelBtn.disabled = true;
-        fetch('/ui/runs/' + _runId + '/cancel', {method: 'POST'})
+        _ownerFetch('/ui/runs/' + _runId + '/cancel', {method: 'POST'})
           .then(function () {
             _cleanup();
             _updateStatus('cancelled');
@@ -243,9 +288,17 @@
     if (_pollTimer) clearInterval(_pollTimer);
     _pollTimer = setInterval(function () {
       if (!_runId) return;
-      fetch('/ui/runs/' + _runId)
-        .then(function (r) { return r.json(); })
+      _ownerFetch('/ui/runs/' + _runId)
+        .then(function (r) {
+          if (r.status === 401) {
+            _stopPolling();
+            _showTokenLostMessage();
+            return null;
+          }
+          return r.json();
+        })
         .then(function (data) {
+          if (data == null) return;
           _updateStatus(data.status);
           if (data.status === 'active') {
             _startLivePoll();
@@ -276,9 +329,17 @@
     if (_livePollTimer) clearInterval(_livePollTimer);
     _livePollTimer = setInterval(function () {
       if (!_runId) return;
-      fetch('/ui/runs/' + _runId + '/live')
-        .then(function (r) { return r.json(); })
+      _ownerFetch('/ui/runs/' + _runId + '/live')
+        .then(function (r) {
+          if (r.status === 401) {
+            _stopPolling();
+            _showTokenLostMessage();
+            return null;
+          }
+          return r.json();
+        })
         .then(function (data) {
+          if (data == null) return;
           _updateStatus(data.run_status);
           if (data.turn != null) {
             var turnPill = document.getElementById('myagent-turn-pill');
@@ -307,6 +368,22 @@
   function _stopPolling() {
     if (_pollTimer) { clearInterval(_pollTimer); _pollTimer = null; }
     if (_livePollTimer) { clearInterval(_livePollTimer); _livePollTimer = null; }
+  }
+
+  function _showTokenLostMessage() {
+    var pill = document.getElementById('myagent-status-pill');
+    if (pill) pill.textContent = '● Access expired';
+    var cancelBtn = document.getElementById('myagent-cancel-btn');
+    if (cancelBtn) cancelBtn.style.display = 'none';
+    var connectPanel = document.getElementById('myagent-connect-panel');
+    if (connectPanel) {
+      var msg = document.createElement('div');
+      msg.className = 'run-token-lost';
+      msg.textContent =
+        'Run access expired or token lost. Cannot resume monitoring. ' +
+        'Results will still appear under Results once the run completes.';
+      connectPanel.appendChild(msg);
+    }
   }
 
   function _updateStatus(status) {

--- a/bench/server/web/ui_app.py
+++ b/bench/server/web/ui_app.py
@@ -9,9 +9,11 @@ Provides:
 
 from __future__ import annotations
 
+import hmac
 import json
 import logging
 import math
+import os
 from dataclasses import asdict
 
 from starlette.requests import Request
@@ -40,6 +42,46 @@ def extract_bearer_token(request: Request) -> str | None:
 def resolve_run_from_token(run_service, raw_token: str):
     """Find RunAssignment by raw token. Returns None if invalid/expired."""
     return run_service.resolve_token(raw_token)
+
+
+def _authorize_control_token(
+    request: Request, run_service, run_id: str
+):
+    """Return the RunAssignment if the request carries a valid control token.
+
+    Returns a ``(JSONResponse, None)`` tuple for the error path and
+    ``(None, assignment)`` for the success path so callers can short-circuit
+    with a single check.
+    """
+    raw = extract_bearer_token(request)
+    if not raw:
+        return JSONResponse(
+            {"error": "Authorization: Bearer <control_token> required"}, 401
+        ), None
+    try:
+        assignment = run_service.verify_control_token(run_id, raw)
+    except PermissionError:
+        return JSONResponse({"error": "Invalid control token"}, 401), None
+    except ValueError:
+        return JSONResponse({"error": "Run not found"}, 404), None
+    return None, assignment
+
+
+def _authorize_admin_token(request: Request):
+    """Compare the bearer token against ``QTB_ADMIN_TOKEN``.
+
+    If the env var is unset we allow the request (local-dev convenience);
+    this lets existing test/CI flows keep working without setting the var.
+    """
+    expected = os.environ.get("QTB_ADMIN_TOKEN", "")
+    if not expected:
+        return None  # no enforcement
+    raw = extract_bearer_token(request) or ""
+    if not raw or not hmac.compare_digest(expected, raw):
+        return JSONResponse(
+            {"error": "Authorization: Bearer <admin_token> required"}, 401
+        )
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -136,12 +178,23 @@ def ui_routes(manager) -> list[Route]:
     # -----------------------------------------------------------------------
 
     async def task_catalog(request: Request) -> JSONResponse:
-        """Public task catalog — labels + category + difficulty only."""
+        """Public task catalog — labels + category + difficulty.
+
+        Used by Results UI. Do not wire this into the Run/exam UI.
+        """
         _ = request
         run_service = getattr(manager, "_run_service", None)
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
         return JSONResponse({"tasks": run_service.catalog.list_public()})
+
+    async def task_catalog_labels(request: Request) -> JSONResponse:
+        """Run/exam-mode catalog — labels only, no category or difficulty."""
+        _ = request
+        run_service = getattr(manager, "_run_service", None)
+        if run_service is None:
+            return JSONResponse({"error": "Run service not initialized"}, 503)
+        return JSONResponse({"tasks": run_service.catalog.list_labels_only()})
 
     # -----------------------------------------------------------------------
     # New: /ui/runs/*
@@ -167,7 +220,7 @@ def ui_routes(manager) -> list[Route]:
         token_ttl = body.get("token_ttl_minutes", 30)
 
         try:
-            assignment, raw_token = run_service.create_run(
+            assignment, raw_token, raw_control_token = run_service.create_run(
                 task=task,
                 mode=mode,
                 persona_policy=persona_policy,
@@ -186,6 +239,7 @@ def ui_routes(manager) -> list[Route]:
                 "status": assignment.status.value,
                 "public_task_label": assignment.public_task_label,
                 "token": raw_token,
+                "control_token": raw_control_token,
                 "token_expires_at": assignment.token_expires_at,
                 "mcp_url": mcp_url,
                 "launch_command": (
@@ -197,10 +251,18 @@ def ui_routes(manager) -> list[Route]:
         )
 
     async def list_runs(request: Request) -> JSONResponse:
-        """``GET /ui/runs`` — list runs with optional filters."""
+        """``GET /ui/runs`` — list runs with optional filters.
+
+        Requires ``Authorization: Bearer <admin_token>`` when
+        ``QTB_ADMIN_TOKEN`` is set; otherwise allowed (local dev).
+        """
         run_service = getattr(manager, "_run_service", None)
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
+
+        err = _authorize_admin_token(request)
+        if err is not None:
+            return err
 
         status = request.query_params.get("status")
         task = request.query_params.get("task")
@@ -208,15 +270,15 @@ def ui_routes(manager) -> list[Route]:
         return JSONResponse({"runs": [r.public_dict() for r in runs]})
 
     async def get_run(request: Request) -> JSONResponse:
-        """``GET /ui/runs/{run_id}`` — query run status."""
+        """``GET /ui/runs/{run_id}`` — query run status. Owner-only."""
         run_service = getattr(manager, "_run_service", None)
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
 
         run_id = request.path_params["run_id"]
-        run = run_service.get_run(run_id)
-        if run is None:
-            return JSONResponse({"error": "Run not found"}, 404)
+        err, run = _authorize_control_token(request, run_service, run_id)
+        if err is not None:
+            return err
         return JSONResponse(run.public_dict())
 
     async def get_run_live(request: Request) -> JSONResponse:
@@ -226,9 +288,9 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse({"error": "Run service not initialized"}, 503)
 
         run_id = request.path_params["run_id"]
-        run = run_service.get_run(run_id)
-        if run is None:
-            return JSONResponse({"error": "Run not found"}, 404)
+        err, run = _authorize_control_token(request, run_service, run_id)
+        if err is not None:
+            return err
 
         # Terminal or pre-active states
         if run.status.value in (
@@ -291,8 +353,15 @@ def ui_routes(manager) -> list[Route]:
         )
 
     async def cancel_run(request: Request) -> JSONResponse:
-        """``POST /ui/runs/{run_id}/cancel`` — cancel at any non-terminal state."""
+        """``POST /ui/runs/{run_id}/cancel`` — owner-only cancel."""
+        run_service = getattr(manager, "_run_service", None)
+        if run_service is None:
+            return JSONResponse({"error": "Run service not initialized"}, 503)
+
         run_id = request.path_params["run_id"]
+        err, _ = _authorize_control_token(request, run_service, run_id)
+        if err is not None:
+            return err
         try:
             await manager.cancel_run(run_id)
         except ValueError as exc:
@@ -301,7 +370,7 @@ def ui_routes(manager) -> list[Route]:
             logger.error("cancel_run %s failed: %s", run_id, exc, exc_info=True)
             return JSONResponse({"error": f"Cancel failed: {exc}"}, 500)
 
-        run = manager._run_service.get_run(run_id)
+        run = run_service.get_run(run_id)
         return JSONResponse(run.public_dict() if run else {"status": "cancelled"})
 
     # -----------------------------------------------------------------------
@@ -360,7 +429,7 @@ def ui_routes(manager) -> list[Route]:
         client_info = body.get("client")
 
         try:
-            assignment, raw_token = run_service.create_and_claim(
+            assignment, raw_token, raw_control_token = run_service.create_and_claim(
                 task=task, client_info=client_info, mode=mode
             )
         except ValueError as exc:
@@ -372,6 +441,7 @@ def ui_routes(manager) -> list[Route]:
             {
                 "run_id": assignment.run_id,
                 "token": raw_token,
+                "control_token": raw_control_token,
                 "mcp_url": f"{base_url}/mcp",
                 "public_task_label": assignment.public_task_label,
                 "status": assignment.status.value,
@@ -427,6 +497,7 @@ def ui_routes(manager) -> list[Route]:
         Route("/ui/results/{session_id}/files/{path:path}", get_file, methods=["GET"]),
         # New: public task catalog
         Route("/ui/tasks/catalog", task_catalog, methods=["GET"]),
+        Route("/ui/tasks/catalog/labels", task_catalog_labels, methods=["GET"]),
         # New: Run management (UI)
         Route("/ui/runs", create_run, methods=["POST"]),
         Route("/ui/runs", list_runs, methods=["GET"]),

--- a/bench/tests/conftest.py
+++ b/bench/tests/conftest.py
@@ -73,10 +73,32 @@ if "mcp" not in sys.modules:
     _mcp_streamable.StreamableHTTPServerTransport = _StreamableHTTPServerTransport
     _mcp_server.streamable_http = _mcp_streamable
 
+    # Stub mcp.client.* so client.transports package can import without
+    # the real SDK present (e.g. REST transport unit tests).
+    _mcp_client = types.ModuleType("mcp.client")
+    _mcp_client_session = types.ModuleType("mcp.client.session")
+    _mcp_client_streamable = types.ModuleType("mcp.client.streamable_http")
+
+    class _ClientSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    async def _streamablehttp_client(*args, **kwargs):  # pragma: no cover
+        raise RuntimeError("mcp.client stubbed — real SDK not installed")
+
+    _mcp_client_session.ClientSession = _ClientSession
+    _mcp_client_streamable.streamablehttp_client = _streamablehttp_client
+    _mcp_client.session = _mcp_client_session
+    _mcp_client.streamable_http = _mcp_client_streamable
+    _mcp.client = _mcp_client
+
     sys.modules["mcp"] = _mcp
     sys.modules["mcp.types"] = _mcp_types
     sys.modules["mcp.server"] = _mcp_server
     sys.modules["mcp.server.streamable_http"] = _mcp_streamable
+    sys.modules["mcp.client"] = _mcp_client
+    sys.modules["mcp.client.session"] = _mcp_client_session
+    sys.modules["mcp.client.streamable_http"] = _mcp_client_streamable
 
 # Ensure bench/ is on sys.path so ``import server.*`` works.
 _BENCH_ROOT = Path(__file__).resolve().parents[1]

--- a/bench/tests/test_health.py
+++ b/bench/tests/test_health.py
@@ -1,0 +1,196 @@
+"""Tests for /health endpoint and backtest concurrency cap."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from unittest.mock import patch
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.api import limits
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    # Docker mode: the /health endpoint runs its full check matrix.
+    app._manager.use_docker = True
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def client_no_docker(app):
+    # Local dev mode: Docker probes are skipped.
+    app._manager.use_docker = False
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _reset_backtest_sem():
+    """Drop the cached semaphore so each test starts with a fresh one
+    bound to the current event loop."""
+    limits.reset_for_tests()
+    yield
+    limits.reset_for_tests()
+
+
+def _fake_proc(returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=b"", stderr=b"")
+
+
+class TestHealth:
+    @pytest.mark.asyncio
+    async def test_ok_when_all_checks_pass(self, client):
+        with (
+            patch("server.api.http_app.subprocess.run", return_value=_fake_proc(0)),
+            patch(
+                "server.api.http_app.shutil.disk_usage",
+                return_value=type("Usage", (), {"total": 100 * 1024**3, "used": 10 * 1024**3, "free": 90 * 1024**3})(),
+            ),
+        ):
+            resp = await client.get("/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert body["checks"]["docker"]["ok"] is True
+        assert body["checks"]["lean_image"]["ok"] is True
+        assert body["checks"]["disk"]["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_down_when_docker_missing(self, client):
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[0] == "docker":
+                raise FileNotFoundError("docker not found")
+            return _fake_proc(0)
+
+        with (
+            patch("server.api.http_app.subprocess.run", side_effect=fake_run),
+            patch(
+                "server.api.http_app.shutil.disk_usage",
+                return_value=type("Usage", (), {"total": 100 * 1024**3, "used": 10 * 1024**3, "free": 90 * 1024**3})(),
+            ),
+        ):
+            resp = await client.get("/health")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["status"] == "down"
+        assert body["checks"]["docker"]["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_down_when_lean_image_missing(self, client):
+        def fake_run(cmd, *args, **kwargs):
+            # docker info OK, image inspect fails
+            if len(cmd) >= 3 and cmd[1] == "image":
+                return _fake_proc(1)
+            return _fake_proc(0)
+
+        with (
+            patch("server.api.http_app.subprocess.run", side_effect=fake_run),
+            patch(
+                "server.api.http_app.shutil.disk_usage",
+                return_value=type("Usage", (), {"total": 100 * 1024**3, "used": 10 * 1024**3, "free": 90 * 1024**3})(),
+            ),
+        ):
+            resp = await client.get("/health")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["checks"]["docker"]["ok"] is True
+        assert body["checks"]["lean_image"]["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_down_when_disk_low(self, client):
+        with (
+            patch("server.api.http_app.subprocess.run", return_value=_fake_proc(0)),
+            patch(
+                "server.api.http_app.shutil.disk_usage",
+                return_value=type("Usage", (), {"total": 100 * 1024**3, "used": 98 * 1024**3, "free": 2 * 1024**3})(),
+            ),
+        ):
+            resp = await client.get("/health")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["checks"]["disk"]["ok"] is False
+        assert body["checks"]["disk"]["free_gb"] < 5.0
+
+    @pytest.mark.asyncio
+    async def test_health_does_not_require_auth(self, client):
+        # No Authorization header; should still respond.
+        with (
+            patch("server.api.http_app.subprocess.run", return_value=_fake_proc(0)),
+            patch(
+                "server.api.http_app.shutil.disk_usage",
+                return_value=type("Usage", (), {"total": 100 * 1024**3, "used": 10 * 1024**3, "free": 90 * 1024**3})(),
+            ),
+        ):
+            resp = await client.get("/health")
+        assert resp.status_code in (200, 503)
+
+    @pytest.mark.asyncio
+    async def test_no_docker_mode_skips_docker_probes(self, client_no_docker):
+        # In --no-docker mode the endpoint should not fail just because
+        # Docker is missing; only disk is checked.
+        with (
+            patch(
+                "server.api.http_app.subprocess.run",
+                side_effect=FileNotFoundError("docker not found"),
+            ),
+            patch(
+                "server.api.http_app.shutil.disk_usage",
+                return_value=type("Usage", (), {"total": 100 * 1024**3, "used": 10 * 1024**3, "free": 90 * 1024**3})(),
+            ),
+        ):
+            resp = await client_no_docker.get("/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert "docker" not in body["checks"]
+        assert "lean_image" not in body["checks"]
+        assert body["checks"]["disk"]["ok"] is True
+
+
+class TestBacktestSemaphore:
+    @pytest.mark.asyncio
+    async def test_semaphore_is_lazy_and_shared(self):
+        sem1 = limits.backtest_sem()
+        sem2 = limits.backtest_sem()
+        assert sem1 is sem2
+
+    @pytest.mark.asyncio
+    async def test_semaphore_caps_concurrency(self, monkeypatch):
+        # Env var set AFTER module import (mirrors load_server_env order)
+        # must still be honoured because backtest_sem() reads it lazily.
+        monkeypatch.setenv("QTB_MAX_CONCURRENT_BACKTESTS", "2")
+        sem = limits.backtest_sem()
+
+        in_flight = 0
+        peak = 0
+
+        async def fake_backtest():
+            nonlocal in_flight, peak
+            async with sem:
+                in_flight += 1
+                peak = max(peak, in_flight)
+                await asyncio.sleep(0.05)
+                in_flight -= 1
+
+        await asyncio.gather(*(fake_backtest() for _ in range(5)))
+        assert peak == 2, f"expected at most 2 concurrent, saw {peak}"
+
+    def test_max_concurrent_reads_env_lazily(self, monkeypatch):
+        monkeypatch.setenv("QTB_MAX_CONCURRENT_BACKTESTS", "7")
+        assert limits._max_concurrent() == 7
+        monkeypatch.setenv("QTB_MAX_CONCURRENT_BACKTESTS", "0")
+        # Floor of 1 to keep the semaphore usable.
+        assert limits._max_concurrent() == 1
+
+    def test_heavy_tools_set_includes_known_backtest_tools(self):
+        assert "run_lean_backtest" in limits.HEAVY_TOOLS
+        assert "run_backtest" in limits.HEAVY_TOOLS

--- a/bench/tests/test_rest_transport_jobs.py
+++ b/bench/tests/test_rest_transport_jobs.py
@@ -1,0 +1,105 @@
+"""Client-side test for the REST transport's async job polling path."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from client.transports import rest_transport
+from client.transports.rest_transport import RESTTransport
+
+
+@pytest.mark.asyncio
+async def test_call_tool_polls_job_until_complete(monkeypatch):
+    # Keep the test fast regardless of the production poll interval.
+    monkeypatch.setattr(rest_transport, "_JOB_POLL_INTERVAL_S", 0.01)
+
+    calls = {"poll_count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/tool/run_lean_backtest") and request.method == "POST":
+            return httpx.Response(
+                202,
+                json={
+                    "job_id": "job-abc",
+                    "status": "pending",
+                    "poll_url": "/session/s1/tool/jobs/job-abc",
+                },
+            )
+        if request.url.path.endswith("/tool/jobs/job-abc"):
+            calls["poll_count"] += 1
+            if calls["poll_count"] < 3:
+                return httpx.Response(200, json={"status": "running"})
+            return httpx.Response(
+                200,
+                json={
+                    "status": "completed",
+                    "result": {"sharpe": 1.23, "trades": 85},
+                },
+            )
+        return httpx.Response(404)
+
+    transport = RESTTransport()
+    transport._base_url = "http://test"
+    transport._session_id = "s1"
+    transport._client = httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(handler)
+    )
+    try:
+        raw = await transport.call_tool("run_lean_backtest", {"path": "x.cs"})
+    finally:
+        await transport._client.aclose()
+
+    payload = json.loads(raw)
+    assert payload == {"sharpe": 1.23, "trades": 85}
+    assert calls["poll_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_call_tool_surfaces_job_failure(monkeypatch):
+    monkeypatch.setattr(rest_transport, "_JOB_POLL_INTERVAL_S", 0.01)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(
+                202, json={"job_id": "job-fail", "status": "pending"}
+            )
+        return httpx.Response(
+            200,
+            json={"status": "failed", "error": "RuntimeError: boom"},
+        )
+
+    transport = RESTTransport()
+    transport._base_url = "http://test"
+    transport._session_id = "s1"
+    transport._client = httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(handler)
+    )
+    try:
+        raw = await transport.call_tool("run_backtest", {})
+    finally:
+        await transport._client.aclose()
+    payload = json.loads(raw)
+    assert "boom" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_call_tool_sync_200_passthrough():
+    # Non-heavy tools still return 200 directly; no polling.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ok": True, "sync": True})
+
+    transport = RESTTransport()
+    transport._base_url = "http://test"
+    transport._session_id = "s1"
+    transport._client = httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(handler)
+    )
+    try:
+        raw = await transport.call_tool("shell_exec", {"command": "echo"})
+    finally:
+        await transport._client.aclose()
+    payload = json.loads(raw)
+    assert payload == {"ok": True, "sync": True}

--- a/bench/tests/test_run_catalog.py
+++ b/bench/tests/test_run_catalog.py
@@ -1,0 +1,53 @@
+"""Tests for TaskCatalog list_public vs list_labels_only."""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from server.run.catalog import TaskCatalog
+
+
+def _write_task(root: Path, task_id: str, category: str, difficulty: str) -> None:
+    path = root / "tasks" / "layer2" / category / f"{task_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "task_id": task_id,
+                "category": category,
+                "difficulty": difficulty,
+                "description": "demo",
+                "persona_ids": ["dev"],
+                "max_turns": 4,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class TaskCatalogTests(unittest.TestCase):
+    def test_labels_only_hides_category_and_difficulty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_task(root, "D01_demo_one", "data_analysis", "easy")
+            _write_task(root, "I02_demo_two", "implementation", "hard")
+
+            cat = TaskCatalog(root)
+
+            public = cat.list_public()
+            self.assertEqual(
+                {"label", "category", "difficulty"}, set(public[0].keys())
+            )
+
+            labels = cat.list_labels_only()
+            self.assertEqual([{"label": "D01"}, {"label": "I02"}], labels)
+            for row in labels:
+                self.assertEqual({"label"}, set(row.keys()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/tests/test_run_control_token.py
+++ b/bench/tests/test_run_control_token.py
@@ -1,0 +1,150 @@
+"""Tests for Step 4: control_token auth on /ui/runs/* endpoints."""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from server.run.catalog import TaskCatalog
+from server.run.service import RunService
+from server.run.store import RunStore
+from server.web.ui_app import ui_routes
+
+
+def _write_task(root: Path) -> None:
+    (root / "tasks" / "layer2" / "data").mkdir(parents=True, exist_ok=True)
+    (root / "tasks" / "layer2" / "data" / "D01_demo.json").write_text(
+        json.dumps(
+            {
+                "task_id": "D01_demo",
+                "category": "data",
+                "difficulty": "easy",
+                "description": "d",
+                "persona_ids": ["p"],
+                "max_turns": 4,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class _StubManager:
+    def __init__(self, root: Path):
+        self.bench_root = root
+        self._run_service = RunService(TaskCatalog(root), RunStore(root / "runs"))
+
+    def get_session(self, _sid):
+        return None
+
+    async def cancel_run(self, run_id):
+        self._run_service.cancel_run(run_id)
+
+
+def _build_client(root: Path) -> tuple[TestClient, _StubManager]:
+    manager = _StubManager(root)
+    app = Starlette(routes=ui_routes(manager))
+    return TestClient(app), manager
+
+
+class ControlTokenTests(unittest.TestCase):
+    def test_create_run_returns_control_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            client, _ = _build_client(Path(tmp))
+            r = client.post("/ui/runs", json={"task": "D01"})
+            self.assertEqual(r.status_code, 200)
+            body = r.json()
+            self.assertIn("control_token", body)
+            self.assertTrue(body["control_token"].startswith("qtc_"))
+            self.assertTrue(body["token"].startswith("qtb_"))
+
+    def test_get_run_without_control_token_returns_401(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            client, _ = _build_client(Path(tmp))
+            body = client.post("/ui/runs", json={"task": "D01"}).json()
+            r = client.get(f"/ui/runs/{body['run_id']}")
+            self.assertEqual(r.status_code, 401)
+
+    def test_get_run_with_wrong_control_token_returns_401(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            client, _ = _build_client(Path(tmp))
+            body = client.post("/ui/runs", json={"task": "D01"}).json()
+            r = client.get(
+                f"/ui/runs/{body['run_id']}",
+                headers={"Authorization": "Bearer qtc_not_real"},
+            )
+            self.assertEqual(r.status_code, 401)
+
+    def test_get_run_with_correct_control_token_succeeds(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            client, _ = _build_client(Path(tmp))
+            body = client.post("/ui/runs", json={"task": "D01"}).json()
+            r = client.get(
+                f"/ui/runs/{body['run_id']}",
+                headers={"Authorization": f"Bearer {body['control_token']}"},
+            )
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()["run_id"], body["run_id"])
+
+    def test_run_token_does_not_authorize_control_endpoint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            client, _ = _build_client(Path(tmp))
+            body = client.post("/ui/runs", json={"task": "D01"}).json()
+            # Use the run_token (qtb_) against a control endpoint — must fail.
+            r = client.get(
+                f"/ui/runs/{body['run_id']}",
+                headers={"Authorization": f"Bearer {body['token']}"},
+            )
+            self.assertEqual(r.status_code, 401)
+
+    def test_cancel_requires_control_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            client, _ = _build_client(Path(tmp))
+            body = client.post("/ui/runs", json={"task": "D01"}).json()
+            r = client.post(f"/ui/runs/{body['run_id']}/cancel")
+            self.assertEqual(r.status_code, 401)
+            r = client.post(
+                f"/ui/runs/{body['run_id']}/cancel",
+                headers={"Authorization": f"Bearer {body['control_token']}"},
+            )
+            self.assertEqual(r.status_code, 200)
+
+    def test_store_find_by_token_hash_distinguishes_types(self):
+        import hashlib
+
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            _, manager = _build_client(Path(tmp))
+            svc = manager._run_service
+            a, run_tok, ctrl_tok = svc.create_run("D01")
+
+            h_run = hashlib.sha256(run_tok.encode()).hexdigest()
+            h_ctrl = hashlib.sha256(ctrl_tok.encode()).hexdigest()
+
+            self.assertIsNotNone(
+                svc._store.find_by_token_hash(h_run, token_type="run")
+            )
+            self.assertIsNone(
+                svc._store.find_by_token_hash(h_run, token_type="control")
+            )
+            self.assertIsNotNone(
+                svc._store.find_by_token_hash(h_ctrl, token_type="control")
+            )
+            self.assertIsNone(
+                svc._store.find_by_token_hash(h_ctrl, token_type="run")
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/tests/test_run_state_transitions.py
+++ b/bench/tests/test_run_state_transitions.py
@@ -1,0 +1,129 @@
+"""Tests for RunService state-transition guards (Step 3 of v6.0 plan)."""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from server.run.catalog import TaskCatalog
+from server.run.models import RunStatus
+from server.run.service import RunService
+from server.run.store import RunStore
+
+
+def _make_service(tmp: Path) -> RunService:
+    (tmp / "tasks" / "layer2" / "data").mkdir(parents=True, exist_ok=True)
+    (tmp / "tasks" / "layer2" / "data" / "D01_demo.json").write_text(
+        json.dumps(
+            {
+                "task_id": "D01_demo",
+                "category": "data",
+                "difficulty": "easy",
+                "description": "d",
+                "persona_ids": ["p"],
+                "max_turns": 4,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return RunService(TaskCatalog(tmp), RunStore(tmp / "runs"))
+
+
+class MarkCompletedGuardTests(unittest.TestCase):
+    def test_rejects_cancelled_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.cancel_run(a.run_id)
+            with self.assertRaises(ValueError):
+                svc.mark_completed(a.run_id, "/tmp/results")
+
+    def test_rejects_failed_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.mark_failed(a.run_id, "boom")
+            with self.assertRaises(ValueError):
+                svc.mark_completed(a.run_id, "/tmp/r")
+
+    def test_rejects_non_active_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")  # CLAIMED, not ACTIVE
+            with self.assertRaises(ValueError):
+                svc.mark_completed(a.run_id, "/tmp/r")
+
+    def test_idempotent_same_result_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.mark_completed(a.run_id, "/tmp/r")
+            again = svc.mark_completed(a.run_id, "/tmp/r")
+            self.assertEqual(again.status, RunStatus.COMPLETED)
+
+    def test_idempotent_rejects_different_result_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.mark_completed(a.run_id, "/tmp/r1")
+            with self.assertRaises(ValueError):
+                svc.mark_completed(a.run_id, "/tmp/r2")
+
+
+class CancelGuardTests(unittest.TestCase):
+    def test_cancel_rejects_completed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.mark_completed(a.run_id, "/tmp/r")
+            with self.assertRaises(ValueError):
+                svc.cancel_run(a.run_id)
+
+    def test_cancel_rejects_failed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.mark_failed(a.run_id, "x")
+            with self.assertRaises(ValueError):
+                svc.cancel_run(a.run_id)
+
+
+class BindSessionRollbackTests(unittest.TestCase):
+    def test_rollback_on_store_error_leaves_run_claimed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+
+            original_save = svc._store.save
+            calls = {"n": 0}
+
+            def flaky_save(x):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise OSError("disk full")
+                return original_save(x)
+
+            svc._store.save = flaky_save  # type: ignore[assignment]
+            with self.assertRaises(OSError):
+                svc.bind_session(a.run_id, "sess")
+
+            # Rollback write happened (call 2 was the rollback save)
+            self.assertGreaterEqual(calls["n"], 2)
+            svc._store.save = original_save  # type: ignore[assignment]
+            fresh = svc.get_run(a.run_id)
+            self.assertEqual(fresh.status, RunStatus.CLAIMED)
+            self.assertIsNone(fresh.session_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/tests/test_tool_jobs.py
+++ b/bench/tests/test_tool_jobs.py
@@ -1,0 +1,303 @@
+"""Tests for async tool-job dispatch (heavy-tool 202 path + polling)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.api import limits
+from server.run.jobs import (
+    JOB_STATUS_COMPLETED,
+    JOB_STATUS_FAILED,
+    JOB_STATUS_PENDING,
+    JOB_STATUS_RUNNING,
+    JobStore,
+)
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _reset_backtest_sem():
+    limits.reset_for_tests()
+    yield
+    limits.reset_for_tests()
+
+
+async def _register_session(client: httpx.AsyncClient) -> str:
+    from tests.helpers import register_session
+
+    return await register_session(client)
+
+
+# ---------------------------------------------------------------------------
+# JobStore unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestJobStore:
+    def test_create_returns_pending_job(self, tmp_path):
+        store = JobStore(tmp_path / "jobs")
+        job = store.create("sess-1", "run_lean_backtest", {"path": "x.cs"})
+        assert job["status"] == JOB_STATUS_PENDING
+        assert job["session_id"] == "sess-1"
+        assert job["tool_name"] == "run_lean_backtest"
+        assert job["arguments"] == {"path": "x.cs"}
+        assert (tmp_path / "jobs" / f"{job['job_id']}.json").exists()
+
+    def test_update_merges_fields(self, tmp_path):
+        store = JobStore(tmp_path / "jobs")
+        job = store.create("sess-1", "run_backtest")
+        updated = store.update(
+            job["job_id"], status=JOB_STATUS_COMPLETED, result={"ok": True}
+        )
+        assert updated["status"] == JOB_STATUS_COMPLETED
+        assert updated["result"] == {"ok": True}
+        # Persisted
+        reread = store.get(job["job_id"])
+        assert reread["status"] == JOB_STATUS_COMPLETED
+
+    def test_get_missing_returns_none(self, tmp_path):
+        store = JobStore(tmp_path / "jobs")
+        assert store.get("nope") is None
+
+    def test_mark_orphans_failed(self, tmp_path):
+        store = JobStore(tmp_path / "jobs")
+        j1 = store.create("sess", "run_backtest")
+        j2 = store.create("sess", "run_backtest")
+        j3 = store.create("sess", "run_backtest")
+        store.update(j2["job_id"], status=JOB_STATUS_RUNNING)
+        store.update(j3["job_id"], status=JOB_STATUS_COMPLETED, result={"ok": True})
+
+        failed = store.mark_orphans_failed()
+        assert failed == 2  # j1 pending + j2 running
+
+        assert store.get(j1["job_id"])["status"] == JOB_STATUS_FAILED
+        assert store.get(j2["job_id"])["status"] == JOB_STATUS_FAILED
+        # Terminal states untouched.
+        assert store.get(j3["job_id"])["status"] == JOB_STATUS_COMPLETED
+        assert "restarted" in store.get(j1["job_id"])["error"]
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestHeavyToolDispatch:
+    @pytest.mark.asyncio
+    async def test_heavy_tool_returns_202_with_job_id(self, client, monkeypatch):
+        sid = await _register_session(client)
+
+        # Replace call_domain_tool with a fast fake so the whole flow can
+        # complete in-process without touching Docker.
+        manager = client._transport.app._manager
+
+        def fake_tool(name, **kwargs):
+            return json.dumps({"ok": True, "tool": name, "args": kwargs})
+
+        state = manager.get_session(sid)
+        monkeypatch.setattr(state, "call_domain_tool", fake_tool)
+
+        # Start the session so the tool-call permission check passes.
+        await client.post(f"/session/{sid}/start", json={})
+
+        resp = await client.post(
+            f"/session/{sid}/tool/run_lean_backtest",
+            json={"algorithm_path": "x.cs"},
+        )
+        assert resp.status_code == 202, resp.text
+        body = resp.json()
+        assert body["status"] == JOB_STATUS_PENDING
+        assert "job_id" in body
+        assert body["poll_url"].endswith(f"/tool/jobs/{body['job_id']}")
+
+        # Poll until completion.
+        job_id = body["job_id"]
+        for _ in range(50):
+            poll = await client.get(f"/session/{sid}/tool/jobs/{job_id}")
+            assert poll.status_code == 200
+            data = poll.json()
+            if data["status"] == JOB_STATUS_COMPLETED:
+                assert data["result"]["ok"] is True
+                assert data["result"]["tool"] == "run_lean_backtest"
+                return
+            if data["status"] == JOB_STATUS_FAILED:
+                pytest.fail(f"Job unexpectedly failed: {data['error']}")
+            await asyncio.sleep(0.05)
+        pytest.fail("Job never reached terminal state")
+
+    @pytest.mark.asyncio
+    async def test_heavy_tool_job_captures_exception(self, client, monkeypatch):
+        sid = await _register_session(client)
+        manager = client._transport.app._manager
+        state = manager.get_session(sid)
+
+        def exploding_tool(name, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(state, "call_domain_tool", exploding_tool)
+        await client.post(f"/session/{sid}/start", json={})
+
+        resp = await client.post(
+            f"/session/{sid}/tool/run_lean_backtest", json={}
+        )
+        assert resp.status_code == 202
+        job_id = resp.json()["job_id"]
+
+        for _ in range(50):
+            poll = await client.get(f"/session/{sid}/tool/jobs/{job_id}")
+            data = poll.json()
+            if data["status"] == JOB_STATUS_FAILED:
+                assert "boom" in data["error"]
+                return
+            if data["status"] == JOB_STATUS_COMPLETED:
+                pytest.fail("Job unexpectedly completed")
+            await asyncio.sleep(0.05)
+        pytest.fail("Job never reached terminal state")
+
+    @pytest.mark.asyncio
+    async def test_job_lookup_rejects_wrong_session(self, client, monkeypatch):
+        sid_a = await _register_session(client)
+        manager = client._transport.app._manager
+        state_a = manager.get_session(sid_a)
+        monkeypatch.setattr(
+            state_a,
+            "call_domain_tool",
+            lambda name, **kw: json.dumps({"ok": True}),
+        )
+        await client.post(f"/session/{sid_a}/start", json={})
+
+        resp = await client.post(
+            f"/session/{sid_a}/tool/run_lean_backtest", json={}
+        )
+        job_id = resp.json()["job_id"]
+
+        # Different session asking about A's job must 404.
+        sid_b = await _register_session(client)
+        poll = await client.get(f"/session/{sid_b}/tool/jobs/{job_id}")
+        assert poll.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_non_heavy_tool_stays_synchronous(self, client, monkeypatch):
+        sid = await _register_session(client)
+        manager = client._transport.app._manager
+        state = manager.get_session(sid)
+        monkeypatch.setattr(
+            state,
+            "call_domain_tool",
+            lambda name, **kw: json.dumps({"ok": True, "sync": True}),
+        )
+        await client.post(f"/session/{sid}/start", json={})
+
+        resp = await client.post(
+            f"/session/{sid}/tool/shell_exec", json={"command": "echo hi"}
+        )
+        assert resp.status_code == 200
+        # No 202, no job_id.
+        body = resp.json()
+        assert body.get("sync") is True
+
+    @pytest.mark.asyncio
+    async def test_orphaned_job_still_pollable_without_session(self, client):
+        """After a restart the in-memory session is gone, but the failed
+        job record on disk must still be reachable so the client sees
+        the terminal state instead of a generic 404."""
+        manager = client._transport.app._manager
+        job = manager._job_store.create(
+            "sess-ghost", "run_lean_backtest", {"x": 1}
+        )
+        manager._job_store.update(
+            job["job_id"],
+            status=JOB_STATUS_FAILED,
+            error="server restarted before job completed",
+        )
+        # Note: no session named sess-ghost exists in the manager.
+        resp = await client.get(
+            f"/session/sess-ghost/tool/jobs/{job['job_id']}"
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["status"] == JOB_STATUS_FAILED
+        assert "restarted" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_queued_job_blocks_same_session_mutation(
+        self, client, monkeypatch
+    ):
+        """A heavy tool accepted first must hold the session lock until
+        it runs, so a later same-session write cannot race ahead and
+        tear the session down before the backtest executes."""
+        sid = await _register_session(client)
+        manager = client._transport.app._manager
+        state = manager.get_session(sid)
+
+        order: list[str] = []
+        tool_started = threading.Event()
+        release_tool = threading.Event()
+
+        def slow_tool(name, **kw):
+            order.append("tool_start")
+            tool_started.set()
+            # Block until the test lets the backtest finish. Runs on the
+            # to_thread worker, so a threading.Event (not asyncio.Event)
+            # is required.
+            release_tool.wait(timeout=5.0)
+            order.append("tool_end")
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr(state, "call_domain_tool", slow_tool)
+        await client.post(f"/session/{sid}/start", json={})
+
+        # 1. Accept a heavy tool — returns 202 immediately, job queued.
+        resp = await client.post(
+            f"/session/{sid}/tool/run_lean_backtest", json={}
+        )
+        assert resp.status_code == 202
+        job_id = resp.json()["job_id"]
+
+        # Wait until the background worker is actually inside the tool
+        # (it already holds state._request_lock at this point).
+        await asyncio.get_event_loop().run_in_executor(
+            None, tool_started.wait, 2.0
+        )
+        assert tool_started.is_set(), "background worker never started"
+
+        # 2. Fire a mutating request concurrently. It must wait for the
+        #    running backtest to release the session lock.
+        async def later_send():
+            order.append("send_issued")
+            r = await client.post(f"/session/{sid}/send", json={"text": "hi"})
+            order.append(f"send_done:{r.status_code}")
+
+        send_task = asyncio.create_task(later_send())
+        await asyncio.sleep(0.1)  # give send a chance to block on the lock
+        assert not any(s.startswith("send_done") for s in order), (
+            "send completed before backtest released the lock"
+        )
+
+        # Release the backtest and wait for both to finish.
+        release_tool.set()
+        for _ in range(200):
+            poll = await client.get(f"/session/{sid}/tool/jobs/{job_id}")
+            if poll.json()["status"] in (JOB_STATUS_COMPLETED, JOB_STATUS_FAILED):
+                break
+            await asyncio.sleep(0.02)
+        await asyncio.wait_for(send_task, timeout=5.0)
+
+        assert "tool_end" in order
+        send_done_idx = next(
+            i for i, v in enumerate(order) if v.startswith("send_done")
+        )
+        assert order.index("tool_end") < send_done_idx


### PR DESCRIPTION
## Summary

Promote two already-merged dev branches to master so the VPS deploy workflow picks them up.

- **P1 — /health probe + backtest concurrency cap** (PR #20, `5e5da19`)
- **P2 — async job pattern for heavy tools** (PR #20, `c4d6fa5`)
- **Issue-18 run hardening** (prior merge `d19957e`) — control_token auth, run state transitions, label-only catalog split. Already on dev; bundled here because it sits in front of the availability commits.

Merging this PR triggers `.github/workflows/deploy.yml` (rsyncs to VPS 217.15.165.83, restarts `quanttutor`, curls `/health` as the new smoke gate).

## Test plan

Pre-merge: all committed behaviour tested on dev — 94/94 in API + new suites.

Post-merge (on the live VPS):
- [ ] Deploy workflow green; smoke test `curl -sf http://127.0.0.1:8000/health` returns 200 with `docker/lean_image/disk` all `ok:true`.
- [ ] `curl https://217-15-165-83.sslip.io/health` from outside reaches the box with the same payload.
- [ ] Real LEAN backtest end-to-end through `benchmark-liard.vercel.app`: POST tool returns 202 with a `job_id` in <1s; client polls `/session/{sid}/tool/jobs/{job_id}` to `completed` without holding a 10-minute HTTP connection.
- [ ] Restart `quanttutor` mid-backtest; client polling the saved `job_id` sees `status:"failed"` with `"server restarted before job completed"` instead of a 404.
- [ ] Fire two concurrent LEAN backtests; confirm semaphore queues the second (logs show one running, one awaiting).