### PR TITLE
Merge dev → master: MCP static tool disclosure (#25)

### DIFF
--- a/bench/server/api/protocol.py
+++ b/bench/server/api/protocol.py
@@ -7,10 +7,18 @@ State transitions:
     REGISTERED    --start_session-->     IN_SESSION
     IN_SESSION    --status=completed-->  COMPLETED
 
+Tool discovery strategy (see issue #25): MCP ``list_tools`` returns the
+static union of all lifecycle tools regardless of phase, so frozen-
+registry clients (e.g. Claude Code) can drive the full flow without
+depending on ``tools/list_changed`` refreshes. Phase enforcement lives
+at call time in ``check_permission`` — wrong-phase calls return an
+imperative error naming the correct next hop.
+
 """
 
 import json
 from enum import Enum
+from typing import Optional
 
 from mcp.types import Tool
 
@@ -64,7 +72,10 @@ START_SESSION_TOOL = Tool(
     description=(
         "Start the tutoring session. Returns the session background, "
         "the student's first message, and the list of available tools. "
-        "Can only be called once after register_session."
+        "Precondition: register_session must have succeeded. "
+        "Called out of order, returns "
+        "{\"error\": ..., \"allowed\": [...], \"current_phase\": ...} — "
+        "follow the \"allowed\" list to decide the next call."
     ),
     inputSchema={"type": "object", "properties": {}, "required": []},
 )
@@ -78,7 +89,9 @@ SEND_MESSAGE_TOOL = Tool(
         "only messages sent through this tool reach them. "
         "Each call advances the conversation by one turn and cannot be undone. "
         "Returns the student's reply and session status. "
-        "When status is 'completed', the session has ended. "
+        "When status is 'completed', the session has ended; follow "
+        "the returned \"next_allowed\" hint (request_evaluation). "
+        "Precondition: start_session must have succeeded. "
         "Optionally include 'reasoning' to record your private rationale "
         "for this turn — it is logged for analysis and is NOT shown to the student."
     ),
@@ -181,6 +194,33 @@ _COMPLETED_TOOLS = frozenset(
 TOOL_ENDPOINT_BLOCKED = SESSION_API_TOOLS | _COMPLETED_TOOLS
 
 
+# Lifecycle tools that MCP ``list_tools`` exposes in every phase (static union).
+LIFECYCLE_TOOL_NAMES: tuple[str, ...] = (
+    "register_session",
+    "start_session",
+    "send_message",
+    "get_background",
+    "request_evaluation",
+    "get_results",
+    "get_scores",
+)
+
+
+# Recommended next-hop tool(s) per phase — the state-machine signal the agent
+# should follow to advance.
+_NEXT_ALLOWED: dict[SessionPhase, list[str]] = {
+    SessionPhase.UNREGISTERED: ["register_session"],
+    SessionPhase.REGISTERED: ["start_session"],
+    SessionPhase.IN_SESSION: ["send_message"],
+    SessionPhase.COMPLETED: ["request_evaluation"],
+}
+
+
+def next_allowed_for_phase(phase: SessionPhase) -> list[str]:
+    """Return the recommended next tool(s) to call from ``phase``."""
+    return list(_NEXT_ALLOWED.get(phase, []))
+
+
 # ---------------------------------------------------------------------------
 # Permission checking
 # ---------------------------------------------------------------------------
@@ -198,14 +238,16 @@ def check_permission(
 
     Returns:
         (allowed, error_message, allowed_operations).
-        error_message and allowed_operations are empty when allowed is True.
+        Error messages are imperative — they name the next tool the agent
+        should call — so a frozen-registry MCP client can drive the state
+        machine from error guidance alone.
     """
     if phase == SessionPhase.UNREGISTERED:
         if tool_name == "register_session":
             return True, "", []
         return (
             False,
-            "Session not registered. Call register_session first.",
+            "Wrong phase. Session not registered — call register_session next.",
             ["register_session"],
         )
 
@@ -214,7 +256,7 @@ def check_permission(
             return True, "", []
         return (
             False,
-            "Session not started. Call start_session first.",
+            "Wrong phase. Session registered but not started — call start_session next.",
             ["start_session"],
         )
 
@@ -224,7 +266,10 @@ def check_permission(
             return True, "", []
         return (
             False,
-            f"Cannot call '{tool_name}' during active session.",
+            (
+                f"Wrong phase. Cannot call '{tool_name}' during active session — "
+                "continue with send_message or a domain tool."
+            ),
             ["send_message", "(domain tools)"],
         )
 
@@ -233,13 +278,29 @@ def check_permission(
             return True, "", []
         return (
             False,
-            "Session completed.",
+            (
+                "Wrong phase. Session completed — call request_evaluation, "
+                "then get_results / get_scores."
+            ),
             sorted(_COMPLETED_TOOLS),
         )
 
     return False, "Unknown phase.", []
 
 
-def make_error_response(error: str, allowed: list[str]) -> str:
-    """Build a JSON error response with allowed operations hint."""
-    return json.dumps({"error": error, "allowed": allowed})
+def make_error_response(
+    error: str,
+    allowed: list[str],
+    *,
+    current_phase: Optional[SessionPhase] = None,
+) -> str:
+    """Build a JSON error response with state-machine hints.
+
+    ``allowed`` names the tools the caller may try from the current phase.
+    When ``current_phase`` is provided (phase-denial errors) it is included
+    so the agent can map the error back to the state machine.
+    """
+    payload: dict = {"error": error, "allowed": allowed}
+    if current_phase is not None:
+        payload["current_phase"] = current_phase.value
+    return json.dumps(payload)

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -46,6 +46,7 @@ from .protocol import (
     SessionPhase,
     check_permission,
     make_error_response,
+    next_allowed_for_phase,
 )
 
 logger = logging.getLogger(__name__)
@@ -577,7 +578,11 @@ class SessionState:
                         exc,
                     )
 
-            return {"session_id": self.session_id}
+            return {
+                "session_id": self.session_id,
+                "current_phase": self.phase.value,
+                "next_allowed": next_allowed_for_phase(self.phase),
+            }
         except Exception as exc:
             logger.exception("Session %s register failed", self.session_id)
             self._reset_registration_state()
@@ -608,6 +613,8 @@ class SessionState:
             }
             for t in self.get_visible_tools()
         ]
+        data["current_phase"] = self.phase.value
+        data["next_allowed"] = next_allowed_for_phase(self.phase)
         return data
 
     # ------------------------------------------------------------------
@@ -640,48 +647,51 @@ class SessionState:
             proxy_kwargs["reasoning"] = reasoning
         result = self.proxy.call_tool("send_message", **proxy_kwargs)
 
-        # Check for session completion
+        # Parse once: drives completion handling and next_allowed injection.
         try:
             data = json.loads(result)
-            if data.get("status") == "completed":
-                self.phase = SessionPhase.COMPLETED
-                self._save_results()
-                self._destroy_container()
-                logger.info(
-                    "Session %s completed: reason=%s",
-                    self.session_id,
-                    data.get("reason", "unknown"),
-                )
-                # Notify Run layer
-                if self._on_completed:
-                    try:
-                        self._on_completed(
-                            str(self._result_dir) if self._result_dir else None
-                        )
-                    except Exception as exc:
-                        logger.warning(
-                            "Session %s _on_completed callback failed: %s",
-                            self.session_id,
-                            exc,
-                        )
-                # Server-side auto_eval
-                if self.auto_eval:
-                    with self._eval_lock:
-                        if self._eval_status == "pending":
-                            self._eval_status = "running"
-                            threading.Thread(
-                                target=self._run_evaluation,
-                                daemon=True,
-                                name=f"autoeval-{self.session_id[:8]}",
-                            ).start()
-                            logger.info(
-                                "Session %s auto_eval started",
-                                self.session_id,
-                            )
-        except (json.JSONDecodeError, KeyError):
-            pass
+        except (json.JSONDecodeError, TypeError):
+            return result
 
-        return result
+        if data.get("status") == "completed":
+            self.phase = SessionPhase.COMPLETED
+            self._save_results()
+            self._destroy_container()
+            logger.info(
+                "Session %s completed: reason=%s",
+                self.session_id,
+                data.get("reason", "unknown"),
+            )
+            # Notify Run layer
+            if self._on_completed:
+                try:
+                    self._on_completed(
+                        str(self._result_dir) if self._result_dir else None
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Session %s _on_completed callback failed: %s",
+                        self.session_id,
+                        exc,
+                    )
+            # Server-side auto_eval
+            if self.auto_eval:
+                with self._eval_lock:
+                    if self._eval_status == "pending":
+                        self._eval_status = "running"
+                        threading.Thread(
+                            target=self._run_evaluation,
+                            daemon=True,
+                            name=f"autoeval-{self.session_id[:8]}",
+                        ).start()
+                        logger.info(
+                            "Session %s auto_eval started",
+                            self.session_id,
+                        )
+
+        data.setdefault("current_phase", self.phase.value)
+        data.setdefault("next_allowed", next_allowed_for_phase(self.phase))
+        return json.dumps(data)
 
     # ------------------------------------------------------------------
     # request_evaluation
@@ -695,7 +705,11 @@ class SessionState:
         Failed evals can be retried.
         """
         if self._closed:
-            return {"status": "failed", "error": "Session is closed"}
+            return {
+                "status": "failed",
+                "error": "Session is closed",
+                "current_phase": self.phase.value,
+            }
         with self._eval_lock:
             if self._eval_status == "pending":
                 self._eval_status = "running"
@@ -704,13 +718,19 @@ class SessionState:
                     daemon=True,
                     name=f"eval-{self.session_id[:8]}",
                 ).start()
-                return {"status": "running", "message": "Evaluation started."}
+                return self._decorate_eval_payload(
+                    {"status": "running", "message": "Evaluation started."}
+                )
 
             if self._eval_status == "running":
-                return {"status": "running", "message": "Evaluation in progress."}
+                return self._decorate_eval_payload(
+                    {"status": "running", "message": "Evaluation in progress."}
+                )
 
             if self._eval_status == "completed":
-                return {"status": "completed", "scores": self._eval_results}
+                return self._decorate_eval_payload(
+                    {"status": "completed", "scores": self._eval_results}
+                )
 
             if self._eval_status == "failed":
                 self._eval_status = "running"
@@ -719,9 +739,20 @@ class SessionState:
                     daemon=True,
                     name=f"eval-{self.session_id[:8]}",
                 ).start()
-                return {"status": "running", "message": "Retrying evaluation."}
+                return self._decorate_eval_payload(
+                    {"status": "running", "message": "Retrying evaluation."}
+                )
 
-        return {"status": "unknown"}
+        return self._decorate_eval_payload({"status": "unknown"})
+
+    def _decorate_eval_payload(self, payload: dict) -> dict:
+        """Attach state-machine hints to a ``request_evaluation`` response."""
+        payload.setdefault("current_phase", self.phase.value)
+        if payload.get("status") == "completed":
+            payload.setdefault("next_allowed", ["get_scores", "get_results"])
+        else:
+            payload.setdefault("next_allowed", ["request_evaluation"])
+        return payload
 
     # ------------------------------------------------------------------
     # Domain tool calls
@@ -738,30 +769,104 @@ class SessionState:
     # ------------------------------------------------------------------
 
     def get_visible_tools(self) -> list[Tool]:
-        """Return MCP Tool list for the current phase.
+        """Return MCP Tool list — static union for frozen-registry clients.
 
-        | Phase       | list_tools returns                              |
-        |-------------|--------------------------------------------------|
-        | UNREGISTERED| [register_session]                               |
-        | REGISTERED  | [start_session]                                  |
-        | IN_SESSION  | [send_message] + all domain tools                |
-        | COMPLETED   | [request_evaluation, get_results, get_scores]    |
+        All lifecycle tools are visible from UNREGISTERED onward so a
+        frozen-registry MCP client (which caches ``list_tools`` at connect
+        time and ignores ``tools/list_changed``) can still drive the full
+        state machine. Phase permissions are enforced at call time via
+        ``check_permission``; wrong-phase calls return an imperative error
+        naming the next hop.
+
+        Domain tools are appended whenever a task is bound to this session
+        — either via ``register_session`` (proxy-resolved, includes live
+        distractors) or via a run-token binding before register (preloaded
+        from the task definition using the same deterministic seed as
+        ``populate_proxy_for_task``, so the initial ``list_tools`` already
+        contains the full catalogue).
         """
-        if self.phase == SessionPhase.UNREGISTERED:
-            return [REGISTER_SESSION_TOOL]
+        lifecycle = [
+            REGISTER_SESSION_TOOL,
+            START_SESSION_TOOL,
+            SEND_MESSAGE_TOOL,
+            GET_BACKGROUND_TOOL,
+            REQUEST_EVALUATION_TOOL,
+            GET_RESULTS_TOOL,
+            GET_SCORES_TOOL,
+        ]
+        return lifecycle + self._resolve_domain_tools()
 
-        domain_tools = self._get_domain_tools()
+    def _resolve_domain_tools(self) -> list[Tool]:
+        """Return task-specific domain tools, preloading when necessary.
 
-        if self.phase == SessionPhase.REGISTERED:
-            return [START_SESSION_TOOL]
+        If the proxy exposes live tool schemas (post-register), they are
+        authoritative. Otherwise — UNREGISTERED on a run-token connection,
+        or a completed session restored from storage where the proxy is a
+        logs-only stub — synthesize schemas from task metadata so
+        ``list_tools`` still returns the full catalogue.
+        """
+        if self.proxy is not None and hasattr(self.proxy, "get_available_tools"):
+            return self._get_domain_tools()
 
-        if self.phase == SessionPhase.IN_SESSION:
-            return [SEND_MESSAGE_TOOL, GET_BACKGROUND_TOOL] + domain_tools
+        task_id = self.task_id or self._run_task_id or ""
+        if not task_id:
+            return []
+        return self._preload_domain_tools_for_task(task_id)
 
-        if self.phase == SessionPhase.COMPLETED:
-            return [REQUEST_EVALUATION_TOOL, GET_RESULTS_TOOL, GET_SCORES_TOOL]
+    def _preload_domain_tools_for_task(self, task_id: str) -> list[Tool]:
+        """Synthesize domain Tool objects from task metadata without a container.
 
-        return []
+        Called in UNREGISTERED phase when a run-token has bound the session
+        to a task but register_session hasn't run yet. Distractor selection
+        mirrors ``populate_proxy_for_task`` (same seed, same pool math) so
+        the preloaded catalogue matches the post-register list.
+        """
+        import random
+
+        from server.core.distractors.distractor_tools import DISTRACTOR_TOOLS
+        from server.core.registry import _TOTAL_TOOL_SLOTS
+        from server.tooling import (
+            get_task_tool_specs,
+            render_agent_tool_description,
+        )
+
+        task = self.task or self._load_task(task_id)
+        if task is None:
+            return []
+
+        core_names = list(
+            task.environment.core_mcp_tools if task.environment else []
+        )
+        convenient_names = list(
+            task.ground_truth.convenient_tools if task.ground_truth else []
+        )
+
+        seed = _session_random_seed(task_id, self.session_id, task.seed)
+        rng = random.Random(seed)
+        excluded = set(core_names) | set(convenient_names)
+        pool = [d for d in DISTRACTOR_TOOLS if d not in excluded]
+        n_slots = max(
+            0,
+            min(
+                _TOTAL_TOOL_SLOTS - len(core_names) - len(convenient_names),
+                len(pool),
+            ),
+        )
+        distractor_names = rng.sample(pool, n_slots) if n_slots > 0 else []
+
+        specs = get_task_tool_specs(
+            core_tool_names=core_names,
+            convenient_tool_names=convenient_names,
+            distractor_tool_names=distractor_names,
+        )
+        return [
+            Tool(
+                name=name,
+                description=render_agent_tool_description(spec),
+                inputSchema=spec.input_schema,
+            )
+            for name, spec in specs.items()
+        ]
 
     # ------------------------------------------------------------------
     # Unified MCP call_tool handler
@@ -813,7 +918,9 @@ class SessionState:
             return [
                 TextContent(
                     type="text",
-                    text=make_error_response(error, allowed_ops),
+                    text=make_error_response(
+                        error, allowed_ops, current_phase=self.phase
+                    ),
                 )
             ]
 

--- a/bench/spec/PROTOCOL.md
+++ b/bench/spec/PROTOCOL.md
@@ -17,14 +17,30 @@ register_session          start_session           status="completed"
  UNREGISTERED ──────→ REGISTERED ──────→ IN_SESSION ──────→ COMPLETED
 ```
 
-| Phase        | Allowed                              | Rejected                                      |
-|--------------|--------------------------------------|-----------------------------------------------|
-| UNREGISTERED | register_session                     | start, send, tools, evaluate, results, scores |
-| REGISTERED   | start_session, list_tools            | register, send, tools, evaluate               |
-| IN_SESSION   | send_message, domain tools           | register, start, evaluate                     |
-| COMPLETED    | request_evaluation, get_results, get_scores | register, start, send, domain tools    |
+Phase enforcement is at call time. `list_tools` returns the static union
+of all lifecycle tools every phase (plus task-specific domain tools once
+a task is bound); the catalogue does not shrink or grow between phases.
+Frozen-registry MCP clients that cache `list_tools` at connect time see
+the full catalogue immediately and drive the state machine from response
+hints rather than tool-list mutation.
 
-Rejected calls return: `{"error": "description", "allowed": ["permitted_operations"]}`
+| Phase        | Callable                                    | Out-of-phase behaviour |
+|--------------|---------------------------------------------|------------------------|
+| UNREGISTERED | register_session                            | Everything else returns `{"error", "allowed", "current_phase"}` |
+| REGISTERED   | start_session                               | Same error shape, `allowed = ["start_session"]` |
+| IN_SESSION   | send_message, domain tools                  | Same error shape, `allowed = ["send_message", "(domain tools)"]` |
+| COMPLETED    | request_evaluation, get_results, get_scores | Same error shape, `allowed = ["request_evaluation", "get_results", "get_scores"]` |
+
+Phase-denial payload:
+```json
+{"error": "Wrong phase. Call start_session next.",
+ "allowed": ["start_session"],
+ "current_phase": "registered"}
+```
+
+Successful lifecycle responses carry `next_allowed` + `current_phase` so the
+agent can advance without re-reading `list_tools` — useful when the client
+ignores `tools/list_changed`.
 
 ---
 
@@ -41,13 +57,14 @@ REST: POST /session/register  {"task_id": "X01_ma_offbyone"}
 
 | Response | Body |
 |----------|------|
-| Success  | `{"accepted": true, "session_id": "a1b2c3d4e5f6"}` |
-| Bad request (400) | `{"accepted": false, "error": "Missing required field: task_id"}` |
-| Not found (404)   | `{"accepted": false, "error": "Task not found: INVALID_ID"}` |
+| Success  | `{"session_id": "a1b2c3d4e5f6", "current_phase": "registered", "next_allowed": ["start_session"]}` |
+| Bad request (400) | `{"error": "Missing required field: task_id"}` |
+| Not found (404)   | `{"error": "Task not found: INVALID_ID"}` |
 
 ### 2.2 start_session
 
-Start the tutoring session. Returns the student's first message. Can only be called once.
+Start the tutoring session. Returns the student's first message plus the
+task-specific tool catalogue. Can only be called once.
 
 ```
 MCP:  start_session()
@@ -56,12 +73,15 @@ REST: POST /session/{sid}/start
 
 | Response | Body |
 |----------|------|
-| Success  | `{"student_message": "I wrote a moving average crossover strategy but..."}` |
-| Wrong phase (403) | `{"error": "...", "allowed": ["start_session"]}` |
+| Success  | `{"student_message": "...", "tools": [...], "current_phase": "in_session", "next_allowed": ["send_message"]}` |
+| Wrong phase (403) | `{"error": "...", "allowed": ["start_session"], "current_phase": "..."}` |
 
 ### 2.3 list_tools / tools
 
-Discover available tools. Tool set varies by task and changes with phase.
+Discover available tools. The catalogue is the **static union** of all
+lifecycle tools plus any task-specific domain tools bound to this
+session; the set does not mutate per phase. Phase enforcement is at call
+time in `handle_tool_call`.
 
 ```
 MCP:  list_tools()                    (standard MCP operation)
@@ -70,7 +90,10 @@ REST: GET /session/{sid}/tools
 
 REST response: `{"tools": [{"name": "shell_exec", "description": "...", "inputSchema": {...}}, ...]}`
 
-Read-only query. Available in any phase.
+Read-only query. Available in any phase. MCP emits `tools/list_changed`
+after phase transitions as a progressive-enhancement for compliant
+clients, but frozen-registry clients are fully supported via the static
+catalogue and response-payload `next_allowed` hints.
 
 ### 2.4 Domain tool call
 
@@ -110,12 +133,14 @@ REST: POST /session/{sid}/send  {"text": "Let me help you debug this...",
 
 | Response | Body |
 |----------|------|
-| Active   | `{"student_message": "Oh I see...", "status": "active"}` |
-| Completed | `{"student_message": "Thanks!", "status": "completed", "reason": "objectives_met"}` |
+| Active   | `{"student_message": "Oh I see...", "status": "active", "current_phase": "in_session", "next_allowed": ["send_message"]}` |
+| Completed | `{"student_message": "Thanks!", "status": "completed", "reason": "objectives_met", "current_phase": "completed", "next_allowed": ["request_evaluation"]}` |
 | Empty text (400) | `{"error": "Empty message. Provide text to send to the student."}` |
 | Bad reasoning type (400) | `{"error": "reasoning must be a string"}` |
 
-When `status == "completed"`, the session has ended. Stop calling tools and send_message.
+When `status == "completed"`, the session has ended. Follow `next_allowed`
+(`request_evaluation`); further `send_message` / domain-tool calls will be
+rejected with the phase-denial shape.
 
 ### 2.6 request_evaluation
 
@@ -128,10 +153,10 @@ REST: POST /session/{sid}/evaluate[?force=true]
 
 | Response | Body |
 |----------|------|
-| Started  | `{"status": "running", "message": "Evaluation started."}` |
-| In progress | `{"status": "running", "message": "Evaluation in progress."}` |
-| Done     | `{"status": "completed", "scores": {"overall": 0.72, ...}}` |
-| Failed   | `{"status": "failed", "error": "..."}` |
+| Started  | `{"status": "running", "message": "Evaluation started.", "current_phase": "completed", "next_allowed": ["request_evaluation"]}` |
+| In progress | `{"status": "running", "message": "Evaluation in progress.", "current_phase": "completed", "next_allowed": ["request_evaluation"]}` |
+| Done     | `{"status": "completed", "scores": {...}, "current_phase": "completed", "next_allowed": ["get_scores", "get_results"]}` |
+| Failed   | `{"status": "failed", "error": "...", "current_phase": "completed"}` |
 
 `?force=true` (REST) resets and re-runs evaluation.
 
@@ -248,7 +273,7 @@ GET /session/abc123/scores
 | Response format | JSON string in TextContent (client must `json.loads`) | Direct JSON object |
 | DELETE response | Per MCP spec | `{"status": "cancelled"}` (HTTP 200) |
 | Session creation | `initialize` creates UNREGISTERED, then `register_session` tool | `POST /session/register` atomic (directly REGISTERED) |
-| Tool discovery | `list_tools` + automatic `tools/list_changed` notification | `GET /tools` on demand; phase change visible in response semantics |
+| Tool discovery | Static union at `list_tools`; `tools/list_changed` emitted after phase transitions as progressive enhancement for compliant clients | `GET /tools` on demand |
 | Error format | JSON-RPC error envelope | HTTP status code + JSON body |
 
 These differences are transport-level only. Same session state, same permission rules, same scoring.

--- a/bench/tests/api/test_completed_phase.py
+++ b/bench/tests/api/test_completed_phase.py
@@ -68,15 +68,20 @@ class TestCompletedPhasePermissions:
 class TestCompletedPhaseTools:
     @pytest.mark.asyncio
     async def test_tools_shows_eval_tools(self, client, completed_session):
+        """Static-union visibility (issue #25): all lifecycle tools remain
+        listed in COMPLETED; calling an out-of-phase one returns the
+        imperative phase-denial error rather than disappearing from the
+        catalogue."""
         sid = completed_session
         tools = await get_tools(client, sid)
         names = [t["name"] for t in tools]
         assert "request_evaluation" in names
         assert "get_results" in names
         assert "get_scores" in names
-        # Session tools should NOT be visible
-        assert "send_message" not in names
-        assert "start_session" not in names
+        # Lifecycle tools stay visible so frozen-registry clients can still
+        # drive the state machine via error guidance.
+        assert "send_message" in names
+        assert "start_session" in names
 
 
 # ---------------------------------------------------------------------------

--- a/bench/tests/unit/test_mcp_tool_routing.py
+++ b/bench/tests/unit/test_mcp_tool_routing.py
@@ -283,23 +283,76 @@ class TestMCPPhaseTransitions:
         assert session_state.phase == SessionPhase.IN_SESSION
 
     @pytest.mark.asyncio
-    async def test_visible_tools_change_per_phase(self, session_state):
-        # UNREGISTERED — only register
+    async def test_visible_tools_static_lifecycle_union(self, session_state):
+        """Lifecycle tools are visible from UNREGISTERED onward.
+
+        See issue #25: frozen-registry MCP clients cache ``list_tools`` at
+        connect time, so the full lifecycle catalogue must be in the first
+        response. Phase permissions are enforced at call time.
+        """
+        from server.api.protocol import LIFECYCLE_TOOL_NAMES
+
+        # UNREGISTERED — full lifecycle already present, no domain tools yet
         tools = session_state.get_visible_tools()
-        names = [t.name for t in tools]
-        assert "register_session" in names
-        assert "send_message" not in names
+        names = {t.name for t in tools}
+        for lifecycle in LIFECYCLE_TOOL_NAMES:
+            assert lifecycle in names, f"{lifecycle} missing from UNREGISTERED list"
 
         await _register(session_state)
-        # REGISTERED — only start
+        # REGISTERED — lifecycle still present; domain tools appear from proxy
         tools = session_state.get_visible_tools()
-        names = [t.name for t in tools]
-        assert "start_session" in names
-        assert "send_message" not in names
+        names = {t.name for t in tools}
+        for lifecycle in LIFECYCLE_TOOL_NAMES:
+            assert lifecycle in names
+        assert len(tools) > len(LIFECYCLE_TOOL_NAMES), "expected domain tools after register"
 
         await _start(session_state)
-        # IN_SESSION — send_message + domain tools
+        # IN_SESSION — same static lifecycle set
         tools = session_state.get_visible_tools()
-        names = [t.name for t in tools]
-        assert "send_message" in names
-        assert "register_session" not in names
+        names = {t.name for t in tools}
+        for lifecycle in LIFECYCLE_TOOL_NAMES:
+            assert lifecycle in names
+
+    @pytest.mark.asyncio
+    async def test_register_response_carries_next_allowed(self, session_state):
+        result = await _register(session_state)
+        assert result.get("current_phase") == "registered"
+        assert result.get("next_allowed") == ["start_session"]
+
+    @pytest.mark.asyncio
+    async def test_start_response_carries_next_allowed(self, session_state):
+        await _register(session_state)
+        result = await _start(session_state)
+        assert result.get("current_phase") == "in_session"
+        assert result.get("next_allowed") == ["send_message"]
+
+    @pytest.mark.asyncio
+    async def test_wrong_phase_error_is_imperative(self, session_state):
+        # Calling start_session before register — frozen-registry clients rely
+        # on this error to learn the next hop.
+        result = await _call(session_state, "start_session", {})
+        assert "error" in result
+        assert result.get("current_phase") == "unregistered"
+        assert "register_session" in result.get("allowed", [])
+        assert "register_session" in result.get("error", "")
+
+    def test_visible_tools_with_logs_only_proxy(self, session_state):
+        """Restored sessions stub ``self.proxy`` as a logs-only
+        ``SimpleNamespace`` (no ``get_available_tools``). ``list_tools``
+        must still succeed by falling through to the preload path.
+        """
+        from types import SimpleNamespace
+
+        from server.api.protocol import LIFECYCLE_TOOL_NAMES, SessionPhase
+
+        session_state.proxy = SimpleNamespace(
+            get_logs=lambda: [],
+            get_distractor_names=lambda: [],
+        )
+        session_state.task_id = DEFAULT_TASK_ID
+        session_state.phase = SessionPhase.COMPLETED
+
+        tools = session_state.get_visible_tools()
+        names = {t.name for t in tools}
+        for lifecycle in LIFECYCLE_TOOL_NAMES:
+            assert lifecycle in names


### PR DESCRIPTION
Promotes #26 (merged to dev) up to master.

## Summary
- `get_visible_tools` returns the static union of lifecycle tools every phase so frozen-registry MCP clients (e.g. Claude Code) can drive the full state machine from their first `list_tools`.
- Domain tools resolve live from the proxy when populated, or preloaded from task metadata + deterministic distractor seed otherwise (covers run-token pre-bind and restored-session stubs without `get_available_tools`).
- Response payloads for `register_session` / `start_session` / `send_message` / `request_evaluation` now carry `next_allowed` + `current_phase`; phase-denial errors include `current_phase` and imperative prose.
- `bench/spec/PROTOCOL.md` updated: static-union catalogue, new response shapes, `tools/list_changed` downgraded to progressive enhancement.

## Eval-rule impact
None. Lifecycle tools never enter `proxy_logs` (routed through `session_api.handle_tool_call`), and the three eval modules (`tool_usage.py`, `process_reasonableness.py`, `result_judge.py`) all filter `proxy_logs` through `NON_SUBSTANTIVE_TOOLS` / `PROTOCOL_ONLY_TOOLS`. The new hint fields land on channels no evaluator reads.

## Test plan
- [x] `bench/tests/run_tests.sh` — 196 passed (adds regression for restored-session logs-only proxy)
- [x] Codex review × 2 rounds — round 1 caught P1 restore-path crash (fixed); round 2 clean