### PR TITLE
fix(rest): include current_phase in REST phase-denial envelopes

### DIFF
--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -899,7 +899,10 @@ async def rest_start(request: Request) -> JSONResponse:
     allowed, error, ops = check_permission(state.phase, "start_session")
     if not allowed:
         logger.debug("[REST:%s] DENIED start in phase %s", sid[:8], state.phase.value)
-        return JSONResponse({"error": error, "allowed": ops}, 403)
+        return JSONResponse(
+            {"error": error, "allowed": ops, "current_phase": state.phase.value},
+            403,
+        )
 
     async with state._request_lock:
         state._last_activity = time.time()
@@ -955,7 +958,10 @@ async def rest_tool_call(request: Request) -> JSONResponse:
         logger.debug(
             "[REST:%s] DENIED %s in phase %s", sid[:8], name, state.phase.value
         )
-        return JSONResponse({"error": error, "allowed": ops}, 403)
+        return JSONResponse(
+            {"error": error, "allowed": ops, "current_phase": state.phase.value},
+            403,
+        )
 
     try:
         body = await request.json()
@@ -1109,7 +1115,10 @@ async def rest_send(request: Request) -> JSONResponse:
     allowed, error, ops = check_permission(state.phase, "send_message")
     if not allowed:
         logger.debug("[REST:%s] DENIED send in phase %s", sid[:8], state.phase.value)
-        return JSONResponse({"error": error, "allowed": ops}, 403)
+        return JSONResponse(
+            {"error": error, "allowed": ops, "current_phase": state.phase.value},
+            403,
+        )
 
     try:
         body = await request.json()
@@ -1173,7 +1182,10 @@ async def rest_evaluate(request: Request) -> JSONResponse:
         logger.debug(
             "[REST:%s] DENIED evaluate in phase %s", sid[:8], state.phase.value
         )
-        return JSONResponse({"error": error, "allowed": ops}, 403)
+        return JSONResponse(
+            {"error": error, "allowed": ops, "current_phase": state.phase.value},
+            403,
+        )
 
     # Parse eval parameters from query string
     eval_mode = request.query_params.get("eval_mode", "full")

--- a/bench/tests/api/test_session_lifecycle.py
+++ b/bench/tests/api/test_session_lifecycle.py
@@ -98,7 +98,10 @@ class TestSendMessage:
         sid = await register_session(client)
         resp = await client.post(f"/session/{sid}/send", json={"text": "hello"})
         assert resp.status_code == 403
-        assert "start_session" in resp.json().get("allowed", [])
+        body = resp.json()
+        assert "start_session" in body.get("allowed", [])
+        # Parity with MCP phase-denial envelope.
+        assert body.get("current_phase") == "registered"
 
 
 class TestTools:


### PR DESCRIPTION
Follow-up to #25 / #26. MCP phase-denial payloads already carried `current_phase` via `make_error_response`; REST handlers built their 403 body inline as `{error, allowed}`. Brings the four REST sites — `rest_start`, `rest_tool_call`, `rest_send_message`, `rest_evaluate` — to the same shape so a client inspecting the body (not just the HTTP status) gets the same state-machine hint on either transport.

## Summary
- `bench/server/api/http_app.py` — all four `JSONResponse({error, allowed}, 403)` sites now emit `{error, allowed, current_phase}`
- `bench/tests/api/test_session_lifecycle.py::test_send_before_start_denied` — asserts `current_phase == "registered"` for REST parity

## Test plan
- [x] `bench/tests/run_tests.sh` — 196 passed
- [x] Codex review — clean