### PR TITLE
fix(lean): session runner config + shared helper + OSS recipe (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,113 @@ python scripts/05_upload/upload_to_huggingface.py \
 
 ---
 
+## Step 8: LEAN Backtest Reproduction
+
+The I-series and most X-series tasks evaluate C# algorithms inside a
+LEAN Docker sandbox. Two runners share the sandbox:
+
+- **Reference generator** (`bench/reference_generator/generate_lean_reference.py`) —
+  host-side Python. Builds a fresh LEAN config, mounts it `:ro` into a
+  one-shot container, runs the reference `.cs`, and writes expected
+  trades/signals/summary to `bench/data/reference/`. Used to produce the
+  ground-truth artefacts shipped on HuggingFace.
+- **Session runner** (`bench/docker/run_backtest.sh`) — runs **inside** the
+  long-lived benchmark container. Seeds the Launcher's runtime config
+  from the benchmark-shipped `lean-config.json`, compiles the agent's
+  algorithm with `dotnet build`, discovers the output DLL, patches
+  `algorithm-type-name` + `algorithm-location` + fees + parameters, and
+  launches LEAN. Used by `run_lean_backtest` during a live tutoring
+  session.
+
+Both runners call the same patch helper at `bench/docker/lean_config.py`
+(shipped into the image at `/lean/helpers/lean_config.py`) so they
+cannot drift on which keys steer the Launcher.
+
+### Container layout knobs
+
+If your image installs LEAN at a non-default path (e.g. capitalised
+`/Lean` or a custom fork), override these env vars before invoking
+`run_backtest`:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `LEAN_ROOT` | `/lean` | Root of the LEAN install. Everything else derives from it. |
+| `LEAN_HELPERS_DIR` | `${LEAN_ROOT}/helpers` | Where `lean_config.py` was copied. |
+| `LEAN_RUN_TIMEOUT` | `300` | Per-backtest wall-clock timeout (seconds). Exit 124 = killed. |
+
+### Minimal reproduction recipe (SMA baseline on BTCUSDT daily)
+
+```bash
+# 1. Build the base image first (Dockerfile.lean inherits from it).
+docker build -f bench/docker/Dockerfile -t quant-tutor-env:v2.2 bench/
+
+# 2. Build the LEAN image (one-time, ~10–20 min, produces ~27.5 GB).
+docker build -f bench/docker/Dockerfile.lean -t quant-tutor-env:lean bench/
+
+# 3. Drop a single-SMA algorithm into a workspace.
+#    Note: run_backtest.sh injects a 12-col custom-data reader and shadows
+#    AddCrypto so the subscription lands in Slice as custom BaseData rather
+#    than a TradeBar. Use `data.ContainsKey(_btc)` + `data[_btc].Value`, not
+#    `data.Bars[_btc].Close` — Bars stays empty for the injected feed.
+mkdir -p /tmp/qtb-workspace
+cat >/tmp/qtb-workspace/strategy.cs <<'CS'
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class SmaBaseline : QCAlgorithm
+    {
+        private Symbol _btc;
+        private SimpleMovingAverage _sma;
+
+        public override void Initialize()
+        {
+            SetStartDate(2022, 1, 1);
+            SetEndDate(2025, 12, 31);
+            SetCash(100000);
+            _btc = AddCrypto("BTCUSDT", Resolution.Daily, Market.Binance).Symbol;
+            _sma = SMA(_btc, 20, Resolution.Daily);
+            SetWarmUp(20, Resolution.Daily);
+        }
+
+        public override void OnData(Slice data)
+        {
+            if (IsWarmingUp || !_sma.IsReady) return;
+            if (!data.ContainsKey(_btc)) return;
+            var price = data[_btc].Value;
+            if (price > _sma && !Portfolio[_btc].Invested) SetHoldings(_btc, 1.0);
+            else if (price < _sma && Portfolio[_btc].Invested) Liquidate(_btc);
+        }
+    }
+}
+CS
+
+# 4. Run inside the container (mount the workspace, mount the HuggingFace
+#    dataset's `lean/` tree as /Lean/Data, and the 12-col CSVs as
+#    /data/custom). --class-name is required so the Launcher resolves
+#    QuantConnect.Algorithm.CSharp.SmaBaseline; without it the runner falls
+#    back to an `Algorithm` type name that won't exist in the compiled DLL.
+#    Results land in /tmp/qtb-workspace/results/sma_baseline.
+docker run --rm \
+  -v /tmp/qtb-workspace:/workspace \
+  -v /path/to/hf-dataset/lean:/Lean/Data \
+  -v /path/to/hf-dataset/custom:/data/custom:ro \
+  quant-tutor-env:lean \
+  run_backtest /workspace/strategy.cs --run-id sma_baseline --class-name SmaBaseline
+
+# 5. Inspect summary + orders.
+jq '.statistics' /tmp/qtb-workspace/results/sma_baseline/summary.json
+jq 'length' /tmp/qtb-workspace/results/sma_baseline/orders.json
+```
+
+See `bench/docker/Dockerfile.lean` for the full image build, and
+[issue #33](https://github.com/varsity-tech-product/benchmark/issues/33)
+for the runner's architectural history.
+
+---
+
 ## Evaluation System (`bench/`)
 
 The `bench/` directory contains the QuantTutorBench evaluation framework -- a two-axis benchmark that evaluates agents on both **quantitative finance expertise** (70%) and **tutoring effectiveness** (30%).

--- a/bench/docker/Dockerfile.lean
+++ b/bench/docker/Dockerfile.lean
@@ -63,6 +63,12 @@ COPY docker/lean-config.json /lean/Launcher/config.json
 COPY docker/run_backtest.sh /usr/local/bin/run_backtest
 RUN chmod +x /usr/local/bin/run_backtest
 
+# ── Install shared LEAN config helper ────────────────────────────────
+# Imported by run_backtest.sh (in-container) and by the reference
+# generator (host-side). Same source, same behaviour — prevents the
+# divergence that caused issue #33.
+COPY docker/lean_config.py /lean/helpers/lean_config.py
+
 # ── Install strategy injection script (for custom data mode) ────────
 COPY scripts/inject_strategy.py /opt/bench/scripts/inject_strategy.py
 

--- a/bench/docker/__init__.py
+++ b/bench/docker/__init__.py
@@ -1,0 +1,1 @@
+"""Docker/LEAN runtime assets shared between the container and host tooling."""

--- a/bench/docker/lean_config.py
+++ b/bench/docker/lean_config.py
@@ -1,0 +1,81 @@
+"""Shared LEAN config builders for the reference generator and the session runner.
+
+Both the host-side reference generator (`bench/reference_generator/generate_lean_reference.py`)
+and the in-container session runner (`bench/docker/run_backtest.sh` via an inline
+`python3 -c "..."`) must agree on a handful of keys that steer the LEAN Launcher —
+`algorithm-type-name`, `algorithm-location`, `parameters`, `results-destination-folder`.
+Any divergence between the two reproduces the empty-`algorithm-location` crash that
+blocked session backtests on prod (see issue #33).
+
+Design:
+
+- `DEFAULT_FEES` / `DEFAULT_CUSTOM_DATA_ROOT` — single source of truth for the
+  default fee rates and custom-data path. Reference generator and session runner
+  both consume these.
+- `resolve_algorithm_type_name()` — one rule for how a class name becomes a fully
+  qualified `algorithm-type-name`, with the same `full_type_name` override semantics.
+- `apply_session_overrides()` — mutates an existing config dict (the seed the
+  session runner loads from the Dockerfile-shipped template) with every key a
+  session-mode backtest needs. Safe to call on a freshly built reference config
+  too, so the reference generator can route through it once we converge further.
+
+This module ships inside the container at `/lean/helpers/lean_config.py` (copied by
+`Dockerfile.lean`) so the in-container python3 heredoc in `run_backtest.sh` can
+import it without relying on the full `bench/` tree being present at runtime.
+"""
+
+from __future__ import annotations
+
+DEFAULT_FEES: dict[str, str] = {
+    "maker-fee-rate": "0.0002",
+    "taker-fee-rate": "0.0005",
+}
+
+DEFAULT_CUSTOM_DATA_ROOT: str = "/data/custom/binance"
+
+DEFAULT_ALGORITHM_NAMESPACE: str = "QuantConnect.Algorithm.CSharp"
+
+
+def resolve_algorithm_type_name(
+    class_name: str = "",
+    full_type_name: str = "",
+) -> str:
+    """Return the fully qualified type name LEAN's Launcher looks up.
+
+    An explicit ``full_type_name`` wins; otherwise ``class_name`` is prefixed
+    with the default namespace to match the shipped project layout. Falls back
+    to ``Algorithm`` if neither is supplied, preserving legacy behaviour.
+    """
+    if full_type_name:
+        return full_type_name
+    name = class_name or "Algorithm"
+    return f"{DEFAULT_ALGORITHM_NAMESPACE}.{name}"
+
+
+def apply_session_overrides(
+    cfg: dict,
+    class_name: str = "",
+    full_type_name: str = "",
+    dll_path: str = "",
+    results_dir: str = "",
+    parameters: dict | None = None,
+) -> dict:
+    """Mutate ``cfg`` with every key a session-mode backtest needs.
+
+    The seed config loaded from the Dockerfile-shipped template carries the
+    structural scaffolding (``environments``, handler names, data paths) but
+    leaves the per-run values empty — this helper fills them in. Returns the
+    same dict so callers can chain or reassign.
+    """
+    cfg["algorithm-type-name"] = resolve_algorithm_type_name(class_name, full_type_name)
+    if dll_path:
+        cfg["algorithm-location"] = dll_path
+    if results_dir:
+        cfg["results-destination-folder"] = results_dir
+
+    merged: dict = dict(DEFAULT_FEES)
+    merged["custom-data-root"] = DEFAULT_CUSTOM_DATA_ROOT
+    if parameters:
+        merged.update(parameters)
+    cfg["parameters"] = merged
+    return cfg

--- a/bench/docker/run_backtest.sh
+++ b/bench/docker/run_backtest.sh
@@ -27,9 +27,20 @@ set -euo pipefail
 LEAN_ROOT="/lean"
 LEAN_LAUNCHER="${LEAN_ROOT}/Launcher"
 LEAN_ALGO_DIR="${LEAN_ROOT}/Algorithm.CSharp"
-LEAN_CONFIG="${LEAN_LAUNCHER}/config.json"
-RESULTS_DIR="/workspace/results"
 LEAN_OUTPUT_DIR="${LEAN_LAUNCHER}/bin/Debug"
+# The Launcher DLL runs from bin/Debug and reads the sibling config.json there.
+# Editing /lean/Launcher/config.json (the source copy) has no runtime effect.
+LEAN_CONFIG="${LEAN_OUTPUT_DIR}/config.json"
+# The benchmark-shipped, comment-free config. Dockerfile.lean copies this to
+# ${LEAN_LAUNCHER}/config.json only; bin/Debug/config.json remains the upstream
+# LEAN default (JSON with comments) that python's json.load cannot parse.
+# Used to seed LEAN_CONFIG before patching.
+LEAN_CONFIG_SEED="${LEAN_LAUNCHER}/config.json"
+RESULTS_DIR="/workspace/results"
+# Location LEAN's JobQueue loads the compiled algorithm from. Must be written
+# into config.json as `algorithm-location` or the Launcher crashes with
+# System.ArgumentException: empty path.
+LEAN_ALGO_DLL="${LEAN_OUTPUT_DIR}/QuantConnect.Algorithm.CSharp.dll"
 
 # Per-backtest timeout in seconds (default 5 min, overridable via env var).
 # Exit code 124 = timeout killed.
@@ -184,6 +195,13 @@ fi
 
 # ── Step 2b: Reset and inject parameters into config.json ─────────────
 echo "[2b/4] Preparing config.json parameters..."
+# Seed the runtime-read config (bin/Debug/config.json, which the Launcher
+# reads) from the benchmark's shipped comment-free copy. Skipped if already
+# identical, so reruns don't thrash.
+if ! cmp -s "$LEAN_CONFIG_SEED" "$LEAN_CONFIG" 2>/dev/null; then
+    cp "$LEAN_CONFIG_SEED" "$LEAN_CONFIG"
+    echo "  -> Seeded $LEAN_CONFIG from $LEAN_CONFIG_SEED"
+fi
 # Write PARAMS_JSON to a temp file to avoid shell injection via heredoc
 _PARAMS_TMPFILE=$(mktemp /tmp/params_XXXXXX.json)
 printf '%s' "$PARAMS_JSON" > "$_PARAMS_TMPFILE"
@@ -222,6 +240,10 @@ if full_type_name:
     cfg['algorithm-type-name'] = full_type_name
 else:
     cfg['algorithm-type-name'] = f'QuantConnect.Algorithm.CSharp.{class_name}'
+
+# Point the Launcher at the freshly copied DLL. Without this the base image's
+# empty default crashes JobQueue.NextJob with an empty-string path.
+cfg['algorithm-location'] = '$LEAN_ALGO_DLL'
 
 with open('$LEAN_CONFIG', 'w') as f:
     json.dump(cfg, f, indent=2)

--- a/bench/docker/run_backtest.sh
+++ b/bench/docker/run_backtest.sh
@@ -24,23 +24,29 @@
 set -euo pipefail
 
 # ── Configuration ──────────────────────────────────────────────────────
-LEAN_ROOT="/lean"
+# LEAN_ROOT may be overridden for image layouts that install LEAN elsewhere
+# (e.g. a capitalised `/Lean` on forks built from a different base image).
+# Everything else derives from it so a reproducer with a non-default layout
+# only needs to set this one knob.
+LEAN_ROOT="${LEAN_ROOT:-/lean}"
 LEAN_LAUNCHER="${LEAN_ROOT}/Launcher"
 LEAN_ALGO_DIR="${LEAN_ROOT}/Algorithm.CSharp"
 LEAN_OUTPUT_DIR="${LEAN_LAUNCHER}/bin/Debug"
 # The Launcher DLL runs from bin/Debug and reads the sibling config.json there.
-# Editing /lean/Launcher/config.json (the source copy) has no runtime effect.
+# Editing $LEAN_LAUNCHER/config.json (the source copy) has no runtime effect.
 LEAN_CONFIG="${LEAN_OUTPUT_DIR}/config.json"
 # The benchmark-shipped, comment-free config. Dockerfile.lean copies this to
 # ${LEAN_LAUNCHER}/config.json only; bin/Debug/config.json remains the upstream
 # LEAN default (JSON with comments) that python's json.load cannot parse.
 # Used to seed LEAN_CONFIG before patching.
 LEAN_CONFIG_SEED="${LEAN_LAUNCHER}/config.json"
+# Shared helper shipped into the container by Dockerfile.lean. Both the
+# reference generator (host-side) and this runner import the same patch
+# logic so the two code paths cannot drift apart (see issue #33).
+# Derived from LEAN_ROOT so the one-variable layout override covers the
+# helper too (e.g. LEAN_ROOT=/Lean puts helpers under /Lean/helpers).
+LEAN_HELPERS_DIR="${LEAN_HELPERS_DIR:-${LEAN_ROOT}/helpers}"
 RESULTS_DIR="/workspace/results"
-# Location LEAN's JobQueue loads the compiled algorithm from. Must be written
-# into config.json as `algorithm-location` or the Launcher crashes with
-# System.ArgumentException: empty path.
-LEAN_ALGO_DLL="${LEAN_OUTPUT_DIR}/QuantConnect.Algorithm.CSharp.dll"
 
 # Per-backtest timeout in seconds (default 5 min, overridable via env var).
 # Exit code 124 = timeout killed.
@@ -182,15 +188,23 @@ echo "  -> Build succeeded"
 # Copy the compiled DLL to the Launcher directory where LEAN expects it.
 # dotnet build outputs to Algorithm.CSharp/bin/Debug/ but LEAN's JobQueue
 # loads from Launcher/QuantConnect.Algorithm.CSharp.dll.
-ALGO_DLL="${LEAN_ALGO_DIR}/bin/Debug/QuantConnect.Algorithm.CSharp.dll"
-if [ -f "$ALGO_DLL" ]; then
+# Discover via `find` to survive TFM bumps (net10.0 -> net11.0 -> ...) and
+# any csproj-level layout change: dotnet may drop the DLL either directly
+# under bin/Debug/ or inside a framework-specific subfolder.
+# `|| true` swallows pipefail exits when find returns nonzero (missing path)
+# or when head closes early (SIGPIPE to find after the first match). Without
+# it, `set -euo pipefail` terminates the runner before reaching the warning.
+ALGO_DLL=$(find "${LEAN_ALGO_DIR}/bin/Debug" -maxdepth 3 \
+    -name 'QuantConnect.Algorithm.CSharp.dll' -type f 2>/dev/null | head -1 || true)
+LEAN_ALGO_DLL="${LEAN_OUTPUT_DIR}/QuantConnect.Algorithm.CSharp.dll"
+if [ -n "$ALGO_DLL" ] && [ -f "$ALGO_DLL" ]; then
     cp "$ALGO_DLL" "${LEAN_LAUNCHER}/QuantConnect.Algorithm.CSharp.dll"
     # LEAN's Composer loads assemblies from Launcher/bin/Debug/, not Launcher/.
     # Both locations must have the freshly compiled DLL.
-    cp "$ALGO_DLL" "${LEAN_LAUNCHER}/bin/Debug/QuantConnect.Algorithm.CSharp.dll"
-    echo "  -> Copied DLL to Launcher directory"
+    cp "$ALGO_DLL" "$LEAN_ALGO_DLL"
+    echo "  -> Copied DLL from $ALGO_DLL"
 else
-    echo "WARNING: Compiled DLL not found at $ALGO_DLL"
+    echo "WARNING: Compiled DLL not found under ${LEAN_ALGO_DIR}/bin/Debug"
 fi
 
 # ── Step 2b: Reset and inject parameters into config.json ─────────────
@@ -207,53 +221,40 @@ _PARAMS_TMPFILE=$(mktemp /tmp/params_XXXXXX.json)
 printf '%s' "$PARAMS_JSON" > "$_PARAMS_TMPFILE"
 export _PARAMS_TMPFILE
 python3 -c "
-import json, os
+import json, os, sys
+
+# Shared helper shipped at /lean/helpers/lean_config.py by Dockerfile.lean.
+# Keeps this runner and the reference generator in lockstep on which keys
+# steer the LEAN Launcher (see issue #33).
+sys.path.insert(0, '$LEAN_HELPERS_DIR')
+import lean_config
 
 with open('$LEAN_CONFIG') as f:
     cfg = json.load(f)
 
 params_file = os.environ.get('_PARAMS_TMPFILE', '')
+params = {}
 if params_file and os.path.isfile(params_file):
     raw = open(params_file).read().strip()
-    params = json.loads(raw) if raw else {}
-else:
-    params = {}
+    if raw:
+        params = json.loads(raw)
 
-# Inject default fee rates (both modes — matches MatchX compiler.py behavior).
-params.setdefault('maker-fee-rate', '0.0002')
-params.setdefault('taker-fee-rate', '0.0005')
-
-data_mode = '$DATA_MODE'
-params.setdefault('custom-data-root', '/data/custom/binance')
-
-cfg['parameters'] = params
-
-# Point LEAN results to the run-specific directory
-cfg['results-destination-folder'] = '$RESULTS_DIR'
-
-# Use submitted class name if provided, else fall back to 'Algorithm'.
-# MatchX uses the submitted strategy_class_name; benchmark previously
-# hardcoded 'Algorithm'.  With --class-name, both paths align.
-class_name = '$CLASS_NAME' or 'Algorithm'
-full_type_name = '$FULL_TYPE_NAME'
-if full_type_name:
-    cfg['algorithm-type-name'] = full_type_name
-else:
-    cfg['algorithm-type-name'] = f'QuantConnect.Algorithm.CSharp.{class_name}'
-
-# Point the Launcher at the freshly copied DLL. Without this the base image's
-# empty default crashes JobQueue.NextJob with an empty-string path.
-cfg['algorithm-location'] = '$LEAN_ALGO_DLL'
+lean_config.apply_session_overrides(
+    cfg,
+    class_name='$CLASS_NAME',
+    full_type_name='$FULL_TYPE_NAME',
+    dll_path='$LEAN_ALGO_DLL',
+    results_dir='$RESULTS_DIR',
+    parameters=params,
+)
 
 with open('$LEAN_CONFIG', 'w') as f:
     json.dump(cfg, f, indent=2)
 
-print(f'  -> Set {len(params)} parameter(s)')
-print(f'  -> Data mode: {data_mode}')
-if full_type_name:
-    print(f'  -> Full type name: {full_type_name}')
-else:
-    print(f'  -> Class name: {class_name}')
+print(f'  -> algorithm-type-name: {cfg[\"algorithm-type-name\"]}')
+print(f'  -> algorithm-location:  {cfg[\"algorithm-location\"]}')
+print(f'  -> Data mode: $DATA_MODE')
+print(f'  -> Parameters: {len(cfg[\"parameters\"])}')
 print(f'  -> Results folder: $RESULTS_DIR')
 " 2>&1
 rm -f "$_PARAMS_TMPFILE"

--- a/bench/orchestrator/container_manager.py
+++ b/bench/orchestrator/container_manager.py
@@ -197,6 +197,34 @@ class ContainerManager:
                     capture_output=True,
                 )
 
+            # Inject shared lean_config.py helper. run_backtest.sh imports this
+            # from /lean/helpers/lean_config.py; without it, containers built
+            # before the helper existed raise ModuleNotFoundError at [2b/4].
+            lean_config_py = Path(__file__).parent.parent / "docker" / "lean_config.py"
+            if lean_config_py.exists():
+                subprocess.run(
+                    [
+                        "docker",
+                        "exec",
+                        "--user",
+                        "root",
+                        container_id,
+                        "mkdir",
+                        "-p",
+                        "/lean/helpers",
+                    ],
+                    capture_output=True,
+                )
+                subprocess.run(
+                    [
+                        "docker",
+                        "cp",
+                        str(lean_config_py),
+                        f"{container_id}:/lean/helpers/lean_config.py",
+                    ],
+                    capture_output=True,
+                )
+
             # Inject the latest 12-col strategy injector so run_backtest.sh does
             # not fall back to the stale image copy or skip injection entirely.
             inject_strategy_py = (

--- a/bench/reference_generator/generate_lean_reference.py
+++ b/bench/reference_generator/generate_lean_reference.py
@@ -34,6 +34,13 @@ SCRIPT_DIR = Path(__file__).parent
 BENCH_ROOT = SCRIPT_DIR.parent
 REFERENCE_ROOT = BENCH_ROOT / "reference"  # bench/reference/
 
+# Shared LEAN config helper — the same module Dockerfile.lean copies to
+# /lean/helpers/lean_config.py inside the container, so reference generation
+# (host) and session backtests (container) cannot drift on which keys get
+# written to config.json.
+sys.path.insert(0, str(BENCH_ROOT / "docker"))
+import lean_config  # noqa: E402
+
 # Series prefix → subdirectory mapping
 _SERIES_SUBDIR = {
     "I": "Implementation",
@@ -300,12 +307,14 @@ def _ensure_lean_runtime() -> tuple[str, str]:
     sys.exit(1)
 
 
-def _build_lean_config(
-    class_name: str, algo_filename: str, start_date: str, end_date: str
-) -> dict:
-    """Build a LEAN configuration for the backtest.
+def _build_lean_config(start_date: str, end_date: str) -> dict:
+    """LEAN scaffolding (environments, handlers, data paths, dates).
 
-    Aligned with MatchX cloud backtest lean-config.json template.
+    Aligned with MatchX cloud backtest lean-config.json template. Session-
+    specific keys — ``algorithm-type-name``, ``algorithm-location``,
+    ``parameters`` — are filled in by ``lean_config.apply_session_overrides``
+    so both the reference generator and the in-container session runner use
+    the same patch logic.
     """
     return {
         "environment": "backtesting",
@@ -320,10 +329,7 @@ def _build_lean_config(
                 "history-provider": "QuantConnect.Lean.Engine.HistoricalData.SubscriptionDataReaderHistoryProvider",
             }
         },
-        "algorithm-type-name": class_name,
         "algorithm-language": "CSharp",
-        "algorithm-location": f"/Lean/Algorithm.CSharp/{algo_filename}",
-        "parameters": {},
         "data-folder": "/Lean/Data",
         "data-directory": "/Lean/Data",
         "results-destination-folder": "/Results",
@@ -638,18 +644,23 @@ def run_lean_backtest(
                     print(f"  Copied {supp_filename} to algo mount dir")
                     break
 
-        # Write LEAN config — point to compiled DLL
+        # Write LEAN config — point to compiled DLL.
+        # Reference generator uses a symmetric 0.0005 maker/taker fee for parity
+        # with MatchX cloud backtests, overriding the shared helper's session
+        # default of 0.0002 maker.
         dll_path = "/CustomAlgo/bin/Debug/net10.0/CustomAlgo.dll"
-        config = _build_lean_config(class_name, algo_file.name, start_date, end_date)
-        config["algorithm-location"] = dll_path
-        # Inject custom data root for 12-col data
-        config.setdefault("parameters", {})
-        config["parameters"]["custom-data-root"] = "/data/custom/binance"
-        config["parameters"]["maker-fee-rate"] = "0.0005"
-        config["parameters"]["taker-fee-rate"] = "0.0005"
-        # Merge task-specific parameters into config
-        if parameters:
-            config["parameters"] = {**config.get("parameters", {}), **parameters}
+        config = _build_lean_config(start_date, end_date)
+        ref_fees = {"maker-fee-rate": "0.0005", "taker-fee-rate": "0.0005"}
+        # class_name here is already a fully qualified name (see class_name_map
+        # above, e.g. "QuantTutorBench.I01ImplementSma"). Pass through
+        # full_type_name so the helper doesn't re-prefix it with
+        # QuantConnect.Algorithm.CSharp.*.
+        lean_config.apply_session_overrides(
+            config,
+            full_type_name=class_name,
+            dll_path=dll_path,
+            parameters={**ref_fees, **(parameters or {})},
+        )
         config_path = os.path.join(config_dir, "config.json")
         with open(config_path, "w") as f:
             json.dump(config, f, indent=2)

--- a/bench/server/core/container.py
+++ b/bench/server/core/container.py
@@ -210,6 +210,36 @@ class ContainerManager:
                     capture_output=True,
                 )
 
+            # Inject shared lean_config.py helper. run_backtest.sh imports this
+            # from /lean/helpers/lean_config.py; without it, containers built
+            # before the helper existed raise ModuleNotFoundError at [2b/4].
+            lean_config_py = (
+                Path(__file__).parent.parent.parent / "docker" / "lean_config.py"
+            )
+            if lean_config_py.exists():
+                subprocess.run(
+                    [
+                        "docker",
+                        "exec",
+                        "--user",
+                        "root",
+                        container_id,
+                        "mkdir",
+                        "-p",
+                        "/lean/helpers",
+                    ],
+                    capture_output=True,
+                )
+                subprocess.run(
+                    [
+                        "docker",
+                        "cp",
+                        str(lean_config_py),
+                        f"{container_id}:/lean/helpers/lean_config.py",
+                    ],
+                    capture_output=True,
+                )
+
             inject_strategy_py = (
                 Path(__file__).parent.parent.parent / "scripts" / "inject_strategy.py"
             )

--- a/bench/tests/test_lean_config.py
+++ b/bench/tests/test_lean_config.py
@@ -1,0 +1,124 @@
+"""Tests for bench/docker/lean_config.py — the shared LEAN config helper.
+
+Locks down the behaviour both the in-container session runner
+(``bench/docker/run_backtest.sh``) and the host-side reference generator
+(``bench/reference_generator/generate_lean_reference.py``) depend on. Any
+divergence between the two callers reproduces the empty-``algorithm-location``
+crash that blocked session backtests on prod (issue #33).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "docker"))
+
+import lean_config  # noqa: E402
+
+
+class TestResolveAlgorithmTypeName:
+    def test_full_type_name_wins(self):
+        assert (
+            lean_config.resolve_algorithm_type_name(
+                class_name="Ignored", full_type_name="My.Ns.Algo"
+            )
+            == "My.Ns.Algo"
+        )
+
+    def test_class_name_gets_default_namespace(self):
+        assert (
+            lean_config.resolve_algorithm_type_name(class_name="SmaBaseline")
+            == "QuantConnect.Algorithm.CSharp.SmaBaseline"
+        )
+
+    def test_blank_inputs_fall_back_to_algorithm(self):
+        assert (
+            lean_config.resolve_algorithm_type_name()
+            == "QuantConnect.Algorithm.CSharp.Algorithm"
+        )
+
+
+class TestApplySessionOverrides:
+    def test_session_runner_shape_matches_run_backtest_sh(self):
+        """The ``bench/docker/run_backtest.sh`` call shape — bare class name,
+        explicit DLL + results dir, task parameters merged in."""
+        cfg = {"environment": "backtesting", "parameters": {"pre-existing": "keep"}}
+
+        result = lean_config.apply_session_overrides(
+            cfg,
+            class_name="SmaBaseline",
+            dll_path="/lean/Launcher/bin/Debug/QuantConnect.Algorithm.CSharp.dll",
+            results_dir="/workspace/results/sma_baseline",
+            parameters={"fast": "10", "slow": "30"},
+        )
+
+        # Mutates in place and also returns the same dict.
+        assert result is cfg
+        assert cfg["algorithm-type-name"] == "QuantConnect.Algorithm.CSharp.SmaBaseline"
+        assert (
+            cfg["algorithm-location"]
+            == "/lean/Launcher/bin/Debug/QuantConnect.Algorithm.CSharp.dll"
+        )
+        assert cfg["results-destination-folder"] == "/workspace/results/sma_baseline"
+
+        # Default fees + custom-data-root appear; task params merge in;
+        # pre-existing `parameters` is replaced wholesale because the session
+        # runner always rewrites the block from the merged defaults.
+        assert cfg["parameters"]["maker-fee-rate"] == "0.0002"
+        assert cfg["parameters"]["taker-fee-rate"] == "0.0005"
+        assert cfg["parameters"]["custom-data-root"] == "/data/custom/binance"
+        assert cfg["parameters"]["fast"] == "10"
+        assert cfg["parameters"]["slow"] == "30"
+        assert "pre-existing" not in cfg["parameters"]
+
+    def test_reference_generator_shape_preserves_fqn_and_ref_fees(self):
+        """``bench/reference_generator/generate_lean_reference.py`` passes the
+        already-fully-qualified class name via ``full_type_name`` and supplies
+        its own symmetric 0.0005 fees."""
+        cfg = {"environment": "backtesting", "start-date": "2022-01-01"}
+
+        ref_fees = {"maker-fee-rate": "0.0005", "taker-fee-rate": "0.0005"}
+        lean_config.apply_session_overrides(
+            cfg,
+            full_type_name="QuantTutorBench.I01ImplementSma",
+            dll_path="/CustomAlgo/bin/Debug/net10.0/CustomAlgo.dll",
+            parameters=ref_fees,
+        )
+
+        # The reference FQN passes through unchanged — no default namespace
+        # re-prefix.
+        assert cfg["algorithm-type-name"] == "QuantTutorBench.I01ImplementSma"
+        assert cfg["algorithm-location"] == "/CustomAlgo/bin/Debug/net10.0/CustomAlgo.dll"
+
+        # Reference overrides win over session defaults.
+        assert cfg["parameters"]["maker-fee-rate"] == "0.0005"
+        assert cfg["parameters"]["taker-fee-rate"] == "0.0005"
+        assert cfg["parameters"]["custom-data-root"] == "/data/custom/binance"
+
+        # Reference generator doesn't pass results_dir; helper must not touch
+        # whatever the scaffolding already set.
+        assert "results-destination-folder" not in cfg
+
+    def test_empty_dll_path_leaves_algorithm_location_untouched(self):
+        """Callers that seed ``algorithm-location`` elsewhere (e.g. a
+        scaffolding default) should be safe to call the helper without it."""
+        cfg = {"algorithm-location": "/some/preexisting.dll"}
+        lean_config.apply_session_overrides(cfg, class_name="Algo")
+        assert cfg["algorithm-location"] == "/some/preexisting.dll"
+
+    def test_empty_parameters_still_gets_defaults(self):
+        cfg: dict = {}
+        lean_config.apply_session_overrides(cfg, class_name="Algo")
+        assert cfg["parameters"]["maker-fee-rate"] == "0.0002"
+        assert cfg["parameters"]["taker-fee-rate"] == "0.0005"
+        assert cfg["parameters"]["custom-data-root"] == "/data/custom/binance"
+
+    def test_task_params_can_override_default_fees(self):
+        cfg: dict = {}
+        lean_config.apply_session_overrides(
+            cfg, class_name="Algo", parameters={"maker-fee-rate": "0.0001"}
+        )
+        assert cfg["parameters"]["maker-fee-rate"] == "0.0001"
+        # Untouched defaults still present.
+        assert cfg["parameters"]["taker-fee-rate"] == "0.0005"


### PR DESCRIPTION
## Summary
- **Phase 1 hotfix (`8ecae95`)** — seed `bin/Debug/config.json` from the benchmark's comment-free template and write `algorithm-location` alongside `algorithm-type-name`. Unblocks `run_lean_backtest` on prod: the Launcher was crashing in `JobQueue.NextJob` with `System.ArgumentException: empty path` because the runner was patching the wrong `config.json` and never writing the DLL path.
- **Phase 2 cleanup (`15d6ccf`)** — new shared `bench/docker/lean_config.py` helper imported by both the in-container session runner and the host-side reference generator so the two can't drift apart again. Adds `LEAN_ROOT` / `LEAN_HELPERS_DIR` env knobs for non-default image layouts, pipefail-safe DLL discovery via `find` (survives TFM bumps), and makes both container-refresh hot-patch paths copy the helper so existing images work without a rebuild.
- **Phase 2e + 2f (`203aaed`)** — pytest coverage for the helper (8 tests, locks both call shapes) and a Step 8 reproduction recipe in the top-level README for HuggingFace reproducers.

Closes #33. Unblocks the `open-source-release` milestone.

## Test plan
- [x] `pytest bench/tests/test_lean_config.py -v` — 8/8 pass locally.
- [x] Shell syntax: `bash -n bench/docker/run_backtest.sh`.
- [x] Python syntax: `py_compile` on `lean_config.py`, `generate_lean_reference.py`, both container-refresh call sites.
- [x] Three rounds of `codex-review` on Phase 2; findings (all P1/P2 bug-chain + one consistency P3) folded in.
- [ ] Deploy-side: after merging dev → master, re-run the same minimal SMA baseline on prod that crashed this morning; expect exit 0, non-empty `summary.json`, ≥ 1 filled order.