### PR TITLE
docs(lean): align v4.0 doc with post-#33 runner architecture

### DIFF
--- a/docs/v4.0-12col-backtest-system.md
+++ b/docs/v4.0-12col-backtest-system.md
@@ -170,6 +170,30 @@ When `--data-mode custom`:
    - `taker-fee-rate`: `0.0005`
    - `custom-data-root`: `/data/custom`
 
+#### Post-v4.0 hardening (see issue #33)
+
+- Config patches are applied to the **project-source** `config.json`
+  (`${LEAN_ROOT}/Launcher/config.json`), not the `bin/Debug/config.json`
+  copy. The runner launches LEAN with `dotnet run --no-build -c Debug`
+  from `${LEAN_ROOT}/Launcher`, so the engine's relative `config.json`
+  lookup resolves to the source file. The reference generator's path
+  is different — it invokes the Launcher DLL directly from bin/Debug,
+  so it writes its own config there.
+- The runner now writes both `algorithm-type-name` **and**
+  `algorithm-location` (pointing at the freshly copied DLL). Missing
+  `algorithm-location` was the cause of LEAN's
+  `JobQueue.NextJob … ReadAllBytes("")` crash.
+- Config patching is delegated to `bench/docker/lean_config.py` —
+  one helper imported by both this runner and
+  `bench/reference_generator/generate_lean_reference.py` so the two
+  can't drift apart.
+- Container/image layout is parametrised via `LEAN_ROOT` (default
+  `/lean`) and `LEAN_HELPERS_DIR` (default `${LEAN_ROOT}/helpers`).
+  Forks with a capitalised `/Lean` layout only need to set one env
+  var.
+- Compiled-DLL discovery uses `find` instead of a hardcoded path so
+  TFM bumps (net10.0 → net11.0 → …) don't break the runner.
+
 ### MCP Tool: `run_lean_backtest()`
 
 New optional parameters:


### PR DESCRIPTION
## Summary
Post-facto doc alignment after #33 and #25 closed. Adds a short "Post-v4.0 hardening" block to \`docs/v4.0-12col-backtest-system.md\` covering:
- which \`config.json\` the session runner actually patches and why it differs from the reference generator;
- the shared \`bench/docker/lean_config.py\` helper;
- the \`LEAN_ROOT\` / \`LEAN_HELPERS_DIR\` env knobs;
- \`find\`-based DLL discovery.

No code changes. Closes the doc-alignment loose end left open by issue #33's close-out.

## Test plan
- [x] Codex review clean — no findings.
- [x] README.md + PROTOCOL.md already updated under #33 / #25 respectively; this completes the doc surface.