### PR TITLE
fix(deps): declare nest_asyncio explicitly (#39)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,11 @@ openai>=1.0.0
 aiohttp>=3.8.0
 tenacity>=8.0.0
 
+# Eval path needs nest_asyncio to run deepeval metrics inside the running
+# event loop (see bench/evaluation/*/async_utils.py). Previously reached
+# prod as a transitive dep; declared explicitly to stop regressions (#39).
+nest_asyncio>=1.6.0
+
 # Utilities
 python-dotenv>=1.0.0
 tqdm>=4.65.0


### PR DESCRIPTION
Closes #39. One-line deps addition — `nest_asyncio` was imported by `bench/evaluation/*/async_utils.py` but never declared; prod lost the transitive pin and every eval fails with ModuleNotFoundError. Adds `nest_asyncio>=1.6.0` to `requirements.txt` so the deploy pip-install picks it up.