### PR TITLE
chore: promote dev → master (nest_asyncio fix + doc alignment)

### DIFF
--- a/docs/v4.0-12col-backtest-system.md
+++ b/docs/v4.0-12col-backtest-system.md
@@ -170,6 +170,30 @@ When `--data-mode custom`:
    - `taker-fee-rate`: `0.0005`
    - `custom-data-root`: `/data/custom`
 
+#### Post-v4.0 hardening (see issue #33)
+
+- Config patches are applied to the **project-source** `config.json`
+  (`${LEAN_ROOT}/Launcher/config.json`), not the `bin/Debug/config.json`
+  copy. The runner launches LEAN with `dotnet run --no-build -c Debug`
+  from `${LEAN_ROOT}/Launcher`, so the engine's relative `config.json`
+  lookup resolves to the source file. The reference generator's path
+  is different — it invokes the Launcher DLL directly from bin/Debug,
+  so it writes its own config there.
+- The runner now writes both `algorithm-type-name` **and**
+  `algorithm-location` (pointing at the freshly copied DLL). Missing
+  `algorithm-location` was the cause of LEAN's
+  `JobQueue.NextJob … ReadAllBytes("")` crash.
+- Config patching is delegated to `bench/docker/lean_config.py` —
+  one helper imported by both this runner and
+  `bench/reference_generator/generate_lean_reference.py` so the two
+  can't drift apart.
+- Container/image layout is parametrised via `LEAN_ROOT` (default
+  `/lean`) and `LEAN_HELPERS_DIR` (default `${LEAN_ROOT}/helpers`).
+  Forks with a capitalised `/Lean` layout only need to set one env
+  var.
+- Compiled-DLL discovery uses `find` instead of a hardcoded path so
+  TFM bumps (net10.0 → net11.0 → …) don't break the runner.
+
 ### MCP Tool: `run_lean_backtest()`
 
 New optional parameters:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,11 @@ openai>=1.0.0
 aiohttp>=3.8.0
 tenacity>=8.0.0
 
+# Eval path needs nest_asyncio to run deepeval metrics inside the running
+# event loop (see bench/evaluation/*/async_utils.py). Previously reached
+# prod as a transitive dep; declared explicitly to stop regressions (#39).
+nest_asyncio>=1.6.0
+
 # Utilities
 python-dotenv>=1.0.0
 tqdm>=4.65.0


### PR DESCRIPTION
Ships: #40 nest_asyncio explicit dep (unblocks prod eval), #38 post-#33/#25 doc alignment. After deploy the GHA workflow will trigger the deps-install step because requirements.txt changed; session eval will unblock.