### PR TITLE
fix(eval): surface per-component errors via /scores (#42 secondary)

### DIFF
--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -667,15 +667,16 @@ class BenchSessionManager:
         if latest_meta.exists():
             try:
                 meta = json.loads(latest_meta.read_text(encoding="utf-8"))
-                return {
-                    "status": "completed",
-                    "scores": {
-                        "quant_result": meta.get("quant_result", 0.0),
-                        "quant_process": meta.get("quant_process", 0.0),
-                        "tutor_scores": meta.get("tutor_scores", {}),
-                        "overall": meta.get("overall_score", 0.0),
-                    },
+                scores: dict = {
+                    "quant_result": meta.get("quant_result", 0.0),
+                    "quant_process": meta.get("quant_process", 0.0),
+                    "tutor_scores": meta.get("tutor_scores", {}),
+                    "overall": meta.get("overall_score", 0.0),
                 }
+                meta_errors = meta.get("errors")
+                if meta_errors:
+                    scores["errors"] = meta_errors
+                return {"status": "completed", "scores": scores}
             except Exception:
                 pass
 

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -268,6 +268,9 @@ class SessionState:
                     "tutor_scores": meta.get("tutor_scores", {}),
                     "overall": meta.get("overall_score", 0.0),
                 }
+                meta_errors = meta.get("errors")
+                if meta_errors:
+                    state._eval_results["errors"] = meta_errors
             except Exception:
                 pass
 
@@ -1147,12 +1150,20 @@ class SessionState:
                 tutor_dims=self._tutor_dims,
             )
 
-            # Build scores summary for API response
+            # Build scores summary for API response. Include per-component
+            # errors so callers seeing an empty tutor_scores / zeroed
+            # quant_result can tell whether it's a genuine zero or a silent
+            # failure upstream (see issue #42).
+            from server.storage.eval_writer import _collect_eval_errors
+
             scores_summary: dict = {
                 "quant_result": eval_results.get("quant_result", 0.0),
                 "quant_process": eval_results.get("quant_process", 0.0),
                 "tutor_scores": eval_results.get("tutor_scores", {}),
             }
+            eval_errors = _collect_eval_errors(eval_results)
+            if eval_errors:
+                scores_summary["errors"] = eval_errors
 
             # Try to compute overall composite score
             try:

--- a/bench/server/storage/eval_writer.py
+++ b/bench/server/storage/eval_writer.py
@@ -25,6 +25,32 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
+# Maps internal error-stash keys produced by `pipeline.evaluate_task` onto
+# the short component name exposed in eval_meta.json + the /scores payload.
+# See issue #42 — the tutor path uses `_eval_error` while quant_result /
+# code_eval use `_error`, so an ad-hoc suffix strip would mangle them.
+_EVAL_ERROR_KEYS: dict[str, str] = {
+    "tutor_eval_error": "tutor",
+    "quant_result_error": "quant_result",
+    "code_eval_error": "code_eval",
+    "tool_usage_error": "tool_usage",
+}
+
+
+def _collect_eval_errors(eval_results: dict) -> dict:
+    """Return a component → error-text dict for every silently-failed eval.
+
+    Keys are the short component name so the API surface reads cleanly
+    and callers can tell an empty/zeroed score apart from a genuine zero.
+    """
+    out: dict = {}
+    for internal, public in _EVAL_ERROR_KEYS.items():
+        msg = eval_results.get(internal)
+        if msg:
+            out[public] = str(msg)
+    return out
+
+
 def run_evaluation(
     task,
     persona,
@@ -120,6 +146,11 @@ def run_evaluation(
     )
 
     # --- Write eval_meta.json ---
+    # Collect per-component errors so callers can see *why* a dimension is
+    # empty/zero (see issue #42). `pipeline.evaluate_task` stores each
+    # component's exception text under its own key when that component
+    # silently fell back to an empty/default score.
+    errors = _collect_eval_errors(eval_results)
     meta = {
         "timestamp": ts,
         "eval_model": eval_model,
@@ -130,6 +161,8 @@ def run_evaluation(
         "tutor_scores": eval_results.get("tutor_scores", {}),
         "overall_score": scores.get("overall_score", 0.0),
     }
+    if errors:
+        meta["errors"] = errors
     meta_path = eval_dir / "eval_meta.json"
     meta_path.write_text(json.dumps(meta, indent=2, default=str), encoding="utf-8")
     logger.info("Saved eval_meta.json to %s", meta_path)

--- a/bench/tests/unit/test_eval_error_surface.py
+++ b/bench/tests/unit/test_eval_error_surface.py
@@ -1,0 +1,75 @@
+"""Tests for issue #42 — silent eval-component failures must surface.
+
+`pipeline.evaluate_task` catches per-component exceptions (missing rubric,
+failed result judge, failed code eval) and returns an empty/zero score
+with the error text stashed under `{component}_eval_error` in eval_results.
+Before this fix those error strings were dropped before reaching
+`eval_meta.json` or `/session/{sid}/scores`, leaving callers with empty
+`tutor_scores: {}` and no way to tell if it was a genuine zero or a
+silent upstream failure.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from server.storage.eval_writer import _collect_eval_errors
+
+
+class TestCollectEvalErrors:
+    def test_empty_results_returns_empty_dict(self):
+        assert _collect_eval_errors({}) == {}
+
+    def test_results_without_error_keys_returns_empty_dict(self):
+        assert _collect_eval_errors({"quant_result": 0.7, "tutor_scores": {}}) == {}
+
+    def test_tutor_error_is_surfaced_without_suffix(self):
+        out = _collect_eval_errors(
+            {"tutor_eval_error": "Rubric file not found: /path/rubric.json"}
+        )
+        assert out == {"tutor": "Rubric file not found: /path/rubric.json"}
+
+    def test_multiple_errors_coexist(self):
+        out = _collect_eval_errors(
+            {
+                "tutor_eval_error": "Rubric missing",
+                "quant_result_error": "eval_script crashed",
+                "code_eval_error": "reference store timeout",
+                "tool_usage_error": "registry lookup failed",
+            }
+        )
+        assert out == {
+            "tutor": "Rubric missing",
+            "quant_result": "eval_script crashed",
+            "code_eval": "reference store timeout",
+            "tool_usage": "registry lookup failed",
+        }
+
+    def test_tool_usage_error_surfaces_standalone(self):
+        # Tool-usage eval feeds quant_process; when it fails silently the
+        # QP score comes back derived/default and callers have no way to
+        # tell unless the error is surfaced alongside.
+        assert _collect_eval_errors({"tool_usage_error": "boom"}) == {
+            "tool_usage": "boom"
+        }
+
+    def test_non_string_error_is_stringified(self):
+        err = ValueError("bad")
+        out = _collect_eval_errors({"tutor_eval_error": err})
+        assert out == {"tutor": "bad"}
+
+    def test_empty_string_error_is_ignored(self):
+        # Guard against a no-op error stash producing a misleading key.
+        assert _collect_eval_errors({"tutor_eval_error": ""}) == {}
+
+    def test_none_error_is_ignored(self):
+        assert _collect_eval_errors({"tutor_eval_error": None}) == {}
+
+    def test_unknown_error_keys_are_not_surfaced(self):
+        # Only the three known component keys propagate; anything else is
+        # left in eval_results for internal use but does not leak to the
+        # API surface.
+        assert _collect_eval_errors({"some_other_error": "nope"}) == {}


### PR DESCRIPTION
## Summary
Secondary-bug fix from #42. When \`pipeline.evaluate_task\` catches a silent component failure (missing tutor rubric, crashed eval script, etc.), the error text now propagates to \`eval_meta.json\` and \`/session/{sid}/scores\` under an \`errors: {component: message}\` dict instead of being buried in \`scores.md\`.

This alone wouldn't have surfaced today's missing-rubric bug — \`scores.md\` had it. But it means the next silent fallback in any of the four components (tutor / quant_result / code_eval / tool_usage) is visible at the REST surface without spelunking on-disk reports.

## Test plan
- [x] \`pytest bench/tests/unit/test_eval_error_surface.py -v\` — 9/9 pass locally. Covers: empty results, single errors per component, co-existence, stringification of non-string exceptions, empty/None ignored, unknown keys filtered, and the \`tool_usage_error\` path (caught by Codex review round 1).
- [x] Two rounds of Codex review. Round 1 caught a missing allow-list entry for \`tool_usage_error\` — folded in. Round 2 clean for the change; only finding is a pre-existing credential-in-stdout issue in \`refresh_mcp_token.sh\` which is unrelated to #42 — filed as #43.
- [ ] Deploy-side: after merge + redeploy, kick a fresh I01 session + force-eval with the current rubric gap → confirm \`/scores\` returns \`{tutor_scores: {}, errors: {tutor: \"Rubric file not found: …\"}}\` instead of silently empty.

## Out of scope
Primary bug (missing persona-specific rubrics) remains open under #42 — needs content authoring or a fallback decision.