### PR TITLE
Merge dev → master: batch evaluator (#47)

### DIFF
--- a/bench/server/evaluator/__init__.py
+++ b/bench/server/evaluator/__init__.py
@@ -1,16 +1,29 @@
 """Offline evaluator for QuantTutorBench bundles.
 
 Reads bundles produced by ``server.storage.result_writer.save_run_state``
-and writes scores to a parallel ``evaluations/server/...`` tree. After
-#46 slice 4 this is the single scoring entry point — the operator REST
-surface (``/ops/session/{sid}/evaluate``) and the CLI
-(``python -m server.evaluator``) both call ``score_bundle`` directly.
-The live session no longer holds any eval state.
+and writes scores to a parallel ``evaluations/server/...`` tree.
 
-See ``server/storage/BUNDLE_SCHEMA.md`` for the bundle contract and issue
-#46 for the producer/consumer split this module implements.
+Entry points:
+
+- ``score_bundle`` — score one bundle synchronously (REST + CLI single mode).
+- ``run_campaign`` — batch driver that fans ``score_bundle`` over many
+  bundles with concurrency and idempotency (issue #47).
+
+See ``server/storage/BUNDLE_SCHEMA.md`` for the bundle contract.
 """
 
+from server.evaluator.batch import (
+    BundleOutcome,
+    CampaignSummary,
+    resolve_bundles,
+    run_campaign,
+)
 from server.evaluator.single import score_bundle
 
-__all__ = ["score_bundle"]
+__all__ = [
+    "score_bundle",
+    "run_campaign",
+    "resolve_bundles",
+    "BundleOutcome",
+    "CampaignSummary",
+]

--- a/bench/server/evaluator/__main__.py
+++ b/bench/server/evaluator/__main__.py
@@ -1,16 +1,19 @@
 """CLI entrypoint for the offline evaluator.
 
-Usage::
+Single-bundle mode::
 
-    python -m server.evaluator --bundle /path/to/bundle/dir
-    python -m server.evaluator --bundle /path/to/bundle --eval-mode qr_only
-    python -m server.evaluator --bundle /path/to/bundle --bench-root /path/to/bench
+    python -m server.evaluator --bundle /path/to/bundle
 
-Scores a single bundle and writes the result tree under
-``{bench_root}/evaluations/server/{task_id}/{persona_id}/{sid8}/{eval_run_id}/``.
+Batch mode (issue #47)::
 
-Batch invocation (``--all-pending``, concurrency, rate-limit pooling) is
-issue #47 and lands on top of this single-bundle driver.
+    python -m server.evaluator --all-pending --concurrency 8
+    python -m server.evaluator --session <sid> --force
+    python -m server.evaluator --task-id I01 --persona fullstack_practitioner
+    python -m server.evaluator --bundles-from bundles.txt --dry-run
+
+Batch mode writes per-bundle outputs to the sibling tree and a
+campaign-level manifest at
+``{bench_root}/evaluations/campaigns/{campaign_id}/summary.json``.
 """
 
 from __future__ import annotations
@@ -20,7 +23,13 @@ import json
 import logging
 import sys
 from pathlib import Path
+from typing import Callable
 
+from server.evaluator.batch import (
+    BundleOutcome,
+    resolve_bundles,
+    run_campaign,
+)
 from server.evaluator.single import score_bundle
 from server.storage.bundle import load_bundle
 
@@ -28,7 +37,6 @@ from server.storage.bundle import load_bundle
 def _resolve_bench_root(arg_value: str | None) -> Path:
     if arg_value:
         return Path(arg_value).resolve()
-    # Walk up from this file: bench/server/evaluator/__main__.py → bench/
     return Path(__file__).resolve().parents[2]
 
 
@@ -50,58 +58,120 @@ def _load_persona(bench_root: Path, persona_id: str):
     )
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(prog="python -m server.evaluator")
-    parser.add_argument(
-        "--bundle",
-        required=True,
-        help="Bundle directory written by save_run_state (must contain manifest.json).",
-    )
-    parser.add_argument(
-        "--bench-root",
-        default=None,
-        help="Repo root (defaults to the bench/ this module ships in).",
-    )
-    parser.add_argument(
+def _memoize(fn: Callable):
+    cache: dict = {}
+
+    def wrapped(key):
+        if key not in cache:
+            cache[key] = fn(key)
+        return cache[key]
+
+    return wrapped
+
+
+def _make_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="python -m server.evaluator")
+    p.add_argument("--bench-root", default=None, help="Repo root (defaults to bench/).")
+    p.add_argument(
         "--eval-model",
+        "--judge",
+        dest="eval_model",
         default="anthropic/claude-sonnet-4-6",
-        help="Judge LLM identifier passed to the pipeline.",
+        help="Judge LLM identifier.",
     )
-    parser.add_argument(
+    p.add_argument(
         "--eval-mode",
         default="full",
         choices=["full", "qr_only", "qp_only", "tutor_only"],
     )
-    parser.add_argument(
+    p.add_argument(
         "--tutor-dim",
         action="append",
         default=None,
         help="Restrict tutor scoring to one dimension; repeat for several.",
     )
-    parser.add_argument(
+    p.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable INFO logging."
+    )
+
+    # Selectors (at least one required)
+    p.add_argument("--bundle", default=None, help="Single bundle directory (legacy single-bundle mode).")
+    p.add_argument(
+        "--session",
+        action="append",
+        default=None,
+        help="Target session id(s). Repeat for several.",
+    )
+    p.add_argument(
+        "--task-id",
+        action="append",
+        default=None,
+        help="Filter bundles by task id. Repeat for several.",
+    )
+    p.add_argument(
+        "--persona",
+        action="append",
+        default=None,
+        help="Filter bundles by persona id. Repeat for several.",
+    )
+    p.add_argument(
+        "--bundles-from",
+        default=None,
+        help="File with one bundle path per line.",
+    )
+    p.add_argument(
+        "--all-pending",
+        action="store_true",
+        help="Score every bundle that lacks a sibling eval run with the same config.",
+    )
+    p.add_argument(
+        "--all",
+        action="store_true",
+        help="Score every bundle under results/server (combine with --force to redo).",
+    )
+
+    # Single-mode extra knob
+    p.add_argument(
         "--eval-run-id",
         default=None,
-        help="Override the auto-generated eval_run_id (use for reruns).",
+        help="Override the auto-generated eval_run_id (single-bundle mode).",
     )
-    parser.add_argument(
-        "-v",
-        "--verbose",
+
+    # Batch controls
+    p.add_argument("--concurrency", type=int, default=4, help="Parallel workers.")
+    p.add_argument(
+        "--rubric-version", default="", help="Rubric version tag (stamped into config_hash)."
+    )
+    p.add_argument(
+        "--formula-version",
+        default="",
+        help="OAS formula version tag (stamped into config_hash).",
+    )
+    p.add_argument(
+        "--skip-scored",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Skip bundles already scored with the same config (default on).",
+    )
+    p.add_argument(
+        "--force",
         action="store_true",
-        help="Enable INFO logging from the evaluator + pipeline.",
+        help="Re-score bundles even if a matching eval already exists.",
     )
-    args = parser.parse_args(argv)
-
-    logging.basicConfig(
-        level=logging.INFO if args.verbose else logging.WARNING,
-        format="%(levelname)s %(name)s: %(message)s",
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve + print planned work; do not score.",
     )
+    return p
 
-    bench_root = _resolve_bench_root(args.bench_root)
+
+def _run_single(args, bench_root: Path) -> int:
     bundle = load_bundle(args.bundle)
     task = _load_task(bench_root, bundle.task_id)
     persona = _load_persona(bench_root, bundle.persona_id)
 
-    results = score_bundle(
+    result = score_bundle(
         bundle_dir=bundle.bundle_dir,
         task=task,
         persona=persona,
@@ -111,10 +181,107 @@ def main(argv: list[str] | None = None) -> int:
         tutor_dims=args.tutor_dim,
         eval_run_id=args.eval_run_id,
     )
-
-    out_dir = results.get("_eval_run_dir")
-    print(f"scored: {bundle.session_id[:8]} → {out_dir}")
+    print(f"scored: {bundle.session_id[:8]} → {result.get('_eval_run_dir')}")
     return 0
+
+
+def _read_bundle_list(path: str) -> list[Path]:
+    out = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if s and not s.startswith("#"):
+            out.append(Path(s))
+    return out
+
+
+def _run_batch(args, bench_root: Path) -> int:
+    explicit_paths = (
+        _read_bundle_list(args.bundles_from) if args.bundles_from else None
+    )
+    bundles = resolve_bundles(
+        bench_root,
+        session_ids=args.session,
+        task_ids=args.task_id,
+        persona_ids=args.persona,
+        bundle_paths=explicit_paths,
+        all_bundles=args.all_pending or args.all,
+    )
+    if not bundles:
+        print("No bundles matched the given filters.")
+        return 0
+
+    print(f"Resolved {len(bundles)} bundles.")
+
+    def _progress(outcome: BundleOutcome, done: int, total: int) -> None:
+        tag = outcome.status.upper()
+        sid = (outcome.session_id or "?")[:8]
+        msg = f"[{done}/{total}] {tag} {outcome.task_id}/{outcome.persona_id}/{sid}"
+        if outcome.overall_score is not None:
+            msg += f" OAS={outcome.overall_score}"
+        if outcome.error:
+            msg += f" ERR={outcome.error}"
+        print(msg)
+
+    summary = run_campaign(
+        bench_root=bench_root,
+        bundles=bundles,
+        task_loader=_memoize(lambda tid: _load_task(bench_root, tid)),
+        persona_loader=_memoize(lambda pid: _load_persona(bench_root, pid)),
+        eval_model=args.eval_model,
+        eval_mode=args.eval_mode,
+        tutor_dims=args.tutor_dim,
+        concurrency=args.concurrency,
+        skip_scored=args.skip_scored,
+        force=args.force,
+        rubric_version=args.rubric_version,
+        formula_version=args.formula_version,
+        dry_run=args.dry_run,
+        on_progress=_progress,
+    )
+
+    totals = summary.totals
+    print(
+        f"\nCampaign {summary.campaign_id}: "
+        f"scored={totals['scored']} skipped={totals['skipped']} "
+        f"failed={totals['failed']} pending={totals['pending']} "
+        f"total={totals['total']} duration={summary.duration_s}s"
+    )
+    if not args.dry_run:
+        path = (
+            bench_root / "evaluations" / "campaigns"
+            / summary.campaign_id / "summary.json"
+        )
+        print(f"Summary: {path}")
+    return 1 if totals["failed"] else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _make_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+    bench_root = _resolve_bench_root(args.bench_root)
+
+    if args.bundle:
+        return _run_single(args, bench_root)
+
+    if not (
+        args.all_pending
+        or args.all
+        or args.session
+        or args.task_id
+        or args.persona
+        or args.bundles_from
+    ):
+        print(
+            "error: pick a selector — --bundle, --all-pending, --all, "
+            "--session, --task-id, --persona, or --bundles-from.",
+            file=sys.stderr,
+        )
+        return 2
+
+    return _run_batch(args, bench_root)
 
 
 if __name__ == "__main__":

--- a/bench/server/evaluator/__main__.py
+++ b/bench/server/evaluator/__main__.py
@@ -25,6 +25,8 @@ import sys
 from pathlib import Path
 from typing import Callable
 
+from datetime import datetime
+
 from server.evaluator.batch import (
     BundleOutcome,
     resolve_bundles,
@@ -163,6 +165,29 @@ def _make_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Resolve + print planned work; do not score.",
     )
+    p.add_argument(
+        "--max-cost-usd",
+        type=float,
+        default=None,
+        help="Stop dispatching once cumulative eval cost meets or exceeds this cap.",
+    )
+    p.add_argument(
+        "--resume",
+        dest="resume",
+        default=None,
+        metavar="CAMPAIGN_ID",
+        help="Resume an interrupted campaign; reuses its id, dir, and checkpoint.",
+    )
+    p.add_argument(
+        "--since",
+        default=None,
+        help="Only consider bundles with created_at >= SINCE (ISO 8601).",
+    )
+    p.add_argument(
+        "--until",
+        default=None,
+        help="Only consider bundles with created_at <= UNTIL (ISO 8601).",
+    )
     return p
 
 
@@ -194,6 +219,15 @@ def _read_bundle_list(path: str) -> list[Path]:
     return out
 
 
+def _parse_iso(value: str | None, *, label: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise SystemExit(f"error: --{label} must be ISO 8601: {exc}")
+
+
 def _run_batch(args, bench_root: Path) -> int:
     explicit_paths = (
         _read_bundle_list(args.bundles_from) if args.bundles_from else None
@@ -205,6 +239,8 @@ def _run_batch(args, bench_root: Path) -> int:
         persona_ids=args.persona,
         bundle_paths=explicit_paths,
         all_bundles=args.all_pending or args.all,
+        since=_parse_iso(args.since, label="since"),
+        until=_parse_iso(args.until, label="until"),
     )
     if not bundles:
         print("No bundles matched the given filters.")
@@ -236,6 +272,8 @@ def _run_batch(args, bench_root: Path) -> int:
         rubric_version=args.rubric_version,
         formula_version=args.formula_version,
         dry_run=args.dry_run,
+        max_cost_usd=args.max_cost_usd,
+        resume_campaign_id=args.resume,
         on_progress=_progress,
     )
 
@@ -244,7 +282,8 @@ def _run_batch(args, bench_root: Path) -> int:
         f"\nCampaign {summary.campaign_id}: "
         f"scored={totals['scored']} skipped={totals['skipped']} "
         f"failed={totals['failed']} pending={totals['pending']} "
-        f"total={totals['total']} duration={summary.duration_s}s"
+        f"total={totals['total']} cost=${summary.cost_usd:.4f} "
+        f"duration={summary.duration_s}s"
     )
     if not args.dry_run:
         path = (

--- a/bench/server/evaluator/batch.py
+++ b/bench/server/evaluator/batch.py
@@ -1,0 +1,544 @@
+"""Batch driver for the offline evaluator.
+
+Wraps ``server.evaluator.single.score_bundle`` with bundle discovery,
+concurrency, idempotency, and a campaign-level manifest. The CLI in
+``__main__.py`` is a thin argparse layer over this module; library users
+(CI / release gating) can import ``run_campaign`` directly.
+
+Idempotency is keyed on a deterministic ``config_hash`` stamped into
+``eval_meta.json`` — re-running the same campaign rewrites nothing unless
+``--force`` or a different judge/mode/dims/rubric is passed. Failures are
+isolated per bundle so one bad bundle does not abort the campaign.
+
+Rate-limit pooling (issue #47) is approximated by scaling the per-session
+``_CONCURRENCY`` down as worker count rises, so the total judge-LLM
+in-flight count stays near today's single-session default. A true shared
+AsyncSemaphore across workers needs an event-loop redesign inside
+``evaluate_task`` and is deferred to future work.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+from server.evaluator.config_hash import compute_config_hash
+from server.evaluator.paths import list_eval_history
+from server.evaluator.single import score_bundle as _score_one
+from server.storage.bundle import MANIFEST_FILENAME, load_bundle
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BundleOutcome:
+    """Per-bundle result within a campaign run."""
+
+    bundle_dir: Path
+    session_id: str
+    task_id: str
+    persona_id: str
+    status: str  # "scored" | "skipped" | "failed" | "pending"
+    eval_run_id: Optional[str] = None
+    eval_run_dir: Optional[Path] = None
+    overall_score: Optional[float] = None
+    duration_seconds: float = 0.0
+    error: Optional[str] = None
+
+
+@dataclass
+class CampaignSummary:
+    """Campaign-level manifest written to ``evaluations/campaigns/.../summary.json``."""
+
+    campaign_id: str
+    started_at: str
+    finished_at: str
+    config: dict
+    totals: dict
+    cost_usd: float
+    duration_s: float
+    outcomes: list[dict] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+def new_campaign_id(now: datetime | None = None) -> str:
+    """Timestamp-based campaign id with microsecond suffix.
+
+    Second-resolution collides when two campaigns start in the same
+    second (rapid ``--all-pending`` reruns that only hit skips); the
+    ``_%f`` microsecond tail keeps the per-campaign summary directory
+    unique without adding a random component.
+    """
+    when = now or datetime.now()
+    return f"cmp_{when.strftime('%Y%m%d_%H%M%S_%f')}"
+
+
+def campaign_dir(bench_root: Path | str, campaign_id: str) -> Path:
+    return Path(bench_root) / "evaluations" / "campaigns" / campaign_id
+
+
+def iter_bundle_dirs(bench_root: Path | str) -> Iterable[Path]:
+    """Yield every bundle directory under ``results/server``.
+
+    A bundle is a leaf directory that carries a ``manifest.json`` — the
+    contract slice 1 of #46 introduced. Pre-manifest directories (legacy
+    bundles) are skipped silently; they cannot be scored by the offline
+    evaluator anyway.
+    """
+    root = Path(bench_root) / "results" / "server"
+    if not root.is_dir():
+        return
+    for task_dir in sorted(root.iterdir()):
+        if not task_dir.is_dir():
+            continue
+        for persona_dir in sorted(task_dir.iterdir()):
+            if not persona_dir.is_dir():
+                continue
+            for bundle in sorted(persona_dir.iterdir()):
+                if bundle.is_dir() and (bundle / MANIFEST_FILENAME).is_file():
+                    yield bundle
+
+
+def resolve_bundles(
+    bench_root: Path | str,
+    *,
+    session_ids: Optional[list[str]] = None,
+    task_ids: Optional[list[str]] = None,
+    persona_ids: Optional[list[str]] = None,
+    bundle_paths: Optional[list[Path]] = None,
+    all_bundles: bool = False,
+) -> list[Path]:
+    """Resolve a bundle set from filter arguments.
+
+    ``bundle_paths`` (when given) wins unconditionally — each entry is
+    returned if it has a manifest and dropped otherwise. Without explicit
+    paths, the tree under ``results/server`` is walked and filtered by any
+    combination of ``session_ids`` / ``task_ids`` / ``persona_ids``. Pass
+    ``all_bundles=True`` to skip filtering entirely.
+    """
+    if bundle_paths:
+        out: list[Path] = []
+        for p in bundle_paths:
+            path = Path(p)
+            if (path / MANIFEST_FILENAME).is_file():
+                out.append(path)
+            else:
+                logger.warning("skipping %s: no manifest.json", path)
+        return out
+
+    if not (session_ids or task_ids or persona_ids or all_bundles):
+        raise ValueError(
+            "resolve_bundles needs at least one filter: session_ids, "
+            "task_ids, persona_ids, bundle_paths, or all_bundles=True."
+        )
+
+    sid_prefixes = {s[:8] for s in session_ids} if session_ids else None
+    task_set = set(task_ids) if task_ids else None
+    persona_set = set(persona_ids) if persona_ids else None
+
+    out = []
+    for bundle in iter_bundle_dirs(bench_root):
+        # Path shape: results/server/{task_id}/{persona_id}/{ts}_{sid8}
+        task_id = bundle.parent.parent.name
+        persona_id = bundle.parent.name
+        sid8 = bundle.name.rsplit("_", 1)[-1]
+        if task_set and task_id not in task_set:
+            continue
+        if persona_set and persona_id not in persona_set:
+            continue
+        if sid_prefixes and sid8 not in sid_prefixes:
+            continue
+        out.append(bundle)
+    return out
+
+
+def bundle_already_scored(
+    bench_root: Path | str,
+    *,
+    task_id: str,
+    persona_id: str,
+    session_id: str,
+    config_hash: str,
+) -> Optional[Path]:
+    """Return the matching eval_run_dir if one was scored with this config.
+
+    Walks the sibling tree's ``eval_meta.json`` files newest-first; the
+    first match wins.
+    """
+    for run_dir in list_eval_history(
+        bench_root,
+        task_id=task_id,
+        persona_id=persona_id,
+        session_id=session_id,
+    ):
+        meta_path = run_dir / "eval_meta.json"
+        if not meta_path.is_file():
+            continue
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if meta.get("config_hash") == config_hash:
+            return run_dir
+    return None
+
+
+def filter_pending(
+    bundles: list[Path],
+    bench_root: Path | str,
+    config_hash: str,
+) -> tuple[list[Path], list[tuple[Path, Path]]]:
+    """Partition bundles into (pending, already_scored).
+
+    ``already_scored`` pairs each skipped bundle with its matching
+    eval-run directory so callers can report why it was skipped. Bundles
+    that fail to load are treated as pending — ``run_campaign`` will
+    surface the load failure as a ``failed`` outcome.
+    """
+    pending: list[Path] = []
+    scored: list[tuple[Path, Path]] = []
+    for bundle in bundles:
+        try:
+            loaded = load_bundle(bundle)
+        except Exception as exc:
+            logger.warning("cannot load %s — treating as pending: %s", bundle, exc)
+            pending.append(bundle)
+            continue
+        match = bundle_already_scored(
+            bench_root,
+            task_id=loaded.task_id,
+            persona_id=loaded.persona_id,
+            session_id=loaded.session_id,
+            config_hash=config_hash,
+        )
+        if match is not None:
+            scored.append((bundle, match))
+        else:
+            pending.append(bundle)
+    return pending, scored
+
+
+# ---------------------------------------------------------------------------
+# Campaign driver
+# ---------------------------------------------------------------------------
+
+
+def run_campaign(
+    *,
+    bench_root: Path | str,
+    bundles: list[Path],
+    task_loader: Callable[[str], object],
+    persona_loader: Callable[[str], object],
+    eval_model: str,
+    eval_mode: str = "full",
+    tutor_dims: Optional[list[str]] = None,
+    concurrency: int = 4,
+    skip_scored: bool = True,
+    force: bool = False,
+    rubric_version: str = "",
+    formula_version: str = "",
+    dry_run: bool = False,
+    on_progress: Optional[Callable[[BundleOutcome, int, int], None]] = None,
+    campaign_id: Optional[str] = None,
+) -> CampaignSummary:
+    """Score ``bundles`` and persist a campaign summary.
+
+    Idempotent by default: bundles already scored with the matching
+    ``config_hash`` are returned as ``skipped`` outcomes without
+    triggering the judge. ``force=True`` bypasses the skip check.
+    """
+    cfg_hash = compute_config_hash(
+        judge=eval_model,
+        eval_mode=eval_mode,
+        tutor_dims=tutor_dims,
+        rubric_version=rubric_version,
+        formula_version=formula_version,
+    )
+
+    if skip_scored and not force:
+        pending, skipped_pairs = filter_pending(bundles, bench_root, cfg_hash)
+    else:
+        pending, skipped_pairs = list(bundles), []
+
+    started_at = datetime.now()
+    t0 = time.time()
+    outcomes: list[BundleOutcome] = [_skipped_outcome(b, m) for b, m in skipped_pairs]
+
+    if dry_run:
+        for bundle in pending:
+            outcomes.append(_pending_outcome(bundle))
+    else:
+        prev_concurrency = _tune_per_worker_concurrency(concurrency)
+        try:
+            def _worker(bundle: Path) -> BundleOutcome:
+                return _score_bundle_isolated(
+                    bundle,
+                    bench_root=bench_root,
+                    task_loader=task_loader,
+                    persona_loader=persona_loader,
+                    eval_model=eval_model,
+                    eval_mode=eval_mode,
+                    tutor_dims=tutor_dims,
+                    config_hash=cfg_hash,
+                )
+
+            total = len(pending)
+            if concurrency <= 1:
+                for idx, bundle in enumerate(pending, 1):
+                    out = _worker(bundle)
+                    outcomes.append(out)
+                    if on_progress:
+                        on_progress(out, idx, total)
+            else:
+                with ThreadPoolExecutor(max_workers=concurrency) as pool:
+                    futures = {pool.submit(_worker, b): b for b in pending}
+                    done = 0
+                    for fut in as_completed(futures):
+                        done += 1
+                        out = fut.result()
+                        outcomes.append(out)
+                        if on_progress:
+                            on_progress(out, done, total)
+        finally:
+            _restore_per_worker_concurrency(prev_concurrency)
+
+    finished_at = datetime.now()
+    summary = CampaignSummary(
+        campaign_id=campaign_id or new_campaign_id(started_at),
+        started_at=started_at.isoformat(),
+        finished_at=finished_at.isoformat(),
+        config={
+            "judge": eval_model,
+            "eval_mode": eval_mode,
+            "tutor_dims": sorted(tutor_dims) if tutor_dims else [],
+            "rubric_version": rubric_version,
+            "formula_version": formula_version,
+            "config_hash": cfg_hash,
+            "concurrency": concurrency,
+            "skip_scored": skip_scored and not force,
+            "force": force,
+            "dry_run": dry_run,
+        },
+        totals=_tally(outcomes),
+        cost_usd=0.0,
+        duration_s=round(time.time() - t0, 2),
+        outcomes=[_outcome_to_dict(o) for o in outcomes],
+    )
+
+    if not dry_run:
+        write_campaign_summary(bench_root, summary)
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _score_bundle_isolated(
+    bundle: Path,
+    *,
+    bench_root: Path | str,
+    task_loader,
+    persona_loader,
+    eval_model: str,
+    eval_mode: str,
+    tutor_dims: Optional[list[str]],
+    config_hash: str,
+) -> BundleOutcome:
+    start = time.time()
+    try:
+        loaded = load_bundle(bundle)
+    except Exception as exc:
+        return BundleOutcome(
+            bundle_dir=bundle,
+            session_id="",
+            task_id="",
+            persona_id="",
+            status="failed",
+            error=f"load_bundle: {exc}",
+            duration_seconds=round(time.time() - start, 2),
+        )
+
+    try:
+        task = task_loader(loaded.task_id)
+        persona = persona_loader(loaded.persona_id)
+        result = _score_one(
+            bundle_dir=bundle,
+            task=task,
+            persona=persona,
+            bench_root=bench_root,
+            eval_model=eval_model,
+            eval_mode=eval_mode,
+            tutor_dims=tutor_dims,
+        )
+    except (Exception, SystemExit) as exc:
+        # ``_load_task`` / ``_load_persona`` raise ``SystemExit`` when a task or
+        # persona JSON is missing (CLI-friendly). In the batch driver that would
+        # kill the whole campaign; treat it as a per-bundle failure instead so
+        # the rest of the cohort keeps going.
+        logger.exception("scoring failed for %s", bundle)
+        return BundleOutcome(
+            bundle_dir=bundle,
+            session_id=loaded.session_id,
+            task_id=loaded.task_id,
+            persona_id=loaded.persona_id,
+            status="failed",
+            error=str(exc),
+            duration_seconds=round(time.time() - start, 2),
+        )
+
+    run_dir: Path = result["_eval_run_dir"]
+    _stamp_config_hash(run_dir / "eval_meta.json", config_hash)
+
+    return BundleOutcome(
+        bundle_dir=bundle,
+        session_id=loaded.session_id,
+        task_id=loaded.task_id,
+        persona_id=loaded.persona_id,
+        status="scored",
+        eval_run_id=result.get("_eval_run_id"),
+        eval_run_dir=run_dir,
+        overall_score=result.get("_overall_score"),
+        duration_seconds=round(time.time() - start, 2),
+    )
+
+
+def _stamp_config_hash(meta_path: Path, config_hash: str) -> None:
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.warning("cannot stamp config_hash: %s unreadable", meta_path)
+        return
+    meta["config_hash"] = config_hash
+    meta_path.write_text(
+        json.dumps(meta, indent=2, default=str), encoding="utf-8"
+    )
+
+
+def _concurrency_modules():
+    """Return (tutor_module, process_metrics_module) or None if unavailable."""
+    try:
+        from server.eval.ewan_eval import process_metrics as proc
+        from server.eval.ewan_eval import tutor_conv_geval as tutor
+
+        return tutor, proc
+    except Exception:
+        return None
+
+
+def _tune_per_worker_concurrency(n_workers: int) -> tuple[int, int] | None:
+    """Scale per-session LLM concurrency and return the prior values.
+
+    Each worker thread spins up its own async loop + ``Semaphore(k)``;
+    without tuning, N workers give N × k in-flight requests. Divide the
+    default-20 budget across workers so the batch does not overrun
+    provider limits. The caller must pass the return value to
+    ``_restore_per_worker_concurrency`` so a long-lived process (REST
+    server, interactive REPL) is not left throttled after the campaign.
+    """
+    mods = _concurrency_modules()
+    if mods is None:
+        return None
+    tutor, proc = mods
+    prev = (tutor._CONCURRENCY, proc._CONCURRENCY)
+    per = max(3, 20 // max(1, n_workers))
+    tutor.set_eval_concurrency(per)
+    proc.set_eval_concurrency(per)
+    return prev
+
+
+def _restore_per_worker_concurrency(prev: tuple[int, int] | None) -> None:
+    if prev is None:
+        return
+    mods = _concurrency_modules()
+    if mods is None:
+        return
+    tutor, proc = mods
+    tutor.set_eval_concurrency(prev[0])
+    proc.set_eval_concurrency(prev[1])
+
+
+def _tally(outcomes: list[BundleOutcome]) -> dict:
+    return {
+        "total": len(outcomes),
+        "scored": sum(1 for o in outcomes if o.status == "scored"),
+        "skipped": sum(1 for o in outcomes if o.status == "skipped"),
+        "failed": sum(1 for o in outcomes if o.status == "failed"),
+        "pending": sum(1 for o in outcomes if o.status == "pending"),
+    }
+
+
+def _outcome_to_dict(o: BundleOutcome) -> dict:
+    d = asdict(o)
+    d["bundle_dir"] = str(d["bundle_dir"])
+    if d.get("eval_run_dir") is not None:
+        d["eval_run_dir"] = str(d["eval_run_dir"])
+    return d
+
+
+def _skipped_outcome(bundle: Path, match: Path) -> BundleOutcome:
+    try:
+        loaded = load_bundle(bundle)
+        sid = loaded.session_id
+        tid = loaded.task_id
+        pid = loaded.persona_id
+    except Exception:
+        sid = tid = pid = ""
+    return BundleOutcome(
+        bundle_dir=bundle,
+        session_id=sid,
+        task_id=tid,
+        persona_id=pid,
+        status="skipped",
+        eval_run_id=match.name,
+        eval_run_dir=match,
+    )
+
+
+def _pending_outcome(bundle: Path) -> BundleOutcome:
+    try:
+        loaded = load_bundle(bundle)
+        return BundleOutcome(
+            bundle_dir=bundle,
+            session_id=loaded.session_id,
+            task_id=loaded.task_id,
+            persona_id=loaded.persona_id,
+            status="pending",
+        )
+    except Exception as exc:
+        return BundleOutcome(
+            bundle_dir=bundle,
+            session_id="",
+            task_id="",
+            persona_id="",
+            status="failed",
+            error=f"load_bundle: {exc}",
+        )
+
+
+def write_campaign_summary(
+    bench_root: Path | str, summary: CampaignSummary
+) -> Path:
+    out_dir = campaign_dir(bench_root, summary.campaign_id)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / "summary.json"
+    path.write_text(
+        json.dumps(asdict(summary), indent=2, default=str), encoding="utf-8"
+    )
+    return path

--- a/bench/server/evaluator/batch.py
+++ b/bench/server/evaluator/batch.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -53,6 +53,7 @@ class BundleOutcome:
     eval_run_id: Optional[str] = None
     eval_run_dir: Optional[Path] = None
     overall_score: Optional[float] = None
+    cost_usd: float = 0.0
     duration_seconds: float = 0.0
     error: Optional[str] = None
 
@@ -122,6 +123,8 @@ def resolve_bundles(
     persona_ids: Optional[list[str]] = None,
     bundle_paths: Optional[list[Path]] = None,
     all_bundles: bool = False,
+    since: Optional[datetime] = None,
+    until: Optional[datetime] = None,
 ) -> list[Path]:
     """Resolve a bundle set from filter arguments.
 
@@ -130,6 +133,10 @@ def resolve_bundles(
     paths, the tree under ``results/server`` is walked and filtered by any
     combination of ``session_ids`` / ``task_ids`` / ``persona_ids``. Pass
     ``all_bundles=True`` to skip filtering entirely.
+
+    ``since`` / ``until`` filter bundles by their manifest ``created_at``
+    timestamp. Bundles without a parseable timestamp pass the filter so
+    legacy producers do not drop out silently.
     """
     if bundle_paths:
         out: list[Path] = []
@@ -163,8 +170,45 @@ def resolve_bundles(
             continue
         if sid_prefixes and sid8 not in sid_prefixes:
             continue
+        if (since or until) and not _bundle_in_window(bundle, since, until):
+            continue
         out.append(bundle)
     return out
+
+
+def _bundle_in_window(
+    bundle: Path, since: Optional[datetime], until: Optional[datetime]
+) -> bool:
+    """Return True when the bundle's manifest timestamp is inside the window.
+
+    Bundles with an unparseable ``created_at`` pass the filter — we'd
+    rather score an old bundle than silently drop one whose manifest
+    got mangled. Both sides of the comparison are stripped to naive
+    datetimes so a tz-aware ``--since 2026-04-15T00:00:00+00:00`` does
+    not crash against the naive ``datetime.now().isoformat()`` writers
+    stamp into manifests today.
+    """
+    try:
+        manifest = json.loads(
+            (bundle / MANIFEST_FILENAME).read_text(encoding="utf-8")
+        )
+        created = manifest.get("created_at")
+        if not created:
+            return True
+        ts = _strip_tz(datetime.fromisoformat(created))
+    except Exception:
+        return True
+    since = _strip_tz(since) if since else None
+    until = _strip_tz(until) if until else None
+    if since and ts < since:
+        return False
+    if until and ts > until:
+        return False
+    return True
+
+
+def _strip_tz(dt: datetime) -> datetime:
+    return dt.replace(tzinfo=None) if dt.tzinfo is not None else dt
 
 
 def bundle_already_scored(
@@ -253,6 +297,8 @@ def run_campaign(
     rubric_version: str = "",
     formula_version: str = "",
     dry_run: bool = False,
+    max_cost_usd: Optional[float] = None,
+    resume_campaign_id: Optional[str] = None,
     on_progress: Optional[Callable[[BundleOutcome, int, int], None]] = None,
     campaign_id: Optional[str] = None,
 ) -> CampaignSummary:
@@ -261,6 +307,18 @@ def run_campaign(
     Idempotent by default: bundles already scored with the matching
     ``config_hash`` are returned as ``skipped`` outcomes without
     triggering the judge. ``force=True`` bypasses the skip check.
+
+    Operational controls:
+
+    - ``max_cost_usd`` caps the campaign's cumulative eval cost. Once
+      the running total meets or exceeds the cap, no further bundles
+      are dispatched; remaining pending bundles are marked skipped
+      with ``error='budget_exceeded'`` so the campaign summary
+      preserves audit information.
+    - ``resume_campaign_id`` reuses a prior campaign's id + directory;
+      bundles already recorded in that campaign's ``checkpoint.jsonl``
+      are skipped, so an interrupted batch can pick up where it left
+      off under the same audit trail.
     """
     cfg_hash = compute_config_hash(
         judge=eval_model,
@@ -270,20 +328,38 @@ def run_campaign(
         formula_version=formula_version,
     )
 
+    started_at = datetime.now()
+    t0 = time.time()
+    effective_id = campaign_id or resume_campaign_id or new_campaign_id(started_at)
+
+    # Apply the checkpoint first. ``filter_pending`` would otherwise
+    # translate every already-scored bundle into a "skipped" outcome (the
+    # sibling-tree eval_meta.json already carries the matching
+    # config_hash), duplicating the checkpoint entries and inflating the
+    # campaign totals on resume.
+    resumed_outcomes: list[BundleOutcome] = []
+    if resume_campaign_id:
+        resumed_outcomes = _load_checkpoint(bench_root, resume_campaign_id)
+        done_bundles = {o.bundle_dir for o in resumed_outcomes}
+        bundles = [b for b in bundles if b not in done_bundles]
+
     if skip_scored and not force:
         pending, skipped_pairs = filter_pending(bundles, bench_root, cfg_hash)
     else:
         pending, skipped_pairs = list(bundles), []
 
-    started_at = datetime.now()
-    t0 = time.time()
-    outcomes: list[BundleOutcome] = [_skipped_outcome(b, m) for b, m in skipped_pairs]
+    outcomes: list[BundleOutcome] = list(resumed_outcomes)
+    outcomes.extend(_skipped_outcome(b, m) for b, m in skipped_pairs)
 
     if dry_run:
         for bundle in pending:
             outcomes.append(_pending_outcome(bundle))
     else:
+        checkpoint_path = _open_checkpoint(
+            bench_root, effective_id, append=bool(resume_campaign_id)
+        )
         prev_concurrency = _tune_per_worker_concurrency(concurrency)
+        cost_so_far = sum(o.cost_usd or 0.0 for o in outcomes)
         try:
             def _worker(bundle: Path) -> BundleOutcome:
                 return _score_bundle_isolated(
@@ -298,28 +374,64 @@ def run_campaign(
                 )
 
             total = len(pending)
+            done_count = 0
+            pending_iter = iter(pending)
+            budget_exceeded = (
+                max_cost_usd is not None and cost_so_far >= max_cost_usd
+            )
+
+            def _record(out: BundleOutcome) -> None:
+                nonlocal done_count, cost_so_far
+                outcomes.append(out)
+                _append_checkpoint(checkpoint_path, out)
+                cost_so_far += out.cost_usd or 0.0
+                done_count += 1
+                if on_progress:
+                    on_progress(out, done_count, total)
+
             if concurrency <= 1:
-                for idx, bundle in enumerate(pending, 1):
-                    out = _worker(bundle)
-                    outcomes.append(out)
-                    if on_progress:
-                        on_progress(out, idx, total)
+                for bundle in pending_iter:
+                    if max_cost_usd is not None and cost_so_far >= max_cost_usd:
+                        budget_exceeded = True
+                        outcomes.append(_budget_skipped_outcome(bundle))
+                        continue
+                    _record(_worker(bundle))
             else:
                 with ThreadPoolExecutor(max_workers=concurrency) as pool:
-                    futures = {pool.submit(_worker, b): b for b in pending}
-                    done = 0
-                    for fut in as_completed(futures):
-                        done += 1
-                        out = fut.result()
-                        outcomes.append(out)
-                        if on_progress:
-                            on_progress(out, done, total)
+                    in_flight: set = set()
+                    while True:
+                        while (
+                            len(in_flight) < concurrency
+                            and not budget_exceeded
+                        ):
+                            try:
+                                bundle = next(pending_iter)
+                            except StopIteration:
+                                break
+                            in_flight.add(pool.submit(_worker, bundle))
+                        if not in_flight:
+                            break
+                        finished, in_flight = wait(
+                            in_flight, return_when=FIRST_COMPLETED
+                        )
+                        for fut in finished:
+                            _record(fut.result())
+                            if (
+                                max_cost_usd is not None
+                                and cost_so_far >= max_cost_usd
+                            ):
+                                budget_exceeded = True
+
+                for bundle in pending_iter:
+                    outcomes.append(_budget_skipped_outcome(bundle))
         finally:
             _restore_per_worker_concurrency(prev_concurrency)
 
     finished_at = datetime.now()
+    totals = _tally(outcomes)
+    total_cost = round(sum(o.cost_usd or 0.0 for o in outcomes), 6)
     summary = CampaignSummary(
-        campaign_id=campaign_id or new_campaign_id(started_at),
+        campaign_id=effective_id,
         started_at=started_at.isoformat(),
         finished_at=finished_at.isoformat(),
         config={
@@ -333,9 +445,11 @@ def run_campaign(
             "skip_scored": skip_scored and not force,
             "force": force,
             "dry_run": dry_run,
+            "max_cost_usd": max_cost_usd,
+            "resumed_from": resume_campaign_id,
         },
-        totals=_tally(outcomes),
-        cost_usd=0.0,
+        totals=totals,
+        cost_usd=total_cost,
         duration_s=round(time.time() - t0, 2),
         outcomes=[_outcome_to_dict(o) for o in outcomes],
     )
@@ -404,7 +518,8 @@ def _score_bundle_isolated(
         )
 
     run_dir: Path = result["_eval_run_dir"]
-    _stamp_config_hash(run_dir / "eval_meta.json", config_hash)
+    cost_usd = _extract_eval_cost(result)
+    _stamp_config_hash(run_dir / "eval_meta.json", config_hash, cost_usd=cost_usd)
 
     return BundleOutcome(
         bundle_dir=bundle,
@@ -415,17 +530,43 @@ def _score_bundle_isolated(
         eval_run_id=result.get("_eval_run_id"),
         eval_run_dir=run_dir,
         overall_score=result.get("_overall_score"),
+        cost_usd=cost_usd,
         duration_seconds=round(time.time() - start, 2),
     )
 
 
-def _stamp_config_hash(meta_path: Path, config_hash: str) -> None:
+def _extract_eval_cost(result: dict) -> float:
+    """Sum the ``_eval_cost`` signals the pipeline leaves in its output.
+
+    Sub-evaluators stamp their own cost under ``_eval_cost`` either at the
+    top level (process metrics, tutor rubric rollup) or nested inside a
+    per-component dict (``result_judge``). Summing the ones we know about
+    is a faithful enough estimate for budget gating; exact dollar parity
+    with ``cost.md`` is not required here.
+    """
+    total = 0.0
+    for key in ("_eval_cost", "_tutor_eval_cost", "_process_eval_cost"):
+        total += float(result.get(key, 0.0) or 0.0)
+
+    for nested_key in ("tutor_scores", "result_judge", "process_metrics"):
+        nested = result.get(nested_key) or {}
+        if isinstance(nested, dict):
+            total += float(nested.get("_eval_cost", 0.0) or 0.0)
+
+    return round(total, 6)
+
+
+def _stamp_config_hash(
+    meta_path: Path, config_hash: str, *, cost_usd: float = 0.0
+) -> None:
     try:
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
     except Exception:
         logger.warning("cannot stamp config_hash: %s unreadable", meta_path)
         return
     meta["config_hash"] = config_hash
+    if cost_usd:
+        meta["cost_usd"] = round(cost_usd, 6)
     meta_path.write_text(
         json.dumps(meta, indent=2, default=str), encoding="utf-8"
     )
@@ -542,3 +683,81 @@ def write_campaign_summary(
         json.dumps(asdict(summary), indent=2, default=str), encoding="utf-8"
     )
     return path
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint / resume
+# ---------------------------------------------------------------------------
+
+
+def _checkpoint_path(bench_root: Path | str, campaign_id: str) -> Path:
+    return campaign_dir(bench_root, campaign_id) / "checkpoint.jsonl"
+
+
+def _open_checkpoint(
+    bench_root: Path | str, campaign_id: str, *, append: bool
+) -> Path:
+    path = _checkpoint_path(bench_root, campaign_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not append:
+        path.write_text("", encoding="utf-8")
+    return path
+
+
+def _append_checkpoint(checkpoint: Path, outcome: BundleOutcome) -> None:
+    line = json.dumps(_outcome_to_dict(outcome), default=str)
+    with checkpoint.open("a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+
+
+def _load_checkpoint(
+    bench_root: Path | str, campaign_id: str
+) -> list[BundleOutcome]:
+    """Rehydrate outcomes recorded before the campaign was interrupted."""
+    path = _checkpoint_path(bench_root, campaign_id)
+    if not path.is_file():
+        return []
+    out: list[BundleOutcome] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        s = raw.strip()
+        if not s:
+            continue
+        try:
+            entry = json.loads(s)
+        except Exception:
+            logger.warning("skipping malformed checkpoint line in %s", path)
+            continue
+        out.append(
+            BundleOutcome(
+                bundle_dir=Path(entry.get("bundle_dir", "")),
+                session_id=entry.get("session_id", ""),
+                task_id=entry.get("task_id", ""),
+                persona_id=entry.get("persona_id", ""),
+                status=entry.get("status", "failed"),
+                eval_run_id=entry.get("eval_run_id"),
+                eval_run_dir=(
+                    Path(entry["eval_run_dir"]) if entry.get("eval_run_dir") else None
+                ),
+                overall_score=entry.get("overall_score"),
+                cost_usd=float(entry.get("cost_usd", 0.0) or 0.0),
+                duration_seconds=float(entry.get("duration_seconds", 0.0) or 0.0),
+                error=entry.get("error"),
+            )
+        )
+    return out
+
+
+def _budget_skipped_outcome(bundle: Path) -> BundleOutcome:
+    try:
+        loaded = load_bundle(bundle)
+        sid, tid, pid = loaded.session_id, loaded.task_id, loaded.persona_id
+    except Exception:
+        sid = tid = pid = ""
+    return BundleOutcome(
+        bundle_dir=bundle,
+        session_id=sid,
+        task_id=tid,
+        persona_id=pid,
+        status="skipped",
+        error="budget_exceeded",
+    )

--- a/bench/server/evaluator/config_hash.py
+++ b/bench/server/evaluator/config_hash.py
@@ -1,0 +1,39 @@
+"""Deterministic config hash for batch idempotency.
+
+Two campaigns with the same ``(judge, eval_mode, tutor_dims, rubric_version,
+formula_version)`` produce the same hash, so ``batch.filter_pending`` can
+skip bundles that already carry a matching ``eval_meta.json``. Any change
+to the judge or the scoring definition yields a different hash and the
+bundle is re-scored.
+
+``CONFIG_HASH_VERSION`` prefixes the serialized payload so bumping the
+hash algorithm or widening the inputs invalidates prior hashes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Iterable, Optional
+
+CONFIG_HASH_VERSION = "1"
+
+
+def compute_config_hash(
+    *,
+    judge: str,
+    eval_mode: str,
+    tutor_dims: Optional[Iterable[str]] = None,
+    rubric_version: str = "",
+    formula_version: str = "",
+) -> str:
+    payload = {
+        "v": CONFIG_HASH_VERSION,
+        "judge": judge,
+        "eval_mode": eval_mode,
+        "tutor_dims": sorted(tutor_dims) if tutor_dims else [],
+        "rubric_version": rubric_version,
+        "formula_version": formula_version,
+    }
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]

--- a/bench/tests/test_evaluator_batch.py
+++ b/bench/tests/test_evaluator_batch.py
@@ -24,6 +24,8 @@ from server.evaluator.batch import (
     resolve_bundles,
     run_campaign,
 )
+from datetime import datetime
+
 from server.evaluator.config_hash import compute_config_hash
 from server.storage.result_writer import save_run_state
 
@@ -91,7 +93,13 @@ def _stub_persona(persona_id="fullstack_practitioner"):
     )
 
 
-def _fake_scored_result(bundle_dir: Path, eval_run_id: str, bench_root: Path):
+def _fake_scored_result(
+    bundle_dir: Path,
+    eval_run_id: str,
+    bench_root: Path,
+    *,
+    cost: float = 0.0,
+):
     """Return the shape ``score_bundle`` hands back + write the sibling artefact."""
     from server.evaluator.paths import eval_run_dir as _run_dir
 
@@ -120,7 +128,7 @@ def _fake_scored_result(bundle_dir: Path, eval_run_id: str, bench_root: Path):
         "_overall_score": 0.7,
         "quant_result": 0.7,
         "quant_process": 0.6,
-        "tutor_scores": {},
+        "tutor_scores": {"_eval_cost": cost},
     }
 
 
@@ -518,6 +526,349 @@ class TestRunCampaign:
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# P2: operational hardening
+# ---------------------------------------------------------------------------
+
+
+class TestCostAndBudget:
+    def test_cost_summed_into_campaign(self, tmp_path):
+        bundles = [
+            _make_bundle(
+                tmp_path,
+                task_id="X01",
+                persona_id="p1",
+                session_id=chr(ord("a") + i) * 32,
+                ts=f"2026042{i}_120000",
+            )
+            for i in range(3)
+        ]
+
+        def _fake(bundle_dir, **_kw):
+            return _fake_scored_result(
+                Path(bundle_dir),
+                f"eval_20260421_{abs(hash(str(bundle_dir))) % 1000000:06d}",
+                tmp_path,
+                cost=0.5,
+            )
+
+        with patch.object(batch_mod, "_score_one", side_effect=_fake):
+            summary = run_campaign(
+                bench_root=tmp_path,
+                bundles=bundles,
+                task_loader=lambda _: _stub_task(),
+                persona_loader=lambda _: _stub_persona(),
+                eval_model="claude",
+                concurrency=1,
+            )
+        assert summary.cost_usd == pytest.approx(1.5)
+        scored = [o for o in summary.outcomes if o["status"] == "scored"]
+        assert all(o["cost_usd"] == 0.5 for o in scored)
+
+    def test_max_cost_stops_dispatch(self, tmp_path):
+        bundles = [
+            _make_bundle(
+                tmp_path,
+                task_id="X01",
+                persona_id="p1",
+                session_id=chr(ord("a") + i) * 32,
+                ts=f"2026042{i}_120000",
+            )
+            for i in range(5)
+        ]
+
+        def _fake(bundle_dir, **_kw):
+            return _fake_scored_result(
+                Path(bundle_dir),
+                f"eval_20260421_{abs(hash(str(bundle_dir))) % 1000000:06d}",
+                tmp_path,
+                cost=0.4,
+            )
+
+        with patch.object(batch_mod, "_score_one", side_effect=_fake):
+            summary = run_campaign(
+                bench_root=tmp_path,
+                bundles=bundles,
+                task_loader=lambda _: _stub_task(),
+                persona_loader=lambda _: _stub_persona(),
+                eval_model="claude",
+                concurrency=1,
+                max_cost_usd=1.0,
+            )
+        budget_skipped = [
+            o for o in summary.outcomes
+            if o["status"] == "skipped" and o.get("error") == "budget_exceeded"
+        ]
+        assert budget_skipped, "expected at least one budget_exceeded skip"
+        assert summary.cost_usd <= 1.0 + 0.4  # the bundle that crossed the cap finishes
+
+
+class TestCostExtraction:
+    def test_process_metrics_cost_summed(self, tmp_path):
+        """``process_metrics._eval_cost`` must reach the campaign total.
+
+        The real pipeline stamps process-metric spend at
+        ``result["process_metrics"]["_eval_cost"]``; missing it would
+        let `--max-cost-usd` overshoot its cap.
+        """
+        b = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+
+        def _fake(bundle_dir, **_kw):
+            result = _fake_scored_result(
+                Path(bundle_dir),
+                "eval_20260421_000001",
+                tmp_path,
+                cost=0.0,
+            )
+            # Simulate the real pipeline's nested cost surface.
+            result["process_metrics"] = {"_eval_cost": 0.75}
+            result["result_judge"] = {"_eval_cost": 0.1}
+            return result
+
+        with patch.object(batch_mod, "_score_one", side_effect=_fake):
+            summary = run_campaign(
+                bench_root=tmp_path,
+                bundles=[b],
+                task_loader=lambda _: _stub_task(),
+                persona_loader=lambda _: _stub_persona(),
+                eval_model="claude",
+                concurrency=1,
+            )
+        assert summary.cost_usd == pytest.approx(0.85)
+
+
+class TestResume:
+    def test_resume_reuses_campaign_id(self, tmp_path, patched_score_bundle):
+        """Resumed campaign lands in the same directory as the original."""
+        b1 = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        b2 = _make_bundle(
+            tmp_path, task_id="X01", persona_id="p1", session_id="b" * 32,
+            ts="20260421_130000",
+        )
+
+        first = run_campaign(
+            bench_root=tmp_path,
+            bundles=[b1],
+            task_loader=lambda _: _stub_task(),
+            persona_loader=lambda _: _stub_persona(),
+            eval_model="claude",
+            concurrency=1,
+        )
+
+        resumed = run_campaign(
+            bench_root=tmp_path,
+            bundles=[b1, b2],
+            task_loader=lambda _: _stub_task(),
+            persona_loader=lambda _: _stub_persona(),
+            eval_model="claude",
+            concurrency=1,
+            skip_scored=False,
+            resume_campaign_id=first.campaign_id,
+        )
+        assert resumed.campaign_id == first.campaign_id
+        # Only b2 actually dispatched via _score_one; b1 came back through
+        # the checkpoint plus b2 was scored fresh.
+        sids_scored = [
+            o["session_id"] for o in resumed.outcomes if o["status"] == "scored"
+        ]
+        assert set(sids_scored) == {"a" * 32, "b" * 32}
+
+    def test_resume_skips_already_done_bundles(self, tmp_path):
+        """After an interrupt, a resume dispatches only the unfinished bundles."""
+        bundles = [
+            _make_bundle(
+                tmp_path,
+                task_id="X01",
+                persona_id="p1",
+                session_id=chr(ord("a") + i) * 32,
+                ts=f"2026042{i}_120000",
+            )
+            for i in range(3)
+        ]
+
+        crashed_at = bundles[1]
+        done_count = {"n": 0}
+
+        def _fake(bundle_dir, **_kw):
+            done_count["n"] += 1
+            if Path(bundle_dir) == crashed_at:
+                raise RuntimeError("simulated interrupt")
+            return _fake_scored_result(
+                Path(bundle_dir),
+                f"eval_20260421_{done_count['n']:06d}",
+                tmp_path,
+                cost=0.0,
+            )
+
+        with patch.object(batch_mod, "_score_one", side_effect=_fake):
+            first = run_campaign(
+                bench_root=tmp_path,
+                bundles=bundles,
+                task_loader=lambda _: _stub_task(),
+                persona_loader=lambda _: _stub_persona(),
+                eval_model="claude",
+                concurrency=1,
+            )
+        assert first.totals["scored"] + first.totals["failed"] == 3
+
+        # Resume: every bundle is rewritten via checkpoint; force is only
+        # needed here to bypass the config_hash skip since the first run
+        # also wrote eval_meta.json entries.
+        call_log: list[Path] = []
+
+        def _second(bundle_dir, **_kw):
+            call_log.append(Path(bundle_dir))
+            return _fake_scored_result(
+                Path(bundle_dir),
+                f"eval_20260421_second_{len(call_log):06d}",
+                tmp_path,
+                cost=0.0,
+            )
+
+        with patch.object(batch_mod, "_score_one", side_effect=_second):
+            resumed = run_campaign(
+                bench_root=tmp_path,
+                bundles=bundles,
+                task_loader=lambda _: _stub_task(),
+                persona_loader=lambda _: _stub_persona(),
+                eval_model="claude",
+                concurrency=1,
+                resume_campaign_id=first.campaign_id,
+                skip_scored=False,
+            )
+
+        # The bundles that were successfully scored in the first run are
+        # skipped by resume; the interrupted one is dispatched again.
+        assert resumed.campaign_id == first.campaign_id
+        assert len(call_log) < 3, f"resume re-scored too many bundles: {call_log}"
+
+
+class TestBudgetEdges:
+    def test_concurrency_path_honors_exhausted_budget(self, tmp_path):
+        """If cost is already over the cap, the concurrent dispatcher
+        must not submit any new bundles before checking.
+        """
+        bundles = [
+            _make_bundle(
+                tmp_path,
+                task_id="X01",
+                persona_id="p1",
+                session_id=chr(ord("a") + i) * 32,
+                ts=f"2026042{i}_120000",
+            )
+            for i in range(4)
+        ]
+
+        call_log: list[Path] = []
+
+        def _fake(bundle_dir, **_kw):
+            call_log.append(Path(bundle_dir))
+            return _fake_scored_result(
+                Path(bundle_dir),
+                f"eval_{len(call_log):06d}",
+                tmp_path,
+                cost=1.0,
+            )
+
+        with patch.object(batch_mod, "_score_one", side_effect=_fake):
+            summary = run_campaign(
+                bench_root=tmp_path,
+                bundles=bundles,
+                task_loader=lambda _: _stub_task(),
+                persona_loader=lambda _: _stub_persona(),
+                eval_model="claude",
+                concurrency=4,
+                max_cost_usd=0.0,
+            )
+        assert call_log == [], "budget_exceeded at start must halt dispatch immediately"
+        assert summary.totals["skipped"] == len(bundles)
+
+
+class TestResumeDeduplicatesWithSkipScored:
+    def test_checkpoint_applied_before_filter_pending(
+        self, tmp_path, patched_score_bundle
+    ):
+        """Resume must not double-count bundles via ``filter_pending``.
+
+        On the first run we wrote ``eval_meta.json`` with the matching
+        ``config_hash``, so a naive resume with ``skip_scored=True``
+        would emit both a "skipped" (from filter_pending) and a
+        "scored" (from checkpoint) outcome for the same bundle.
+        """
+        b = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        first = run_campaign(
+            bench_root=tmp_path,
+            bundles=[b],
+            task_loader=lambda _: _stub_task(),
+            persona_loader=lambda _: _stub_persona(),
+            eval_model="claude",
+            concurrency=1,
+        )
+        resumed = run_campaign(
+            bench_root=tmp_path,
+            bundles=[b],
+            task_loader=lambda _: _stub_task(),
+            persona_loader=lambda _: _stub_persona(),
+            eval_model="claude",
+            concurrency=1,
+            resume_campaign_id=first.campaign_id,
+        )
+        # Each bundle must appear exactly once across the resumed outcomes.
+        sids = [o["session_id"] for o in resumed.outcomes]
+        assert len(sids) == len(set(sids))
+
+
+class TestTimeWindow:
+    def test_resolve_filters_since(self, tmp_path):
+        _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        _make_bundle(
+            tmp_path, task_id="X01", persona_id="p1", session_id="b" * 32,
+            ts="20260421_130000",
+        )
+        # created_at is stamped at manifest write time; fake both manifests.
+        for b in (tmp_path / "results" / "server" / "X01" / "p1").iterdir():
+            mf = b / "manifest.json"
+            data = json.loads(mf.read_text())
+            if "aaaaaaaa" in b.name:
+                data["created_at"] = "2026-04-01T00:00:00"
+            else:
+                data["created_at"] = "2026-04-20T00:00:00"
+            mf.write_text(json.dumps(data))
+
+        recent = batch_mod.resolve_bundles(
+            tmp_path, all_bundles=True, since=datetime(2026, 4, 15)
+        )
+        assert len(recent) == 1
+        assert "bbbbbbbb" in recent[0].name
+
+    def test_resolve_handles_tz_aware_since(self, tmp_path):
+        """Manifests store naive timestamps; a tz-aware ``since``
+        must not crash the comparison."""
+        from datetime import timezone
+
+        b = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        mf = b / "manifest.json"
+        data = json.loads(mf.read_text())
+        data["created_at"] = "2026-04-20T00:00:00"
+        mf.write_text(json.dumps(data))
+
+        tz_since = datetime(2026, 4, 15, tzinfo=timezone.utc)
+        got = batch_mod.resolve_bundles(tmp_path, all_bundles=True, since=tz_since)
+        assert got == [b]
+
+    def test_resolve_keeps_unparseable_timestamp(self, tmp_path):
+        b = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        mf = b / "manifest.json"
+        data = json.loads(mf.read_text())
+        data["created_at"] = "not-a-date"
+        mf.write_text(json.dumps(data))
+
+        got = batch_mod.resolve_bundles(
+            tmp_path, all_bundles=True, since=datetime(2026, 4, 15)
+        )
+        assert got == [b]
 
 
 class TestCLI:

--- a/bench/tests/test_evaluator_batch.py
+++ b/bench/tests/test_evaluator_batch.py
@@ -1,0 +1,572 @@
+"""Tests for the batch evaluator (issue #47 slice P1).
+
+Covers discovery, idempotency via ``config_hash``, concurrency, failure
+isolation, dry-run, and CLI round-trip. Stubs the single-bundle scorer
+so tests stay hermetic — the scoring pipeline itself is exercised by
+``test_evaluator_single``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from server.evaluator import batch as batch_mod
+from server.evaluator.batch import (
+    BundleOutcome,
+    filter_pending,
+    iter_bundle_dirs,
+    resolve_bundles,
+    run_campaign,
+)
+from server.evaluator.config_hash import compute_config_hash
+from server.storage.result_writer import save_run_state
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_bundle(
+    bench_root: Path,
+    *,
+    task_id: str,
+    persona_id: str,
+    session_id: str,
+    ts: str = "20260421_120000",
+) -> Path:
+    bundle_dir = (
+        bench_root
+        / "results"
+        / "server"
+        / task_id
+        / persona_id
+        / f"{ts}_{session_id[:8]}"
+    )
+    workspace = bench_root / "_ws" / session_id
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "solution.py").write_text("print(1)\n", encoding="utf-8")
+    save_run_state(
+        result_dir=bundle_dir,
+        conversation=[
+            {"role": "user", "content": "help"},
+            {"role": "assistant", "content": "sure"},
+        ],
+        tool_logs=[],
+        workspace_path=str(workspace),
+        duration_seconds=1.0,
+        distractor_names=[],
+        task_id=task_id,
+        session_id=session_id,
+        persona_id=persona_id,
+        session_status="completed",
+        termination_reason="tc_complete",
+        run_id=f"run_{task_id}_{session_id[:4]}",
+        public_task_label=task_id,
+    )
+    return bundle_dir
+
+
+def _stub_task(task_id="X01"):
+    return types.SimpleNamespace(
+        task_id=task_id,
+        category=types.SimpleNamespace(value="data_analysis"),
+        difficulty=types.SimpleNamespace(value="medium"),
+        requires_code=True,
+    )
+
+
+def _stub_persona(persona_id="fullstack_practitioner"):
+    return types.SimpleNamespace(
+        persona_id=persona_id,
+        knowledge_level="proficient_code",
+    )
+
+
+def _fake_scored_result(bundle_dir: Path, eval_run_id: str, bench_root: Path):
+    """Return the shape ``score_bundle`` hands back + write the sibling artefact."""
+    from server.evaluator.paths import eval_run_dir as _run_dir
+
+    loaded_manifest = json.loads((bundle_dir / "manifest.json").read_text())
+    out = _run_dir(
+        bench_root,
+        task_id=loaded_manifest["task_id"],
+        persona_id=loaded_manifest["persona_id"],
+        session_id=loaded_manifest["session_id"],
+        eval_run_id=eval_run_id,
+    )
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "eval_meta.json").write_text(
+        json.dumps(
+            {
+                "eval_run_id": eval_run_id,
+                "bundle_dir": str(bundle_dir),
+                "overall_score": 0.7,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return {
+        "_eval_run_id": eval_run_id,
+        "_eval_run_dir": out,
+        "_overall_score": 0.7,
+        "quant_result": 0.7,
+        "quant_process": 0.6,
+        "tutor_scores": {},
+    }
+
+
+@pytest.fixture
+def patched_score_bundle(tmp_path):
+    """Replace ``_score_one`` inside batch with a fast stub.
+
+    Counts per-bundle invocations so tests can assert idempotency.
+    """
+    calls: list[Path] = []
+
+    def _fake(bundle_dir, *, task, persona, bench_root, eval_model, eval_mode, tutor_dims, cancel_event=None, eval_run_id=None):
+        calls.append(Path(bundle_dir))
+        return _fake_scored_result(
+            Path(bundle_dir),
+            eval_run_id or f"eval_20260421_{len(calls):06d}",
+            Path(bench_root),
+        )
+
+    with patch.object(batch_mod, "_score_one", side_effect=_fake):
+        yield calls
+
+
+# ---------------------------------------------------------------------------
+# config_hash
+# ---------------------------------------------------------------------------
+
+
+class TestConfigHash:
+    def test_deterministic(self):
+        a = compute_config_hash(judge="j", eval_mode="full")
+        b = compute_config_hash(judge="j", eval_mode="full")
+        assert a == b
+
+    def test_judge_changes_hash(self):
+        a = compute_config_hash(judge="claude", eval_mode="full")
+        b = compute_config_hash(judge="gpt", eval_mode="full")
+        assert a != b
+
+    def test_tutor_dim_order_independent(self):
+        a = compute_config_hash(judge="j", eval_mode="full", tutor_dims=["D3", "D4"])
+        b = compute_config_hash(judge="j", eval_mode="full", tutor_dims=["D4", "D3"])
+        assert a == b
+
+    def test_rubric_version_changes_hash(self):
+        a = compute_config_hash(judge="j", eval_mode="full", rubric_version="1.0")
+        b = compute_config_hash(judge="j", eval_mode="full", rubric_version="2.0")
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+class TestDiscovery:
+    def test_iter_bundle_dirs_finds_manifested_bundles(self, tmp_path):
+        _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        _make_bundle(tmp_path, task_id="I01", persona_id="p2", session_id="b" * 32)
+
+        bundles = list(iter_bundle_dirs(tmp_path))
+        assert len(bundles) == 2
+
+    def test_iter_bundle_dirs_skips_pre_manifest_dirs(self, tmp_path):
+        _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        legacy = tmp_path / "results" / "server" / "X01" / "p1" / "20200101_000000_legacy00"
+        legacy.mkdir(parents=True)
+        (legacy / "run_state.json").write_text("{}")
+
+        bundles = list(iter_bundle_dirs(tmp_path))
+        assert len(bundles) == 1
+
+    def test_resolve_filters_by_task_and_persona(self, tmp_path):
+        _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        _make_bundle(tmp_path, task_id="X02", persona_id="p1", session_id="b" * 32)
+        _make_bundle(tmp_path, task_id="X01", persona_id="p2", session_id="c" * 32)
+
+        only_x01 = resolve_bundles(tmp_path, task_ids=["X01"])
+        assert len(only_x01) == 2
+
+        only_x01_p2 = resolve_bundles(tmp_path, task_ids=["X01"], persona_ids=["p2"])
+        assert len(only_x01_p2) == 1
+
+    def test_resolve_filters_by_session_id(self, tmp_path):
+        sid = "a" * 32
+        _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id=sid)
+        _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="b" * 32)
+
+        got = resolve_bundles(tmp_path, session_ids=[sid])
+        assert len(got) == 1
+
+    def test_resolve_requires_filter(self, tmp_path):
+        with pytest.raises(ValueError, match="needs at least one filter"):
+            resolve_bundles(tmp_path)
+
+    def test_resolve_bundle_paths_passthrough(self, tmp_path):
+        b = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        got = resolve_bundles(tmp_path, bundle_paths=[b])
+        assert got == [b]
+
+    def test_resolve_bundle_paths_drops_missing_manifest(self, tmp_path):
+        fake = tmp_path / "missing"
+        fake.mkdir()
+        got = resolve_bundles(tmp_path, bundle_paths=[fake])
+        assert got == []
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    def test_filter_pending_splits_on_config_hash(self, tmp_path, patched_score_bundle):
+        b1 = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        b2 = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="b" * 32, ts="20260421_130000")
+
+        run_campaign(
+            bench_root=tmp_path,
+            bundles=[b1],
+            task_loader=lambda _: _stub_task(),
+            persona_loader=lambda _: _stub_persona(),
+            eval_model="claude",
+            eval_mode="full",
+            concurrency=1,
+        )
+
+        cfg = compute_config_hash(judge="claude", eval_mode="full")
+        pending, scored = filter_pending([b1, b2], tmp_path, cfg)
+        assert [p for p in pending] == [b2]
+        assert scored and scored[0][0] == b1
+
+    def test_skip_scored_default_reruns_nothing(
+        self, tmp_path, patched_score_bundle
+    ):
+        b = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        kwargs = dict(
+            bench_root=tmp_path,
+            bundles=[b],
+            task_loader=lambda _: _stub_task(),
+            persona_loader=lambda _: _stub_persona(),
+            eval_model="claude",
+            eval_mode="full",
+            concurrency=1,
+        )
+        run_campaign(**kwargs)
+        assert len(patched_score_bundle) == 1
+
+        run_campaign(**kwargs)
+        assert len(patched_score_bundle) == 1  # skipped second time
+
+    def test_force_rescores(self, tmp_path, patched_score_bundle):
+        b = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        kwargs = dict(
+            bench_root=tmp_path,
+            bundles=[b],
+            task_loader=lambda _: _stub_task(),
+            persona_loader=lambda _: _stub_persona(),
+            eval_model="claude",
+            eval_mode="full",
+            concurrency=1,
+        )
+        run_campaign(**kwargs)
+        run_campaign(**{**kwargs, "force": True})
+        assert len(patched_score_bundle) == 2
+
+    def test_different_judge_triggers_rescoring(
+        self, tmp_path, patched_score_bundle
+    ):
+        b = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        common = dict(
+            bench_root=tmp_path,
+            bundles=[b],
+            task_loader=lambda _: _stub_task(),
+            persona_loader=lambda _: _stub_persona(),
+            eval_mode="full",
+            concurrency=1,
+        )
+        run_campaign(**common, eval_model="claude")
+        run_campaign(**common, eval_model="gpt")
+        assert len(patched_score_bundle) == 2
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+class TestRunCampaign:
+    def test_writes_campaign_summary(self, tmp_path, patched_score_bundle):
+        b = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        summary = run_campaign(
+            bench_root=tmp_path,
+            bundles=[b],
+            task_loader=lambda _: _stub_task(),
+            persona_loader=lambda _: _stub_persona(),
+            eval_model="claude",
+            eval_mode="full",
+            concurrency=1,
+        )
+        assert summary.totals["scored"] == 1
+        path = (
+            tmp_path / "evaluations" / "campaigns"
+            / summary.campaign_id / "summary.json"
+        )
+        assert path.is_file()
+        data = json.loads(path.read_text())
+        assert data["totals"]["scored"] == 1
+        assert data["config"]["judge"] == "claude"
+        assert data["config"]["config_hash"]
+
+    def test_dry_run_does_not_score(self, tmp_path, patched_score_bundle):
+        b = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        summary = run_campaign(
+            bench_root=tmp_path,
+            bundles=[b],
+            task_loader=lambda _: _stub_task(),
+            persona_loader=lambda _: _stub_persona(),
+            eval_model="claude",
+            dry_run=True,
+            concurrency=1,
+        )
+        assert summary.totals["pending"] == 1
+        assert summary.totals["scored"] == 0
+        assert len(patched_score_bundle) == 0
+        # dry-run must not persist a summary
+        assert not (tmp_path / "evaluations" / "campaigns").exists()
+
+    def test_concurrency_scores_every_bundle(
+        self, tmp_path, patched_score_bundle
+    ):
+        bundles = [
+            _make_bundle(
+                tmp_path,
+                task_id="X01",
+                persona_id="p1",
+                session_id=chr(ord("a") + i) * 32,
+                ts=f"2026042{i}_120000",
+            )
+            for i in range(5)
+        ]
+        summary = run_campaign(
+            bench_root=tmp_path,
+            bundles=bundles,
+            task_loader=lambda _: _stub_task(),
+            persona_loader=lambda _: _stub_persona(),
+            eval_model="claude",
+            concurrency=3,
+        )
+        assert summary.totals["scored"] == 5
+        assert len(patched_score_bundle) == 5
+
+    def test_failure_isolated_per_bundle(self, tmp_path):
+        ok = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        boom = _make_bundle(tmp_path, task_id="X02", persona_id="p1", session_id="b" * 32, ts="20260421_130000")
+
+        def _side_effect(
+            bundle_dir, *, task, persona, bench_root, eval_model, eval_mode,
+            tutor_dims, cancel_event=None, eval_run_id=None,
+        ):
+            if Path(bundle_dir) == boom:
+                raise RuntimeError("judge timeout")
+            return _fake_scored_result(
+                Path(bundle_dir),
+                "eval_20260421_000001",
+                Path(bench_root),
+            )
+
+        with patch.object(batch_mod, "_score_one", side_effect=_side_effect):
+            summary = run_campaign(
+                bench_root=tmp_path,
+                bundles=[ok, boom],
+                task_loader=lambda _: _stub_task(),
+                persona_loader=lambda _: _stub_persona(),
+                eval_model="claude",
+                concurrency=1,
+            )
+        assert summary.totals["scored"] == 1
+        assert summary.totals["failed"] == 1
+        failed = [o for o in summary.outcomes if o["status"] == "failed"]
+        assert failed and "judge timeout" in failed[0]["error"]
+
+    def test_loader_systemexit_isolated_per_bundle(self, tmp_path, patched_score_bundle):
+        """``_load_task`` raises ``SystemExit`` when a task JSON is missing.
+
+        A bare ``except Exception`` would let that propagate and abort the
+        campaign; the isolated worker must convert it to a failed outcome.
+        """
+        good = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        bad = _make_bundle(
+            tmp_path, task_id="XNOT_FOUND", persona_id="p1",
+            session_id="b" * 32, ts="20260421_130000",
+        )
+
+        def _loader(task_id: str):
+            if task_id == "XNOT_FOUND":
+                raise SystemExit(f"task {task_id!r} not found")
+            return _stub_task(task_id)
+
+        summary = run_campaign(
+            bench_root=tmp_path,
+            bundles=[good, bad],
+            task_loader=_loader,
+            persona_loader=lambda _: _stub_persona(),
+            eval_model="claude",
+            concurrency=1,
+        )
+        assert summary.totals["scored"] == 1
+        assert summary.totals["failed"] == 1
+
+    def test_per_worker_concurrency_restored_after_run(
+        self, tmp_path, patched_score_bundle
+    ):
+        """Concurrency tuning must not leak out of the campaign.
+
+        A long-lived process (the REST server, tests, a REPL) would
+        otherwise run unrelated single-bundle evals at the throttled
+        per-worker cap forever after the batch exits.
+
+        The real evaluator modules may not import in a CI env lacking
+        ``nest_asyncio``; stub ``_concurrency_modules`` so the test
+        pins behaviour independent of that optional dependency.
+        """
+        tutor_stub = types.SimpleNamespace(
+            _CONCURRENCY=20,
+            set_eval_concurrency=lambda n: setattr(tutor_stub, "_CONCURRENCY", n),
+        )
+        proc_stub = types.SimpleNamespace(
+            _CONCURRENCY=20,
+            set_eval_concurrency=lambda n: setattr(proc_stub, "_CONCURRENCY", n),
+        )
+        b = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        with patch.object(
+            batch_mod, "_concurrency_modules", return_value=(tutor_stub, proc_stub)
+        ):
+            run_campaign(
+                bench_root=tmp_path,
+                bundles=[b],
+                task_loader=lambda _: _stub_task(),
+                persona_loader=lambda _: _stub_persona(),
+                eval_model="claude",
+                concurrency=8,
+            )
+        assert tutor_stub._CONCURRENCY == 20
+        assert proc_stub._CONCURRENCY == 20
+
+    def test_campaign_ids_unique_within_a_second(self, tmp_path, patched_score_bundle):
+        """Rapid reruns (all-skipped --all-pending) must not clobber each other."""
+        b = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        kwargs = dict(
+            bench_root=tmp_path,
+            bundles=[b],
+            task_loader=lambda _: _stub_task(),
+            persona_loader=lambda _: _stub_persona(),
+            eval_model="claude",
+            concurrency=1,
+        )
+        run_campaign(**kwargs)
+        run_campaign(**kwargs)
+        run_campaign(**kwargs)
+
+        campaign_root = tmp_path / "evaluations" / "campaigns"
+        dirs = [p.name for p in campaign_root.iterdir() if p.is_dir()]
+        assert len(dirs) == 3, f"expected 3 distinct campaign dirs, got {dirs}"
+
+    def test_progress_callback_invoked(self, tmp_path, patched_score_bundle):
+        bundles = [
+            _make_bundle(
+                tmp_path,
+                task_id="X01",
+                persona_id="p1",
+                session_id=chr(ord("a") + i) * 32,
+                ts=f"2026042{i}_120000",
+            )
+            for i in range(3)
+        ]
+        seen: list[tuple[int, int, str]] = []
+
+        def _cb(o: BundleOutcome, done: int, total: int) -> None:
+            seen.append((done, total, o.status))
+
+        run_campaign(
+            bench_root=tmp_path,
+            bundles=bundles,
+            task_loader=lambda _: _stub_task(),
+            persona_loader=lambda _: _stub_persona(),
+            eval_model="claude",
+            concurrency=1,
+            on_progress=_cb,
+        )
+        assert len(seen) == 3
+        assert all(total == 3 for _, total, _ in seen)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_all_pending_round_trip(self, tmp_path, patched_score_bundle):
+        b = _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        from server.evaluator import __main__ as cli
+
+        with (
+            patch.object(cli, "_load_task", return_value=_stub_task()),
+            patch.object(cli, "_load_persona", return_value=_stub_persona()),
+        ):
+            rc = cli.main(
+                [
+                    "--bench-root",
+                    str(tmp_path),
+                    "--all-pending",
+                    "--eval-model",
+                    "claude",
+                    "--concurrency",
+                    "1",
+                ]
+            )
+        assert rc == 0
+        assert len(patched_score_bundle) == 1
+        b  # silence linters
+
+    def test_dry_run_exits_zero(self, tmp_path, patched_score_bundle):
+        _make_bundle(tmp_path, task_id="X01", persona_id="p1", session_id="a" * 32)
+        from server.evaluator import __main__ as cli
+
+        with (
+            patch.object(cli, "_load_task", return_value=_stub_task()),
+            patch.object(cli, "_load_persona", return_value=_stub_persona()),
+        ):
+            rc = cli.main(
+                [
+                    "--bench-root",
+                    str(tmp_path),
+                    "--all-pending",
+                    "--dry-run",
+                ]
+            )
+        assert rc == 0
+        assert len(patched_score_bundle) == 0
+
+    def test_missing_selector_returns_error(self, tmp_path, capsys):
+        from server.evaluator import __main__ as cli
+
+        rc = cli.main(["--bench-root", str(tmp_path)])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "selector" in err

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -283,6 +283,21 @@ in the sibling `evaluations/server/...` tree, and bundles must carry
 
 Issue #47 slice P1 (landed): `batch.py` + `config_hash.py` layered on
 top of `score_bundle` with idempotent dispatch, failure isolation, and
-a campaign summary. Remaining work (slice P2) adds `--max-cost-usd`,
-`--resume` from checkpoint, `--since`/`--until`, and a retry wrapper
-for transient judge-LLM failures.
+a campaign summary.
+
+Issue #47 slice P2 (landed): budget gating, checkpoint/resume, and
+time-window filters.
+
+- `--max-cost-usd` runs the worker pool in lazy-dispatch mode: pull the
+  next bundle only when below the cap, mark the rest skipped with
+  `error="budget_exceeded"` so the summary still audits them.
+- `--resume CAMPAIGN_ID` reuses the original campaign dir and replays
+  `checkpoint.jsonl` to skip bundles already scored. Every outcome is
+  appended to that checkpoint as it completes so an interrupted run
+  has something to restart from.
+- `--since` / `--until` filter bundles by manifest `created_at`;
+  unparseable timestamps pass so legacy producers don't silently drop.
+- Per-bundle cost comes from the `_eval_cost` signals the pipeline
+  already emits (tutor rubric + process metrics + result judge). The
+  total lands in `CampaignSummary.cost_usd` and is stamped into
+  `eval_meta.json` for downstream audit.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,15 +121,18 @@ bundles and writes to the sibling tree:
 | File | Role |
 |------|------|
 | `single.py::score_bundle` | Load a bundle, call `evaluate_task`, compute overall score, write reports + `eval_meta.json` to `evaluations/server/.../`. |
-| `paths.py` | `eval_run_dir`, `new_eval_run_id`, `find_latest_eval_dir`, `list_eval_history` — single source of truth for eval output locations, with legacy-fallback. |
-| `__main__.py` | CLI: `python -m server.evaluator --bundle <path> [--eval-mode …] [--eval-model …]`. Issue #47 will add batch flags on top. |
+| `paths.py` | `eval_run_dir`, `new_eval_run_id`, `find_latest_eval_dir`, `list_eval_history` — single source of truth for eval output locations. |
+| `batch.py::run_campaign` | Fan `score_bundle` over many bundles with `ThreadPoolExecutor` dispatch, idempotency via `config_hash`, failure isolation, and a campaign-level summary at `evaluations/campaigns/{campaign_id}/summary.json`. |
+| `config_hash.py` | Deterministic 16-char hash over `(judge, eval_mode, tutor_dims, rubric_version, formula_version)`; stamped into `eval_meta.json` so `--skip-scored` can recognise prior runs. |
+| `__main__.py` | CLI with two modes: single-bundle (`--bundle <path>`) and batch (`--all-pending`, `--session`, `--task-id`, `--persona`, `--bundles-from`, `--concurrency`, `--skip-scored`/`--force`, `--dry-run`). |
 
 `score_bundle` is the single scoring entry point. The operator REST
 handler (`http_app.ops_evaluate`) calls it synchronously via
 `asyncio.to_thread`; the CLI calls it directly. All readers (session
 API `get_eval_scores`, archived-session REST, UI indexer) go through
 `paths.find_latest_eval_dir` so the on-disk layout is decided in one
-place.
+place. Campaigns write to `evaluations/campaigns/{campaign_id}/summary.json`
+(sibling to the per-session tree) for audit.
 
 ## Evaluation pipeline (`bench/server/eval/`)
 
@@ -278,5 +281,8 @@ in the sibling `evaluations/server/...` tree, and bundles must carry
 `manifest.json` — `load_bundle` is the single source of truth for
 "what's in a bundle". The producer/consumer split is complete.
 
-Issue #47 (batch evaluator) is unblocked — its CLI sits on top of
-`score_bundle`.
+Issue #47 slice P1 (landed): `batch.py` + `config_hash.py` layered on
+top of `score_bundle` with idempotent dispatch, failure isolation, and
+a campaign summary. Remaining work (slice P2) adds `--max-cost-usd`,
+`--resume` from checkpoint, `--since`/`--until`, and a retry wrapper
+for transient judge-LLM failures.


### PR DESCRIPTION
## Summary

Promotes issue #47 (batch evaluator) from dev to master via PR #52 ([`bb452e8`](https://github.com/varsity-tech-product/benchmark/commit/bb452e8)).

- P1: `batch.py::run_campaign` + idempotent `config_hash` + CLI selectors + campaign summary.
- P2: `--max-cost-usd`, `--resume CAMPAIGN_ID` (checkpoint-aware), `--since`/`--until`, `process_metrics` cost coverage.

## Test plan

- [x] 36 batch tests + 60 evaluator/bundle/eval-flow tests green on the feature branch before merge.
- [x] Two codex-review rounds (one per slice); all eight accepted findings fixed inline, logged in issue #47 comments.