### PR TITLE
Merge dev → master: DELETE persist fix (#54)

### DIFF
--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -1319,7 +1319,11 @@ async def rest_session_status(request: Request) -> JSONResponse | Response:
         if not state:
             return JSONResponse({"error": "Session not found"}, 404)
         logger.info("[REST:%s] DELETE — cancelling session", sid[:8])
-        await manager._cleanup_session(sid)
+        # persist_partial=True so an active session's conversation + tool
+        # logs land as a bundle under results/server/... before the
+        # container is destroyed. Without this the offline evaluator
+        # (issue #47 batch driver) cannot see DELETEd sessions at all.
+        await manager._cleanup_session(sid, persist_partial=True)
         return JSONResponse({"status": "cancelled"})
 
     # GET

--- a/bench/tests/api/test_session_lifecycle.py
+++ b/bench/tests/api/test_session_lifecycle.py
@@ -146,6 +146,40 @@ class TestSessionStatus:
         assert resp.json()["status"] == "cancelled"
 
     @pytest.mark.asyncio
+    async def test_delete_persists_bundle(self, client, bench_root):
+        """Regression for issue #54.
+
+        DELETE used to discard the bundle because ``_cleanup_session``
+        was called without ``persist_partial=True``. That made DELETEd
+        sessions invisible to the batch evaluator (issue #47). The fix
+        routes DELETE through the same agent-abandoned persistence path
+        the lifespan shutdown hooks already used.
+        """
+        import json
+
+        sid, _ = await register_and_start(client)
+        await send_message(client, sid, "some conversation before DELETE")
+
+        resp = await client.delete(f"/session/{sid}")
+        assert resp.status_code == 200
+
+        task_root = bench_root / "results" / "server" / DEFAULT_TASK_ID
+        matches = list(task_root.rglob(f"*_{sid[:8]}"))
+        assert matches, f"bundle was not persisted under {task_root}"
+        bundle = matches[0]
+
+        manifest = json.loads((bundle / "manifest.json").read_text())
+        assert manifest["bundle_schema_version"].startswith("1.")
+        assert manifest["session_id"] == sid
+
+        run_state = json.loads((bundle / "run_state.json").read_text())
+        # ``agent_abandoned`` is not in ``_is_failed_reason`` so the
+        # session_status rolls up as ``completed``; the reason string is
+        # what distinguishes a DELETE from a normal finish.
+        assert run_state["termination_reason"] == "agent_abandoned"
+        assert run_state["session_status"] in ("completed", "failed")
+
+    @pytest.mark.asyncio
     async def test_list_sessions(self, client):
         sid, _ = await register_and_start(client)
         resp = await client.get("/session/list")


### PR DESCRIPTION
Promotes #55 ([`f5c3170`](https://github.com/varsity-tech-product/benchmark/commit/f5c3170)) from dev to master. Fixes issue #54: DELETE /session now persists the bundle via `_cleanup_session(sid, persist_partial=True)` so the batch evaluator (#47) can see DELETEd sessions.