### PR TITLE
docs(agent): agent-in-loop reference + Claude Code skill (#57)

### DIFF
--- a/.claude/skills/quanttutorbench-agent/SKILL.md
+++ b/.claude/skills/quanttutorbench-agent/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: quanttutorbench-agent
+description: Drive a QuantTutorBench tutoring session as the agent in the loop via REST. Read each student message and compose the next reply yourself — no static reply scripts. Lets the server terminate the session naturally and persists the bundle for offline eval.
+disable-model-invocation: false
+allowed-tools: Bash, Read, Write
+---
+
+# QuantTutorBench: agent in the loop
+
+You are the **tutor agent** for a QuantTutorBench session driven over REST.
+The student is a server-side LLM persona; you cannot see them, you only see
+their text replies. Your job is to drive a real tutoring conversation —
+read each student message and compose the next reply based on what they
+actually said.
+
+## Source of truth
+
+The full reference — REST flow, termination semantics, workspace tools,
+bundle persistence, the five real pitfalls, and the pre-flight checklist —
+lives at **`docs/agent_in_loop.md`**. Read it before driving a session.
+
+That document is the canonical, agent-agnostic reference (Codex, Cursor,
+Gemini, custom agents read it too). This skill exists so that Claude Code
+agents in this repo can be auto-invoked into the right behavior; both
+artifacts are kept in sync via issue #57.
+
+The runnable reference driver is **`bench/scripts/agent_in_loop_example.py`**
+— replace its `compose_reply` stub with your model integration and the rest
+works as-is.
+
+## When to use this skill
+
+The user asks you to:
+
+- "Drive an I-series / X-series / E-series / D-series / B-series / S-series
+  / A-series task on prod or local"
+- "Run a live tutoring session against the benchmark server"
+- "Be the agent for a QuantTutorBench eval session"
+- "Smoke-test the eval flow with a real LLM in the loop"
+
+Do **not** use this skill for:
+
+- Static availability smoke tests — `bench/scripts/prod_smoke.py`.
+- Batch evaluation of existing bundles — `python -m server.evaluator --all-pending`.
+- Building a new task or persona — JSON edits under `bench/tasks/` and `bench/personas/`.
+
+## How to drive a session (operational summary)
+
+1. **Read `docs/agent_in_loop.md` first** — every section is load-bearing.
+2. Create the run + session via the four-call lifecycle described there.
+3. Run the per-turn loop: read `student_message`, compose the next reply
+   based on what they actually said, POST to `/session/{sid}/send`. Repeat
+   until `status != "active"`.
+4. **Never use a static reply queue.** The server's repeat-detector fires
+   `agent_stuck` after 3× identical text. Compose every reply.
+5. Use HTTP client timeout ≥ 900 s on `/send` (student-sim turns can take
+   5–15 s, with outliers around 16 s).
+6. Don't DELETE active sessions to "clean up" — let the server terminate
+   naturally (max_turns is the usual endpoint).
+7. When terminal, print the session id and expected bundle path:
+   `bench/results/server/{task_id}/{persona_id}/{YYYYMMDD_HHMMSS}_{session_id[:8]}/`.
+8. Eval is out of band — point the operator at
+   `python -m server.evaluator --bundle <bundle_dir>`.
+
+## Default environment
+
+Production VPS is the canonical target for any agent driving a session
+unless the user explicitly asks for local dev:
+
+```
+BASE="https://217-15-165-83.sslip.io"
+```
+
+Use `http://localhost:8765` **only** when the user has confirmed they
+started a local server with `python -m server --port 8765 --docker`. Other
+agents reading your output expect prod URLs in any commands you produce.
+
+`https://benchmark-liard.vercel.app` proxies to the same backend; use it
+only if you specifically need to exercise the Vercel rewrites layer.
+
+## Pre-flight check before you start
+
+- `BASE` defaults to the production VPS above unless the user said otherwise.
+- `task_id` and `persona_id` are real (consult `bench/tasks/.../*.json`).
+- Your reply strategy reads the latest `student_message` (no static queue).
+- HTTP client timeout ≥ 900 s.
+- You're prepared for ~15+ turns; don't bail early.
+
+If any of those are unclear, read `docs/agent_in_loop.md` end to end before
+starting.

--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,10 @@ bench/experiments/student_sim_stability/pilot/
 bench/experiments/student_sim_stability/doc/
 
 # Claude Code local state
-.claude/
+# Claude Code config — local user settings stay private, but project-scoped
+# skills are checked in so they ship with the repo (issue #57).
+.claude/*
+!.claude/skills/
 
 # Vercel
 vercel-frontend/.vercel/

--- a/bench/scripts/agent_in_loop_example.py
+++ b/bench/scripts/agent_in_loop_example.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Drive a QuantTutorBench REST session with an agent-in-the-loop.
+
+Reference driver for engineers wiring their own LLM tutor into the
+benchmark. Replace ``compose_reply`` with a real model call; the rest of
+the file shows the REST lifecycle and terminal-status handling.
+
+For the full agent-in-loop reference (auth, termination semantics,
+workspace tools, common pitfalls), read the project skill at
+``.claude/skills/quanttutorbench-agent/SKILL.md``. Issue #57.
+
+Usage:
+    # Default target is the production VPS — see docs/agent_in_loop.md
+    python bench/scripts/agent_in_loop_example.py --task I02 --persona developer_crossover
+
+    # Override only when running a local dev server (python -m server --port 8765 --docker)
+    python bench/scripts/agent_in_loop_example.py --task I02 --base-url http://localhost:8765
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+DEFAULT_BASE_URL = "https://217-15-165-83.sslip.io"  # production VPS — see docs/agent_in_loop.md
+CLIENT_INFO = {"name": "agent_in_loop_example", "version": "0.1.0"}
+TERMINAL = {"completed", "failed"}
+
+
+def compose_reply(student_message: str, history: list[dict[str, str]]) -> str:
+    """Extension point: replace this stub with your LLM tutor call.
+
+    A production version sends ``history`` plus the latest
+    ``student_message`` to OpenAI, Anthropic, Gemini, or another model and
+    returns the tutor's next message. This stub stays deterministic and
+    varies each turn so the server's repeat detector sees a real loop.
+
+    Pitfall: returning the same string three turns in a row trips the
+    server's repeat-detector and ends the session with
+    ``reason=agent_stuck``. Always derive the reply from the actual
+    ``student_message`` content.
+    """
+    turn = 1 + sum(1 for item in history if item["role"] == "tutor")
+    focus = " ".join(student_message.split())[:180] or "the current task"
+    return (
+        f"Turn {turn}: I read your latest note: {focus}\n\n"
+        "For the next step, keep the work concrete: identify the strategy state, "
+        "write or inspect the implementation, run the relevant check, and share "
+        "the output you observe."
+    )
+
+
+def _repo_bench_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _find_local_bundle(session_id: str, bench_root: Path) -> Path | None:
+    short_id = session_id[:8]
+    results_root = bench_root / "results" / "server"
+    if not results_root.is_dir():
+        return None
+    matches = sorted(results_root.glob(f"*/*/*_{short_id}"))
+    for path in matches:
+        if (path / "manifest.json").is_file():
+            return path
+    return None
+
+
+async def _post_json(
+    client: httpx.AsyncClient,
+    path: str,
+    *,
+    json_body: dict[str, Any],
+    headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    response = await client.post(path, json=json_body, headers=headers or {})
+    if response.status_code < 200 or response.status_code >= 300:
+        raise RuntimeError(f"{path} -> HTTP {response.status_code}: {response.text}")
+    return response.json()
+
+
+async def run_session(args: argparse.Namespace) -> int:
+    base_url = args.base_url.rstrip("/")
+    timeout = httpx.Timeout(args.timeout, connect=10.0)
+    history: list[dict[str, str]] = []
+    turn_count = 0
+
+    async with httpx.AsyncClient(base_url=base_url, timeout=timeout) as client:
+        run = await _post_json(
+            client,
+            "/client/runs/start",
+            json_body={"task": args.task, "client": CLIENT_INFO},
+        )
+        run_id = run["run_id"]
+        token = run["token"]
+        auth = {"Authorization": f"Bearer {token}"}
+        print(f"run_id={run_id} task={run.get('public_task_label', args.task)}")
+
+        register_body: dict[str, str] = {}
+        if args.persona:
+            register_body["persona_id"] = args.persona
+        registration = await _post_json(
+            client, "/session/register", json_body=register_body, headers=auth
+        )
+        session_id = registration["session_id"]
+        print(f"session_id={session_id}")
+
+        started = await _post_json(
+            client, f"/session/{session_id}/start", json_body={}, headers=auth
+        )
+        background = started.get("background", "")
+        student_message = started.get("student_message", "")
+        history.append({"role": "system", "content": background})
+        history.append({"role": "student", "content": student_message})
+        status = started.get("status", "active")
+
+        print(f"student: {student_message[:240]}")
+        while status not in TERMINAL:
+            turn_count += 1
+            if turn_count > args.safety_turn_cap:
+                # Hard kill so a misbehaving compose_reply (or a server
+                # that never terminates) cannot loop forever. The bundle
+                # still persists via the DELETE-with-persist path (#54).
+                print(
+                    f"safety-cap turn={turn_count} > {args.safety_turn_cap} "
+                    "— DELETEing session"
+                )
+                await client.delete(f"/session/{session_id}", headers=auth)
+                break
+            tutor_text = compose_reply(student_message, history)
+            history.append({"role": "tutor", "content": tutor_text})
+            print(f"tutor: {tutor_text.splitlines()[0]}")
+
+            turn = await _post_json(
+                client,
+                f"/session/{session_id}/send",
+                json_body={"text": tutor_text},
+                headers=auth,
+            )
+            status = turn.get("status", "active")
+            reason = turn.get("reason", "")
+            student_message = turn.get("student_message", "")
+            if student_message:
+                history.append({"role": "student", "content": student_message})
+                print(f"student: {student_message[:240]}")
+            print(f"status={status}" + (f" reason={reason}" if reason else ""))
+
+        bundle = _find_local_bundle(session_id, args.bench_root)
+        if bundle:
+            print(f"bundle={bundle}")
+        else:
+            print(f"bundle=check server results for session {session_id}")
+        # Eval is out-of-band; the agent loop never triggers it. Print
+        # the command so the operator knows what to run next.
+        print(
+            f"score it later: python -m server.evaluator --bundle <bundle_dir> "
+            f"  # session_id={session_id}"
+        )
+        return 0 if status == "completed" else 1
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help=(
+            "Server URL. Defaults to production VPS "
+            f"({DEFAULT_BASE_URL}). Override with http://localhost:8765 "
+            "only when running a local dev server."
+        ),
+    )
+    parser.add_argument("--task", default="D01")
+    parser.add_argument("--persona", default="")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=900.0,
+        help=(
+            "Per-call HTTP timeout in seconds. /session/{sid}/send can "
+            "take 5-15 s on heavy student-sim turns; default 900 leaves "
+            "headroom without masking real hangs."
+        ),
+    )
+    parser.add_argument(
+        "--safety-turn-cap",
+        type=int,
+        default=50,
+        help=(
+            "Hard kill after this many turns even if the server has not "
+            "terminated. Higher than any task.max_turns. Default: 50."
+        ),
+    )
+    parser.add_argument(
+        "--bench-root",
+        type=Path,
+        default=_repo_bench_root(),
+        help="Local bench/ path used only to locate persisted bundles.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        return asyncio.run(run_session(args))
+    except (httpx.HTTPError, RuntimeError, KeyError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/agent_in_loop.md
+++ b/docs/agent_in_loop.md
@@ -1,0 +1,280 @@
+# Agent in the loop: driving QuantTutorBench sessions over REST
+
+**Audience.** Any engineer or AI agent (Claude, Codex, Cursor, Gemini, custom)
+that wants to drive a QuantTutorBench tutoring session as the **tutor** in
+the loop. The student is a server-side LLM persona — you cannot see them,
+you only see their text replies. Your job is to drive a real conversation:
+read each student message and compose the next reply based on what they
+actually said.
+
+This is the **canonical, agent-agnostic reference**. Claude Code agents
+working in this repo also see a thin invocation shim at
+`.claude/skills/quanttutorbench-agent/SKILL.md` that points back here.
+The runnable example is `bench/scripts/agent_in_loop_example.py`.
+
+Issue #57 captures the design decisions and the empirical evidence behind
+the pitfalls below.
+
+---
+
+## Environments — pick the right BASE
+
+There are three URLs for the benchmark. **Default to production unless you
+have a specific reason to use local.**
+
+| Where | URL | When to use |
+|---|---|---|
+| **Production VPS** (canonical) | `https://217-15-165-83.sslip.io` | Real eval runs, batch campaigns, anything you want bundles persisted on the canonical host. **This is the default for any external agent.** |
+| Production via Vercel | `https://benchmark-liard.vercel.app` | Same backend; use only if you need to exercise the Vercel rewrites layer (frontend integration testing). |
+| Local dev | `http://localhost:8765` | You started the server yourself with `python -m server --port 8765 --docker` for code changes / debugging. **Do not use this in command examples for other agents** — they probably do not have a local server running. |
+
+If you are an agent reading this guide and the user did not tell you which
+environment to use, **assume production**:
+
+```bash
+BASE="https://217-15-165-83.sslip.io"
+```
+
+## When this applies
+
+Use this guide when you want to:
+
+- Drive an I-series / X-series / E-series / D-series / B-series / S-series
+  / A-series task on prod or local.
+- Run a live tutoring session against the benchmark server with your own LLM
+  acting as the tutor.
+- Smoke-test the eval pipeline end-to-end with a real LLM in the loop.
+
+This is **not** the right reference for:
+
+- Static availability ping — that's `bench/scripts/prod_smoke.py`.
+- Batch evaluation of existing bundles — that's
+  `python -m server.evaluator --all-pending` (issue #47).
+- Building a new task or persona — those are JSON edits under
+  `bench/tasks/` and `bench/personas/`.
+
+---
+
+## The four-call lifecycle
+
+```
+POST /client/runs/start    → run_id, token
+POST /session/register     → session_id     (Authorization: Bearer <token>)
+POST /session/{sid}/start  → background, opening student_message
+POST /session/{sid}/send   → student reply, status, reason     (loop)
+```
+
+Concrete shell sketch:
+
+```bash
+BASE="${BASE:-https://217-15-165-83.sslip.io}"   # production VPS — default; see Environments table
+TASK="I01_implement_sma"                          # any bench/tasks/.../*.json id
+PERSONA="fullstack_practitioner"                  # one of task.persona_ids
+
+RUN=$(curl -sS -X POST "$BASE/client/runs/start" \
+        -H 'content-type: application/json' \
+        -d "{\"task\":\"$TASK\",\"mode\":\"agent\"}")
+TOKEN=$(echo "$RUN" | jq -r .token)
+
+SID=$(curl -sS -X POST "$BASE/session/register" \
+        -H "authorization: Bearer $TOKEN" \
+        -H 'content-type: application/json' \
+        -d "{\"persona_id\":\"$PERSONA\"}" | jq -r .session_id)
+
+START=$(curl -sS -X POST "$BASE/session/$SID/start")
+OPENER=$(echo "$START" | jq -r .student_message)
+# ... loop send_message until terminal ...
+```
+
+For a complete reference implementation, read
+`bench/scripts/agent_in_loop_example.py`. The `compose_reply` function is
+the LLM extension point — replace its stub with your model integration.
+
+---
+
+## The per-turn loop (the only correct pattern)
+
+Each turn:
+
+1. You have the most recent `student_message` (from `/start` on turn 1, or
+   from the previous `/send` response on subsequent turns).
+2. **You read it carefully and compose the next reply based on what the
+   student actually said.** Not a preset list. Not a template. Address the
+   specific question or concern in their last message.
+3. POST to `/session/{sid}/send` with `{"text": "<your reply>"}`.
+4. Response shape (verified against `bench/server/core/session.py::TutoringSession._result`):
+   `{"student_message": "...", "status": "active|completed|failed", "reason": "...", "sim_error": {...}?, "current_phase": "...", "next_allowed": [...]}`.
+   `reason` is omitted on `active`; `sim_error` only appears on
+   `student_sim_error:*` failures. There is **no** `tool_calls` field —
+   the student persona has no tools to call.
+5. If `status != "active"`, the session is terminal — stop the loop.
+
+The repeat-detector pitfall (below) makes this non-negotiable: you must
+*compose* each reply. A static reply queue will eventually trigger
+`agent_stuck`.
+
+---
+
+## Termination semantics
+
+The server ends the session when one of these fires:
+
+| `status` | `reason` | What it means |
+|---|---|---|
+| `completed` | `objectives_met` | T/C checker fired — task objectives covered. Cleanest possible close. |
+| `completed` | `max_turns` | Hit `task.max_turns` (e.g. I01 = 15). Natural close. |
+| `completed` | `timeout` | `task.timeout_minutes` deadline reached. Still treated as `completed` (see `_is_failed_reason` in `bench/server/core/session.py`). |
+| `completed` | `agent_abandoned` | DELETE during an active session. Bundle persists since #54. |
+| `failed` | `agent_stuck` | You sent the **same `text` 3× in a row** — repeat-detector. |
+| `failed` | `student_sim_error:*` | Student-sim LLM failure. Response also carries `sim_error` with structured failure metadata. Not your fault. |
+
+There is **no "agent declares done" tool** in the protocol. The protocol
+terminates only via server-side signals. The natural endpoint is
+`max_turns` for most tasks. See `bench/server/api/protocol.py` for the
+state machine.
+
+After terminal status, the protocol exposes `next_allowed: []` and the
+agent lifecycle ends.
+
+---
+
+## Workspace tools (when to call them)
+
+You also have access to per-session tool endpoints under
+`/session/{sid}/tool/<name>`. The full catalogue is at
+`/session/{sid}/tools`. Common ones:
+
+- `file_write`, `file_read`, `file_list`, `shell_exec`, `code_exec`
+- `fetch_market_data`, `compute_indicator`, `compute_statistics`
+- `run_backtest` — Python backtest engine. **Async**: returns HTTP 202
+  with `{job_id, status, poll_url}`; poll
+  `GET /session/{sid}/tool/jobs/{job_id}` for terminal state.
+- `run_lean_backtest` — LEAN C# backtest. **Async**: same 202 +
+  `{job_id, status, poll_url}` shape as `run_backtest`. Both belong to
+  `HEAVY_TOOLS` (`bench/server/api/limits.py`) and share the
+  `QTB_MAX_CONCURRENT_BACKTESTS` semaphore.
+
+These tools run **inside the session's Docker sandbox** with
+`cwd=/workspace`. Anything you write to `/workspace` is captured as
+`agent_files/` in the final bundle.
+
+**The student cannot call tools.** They are a simulated LLM persona
+(`bench/server/core/student_sim.py`) — pure text in, pure text out. If the
+student says "I'll run it now", nothing physical happens. If you want a
+real backtest result to feature in the session, **you** must call
+`run_lean_backtest` yourself and incorporate the output into your next
+reply.
+
+When to call workspace tools (not exhaustive):
+
+- **Debug-class tasks (X-series).** Copy `/student_code/foo.cs` into
+  `/workspace`, edit, build, backtest, compare to reference.
+- **Implementation tasks (I-series)** *if* the student asks for a
+  demonstration. By default I-series is verbal guidance — only run code if
+  it adds genuine value to the conversation.
+- **Validation tasks.** Run the algorithm to verify a specific claim before
+  asserting it in your next reply.
+
+---
+
+## Five real pitfalls
+
+Each one is grounded in a live failure mode (sessions `01e84317` and
+`42e74d3a`):
+
+1. **Static reply queues trigger `agent_stuck`.** A driver that sends
+   pre-written messages indexed by turn number will eventually emit the
+   same closing line three times in a row. The server's repeat-detector
+   fires `reason=agent_stuck` and the session ends `failed`. Always
+   compose each reply from the actual `student_message` you just received.
+
+2. **`/session/{sid}/send` can take 5–15 seconds** per call (student-sim
+   LLM round-trip). Use a generous client timeout — `--max-time 900` or
+   the equivalent in your HTTP client. Live runs have produced
+   individual turns up to ~16 s.
+
+3. **`max_turns` is per-task, not per-session.** I01 = 15. You cannot
+   raise it from the agent side. Don't set your own lower cap — let the
+   server end the session.
+
+4. **Don't DELETE active sessions to "clean up" early.** It's safe since
+   #54 (the bundle persists), but `reason=agent_abandoned` is a worse
+   audit trail than `reason=max_turns` or `reason=objectives_met`. Drive to
+   natural terminal whenever possible.
+
+5. **Auth.** Only `/ops/*` endpoints need `QTB_ADMIN_TOKEN`. The agent
+   surface (`/client/runs/*`, `/session/*`) uses the per-run bearer
+   token returned by `/client/runs/start`. Don't ask the user for an
+   admin token to drive a session — it's not needed and you shouldn't
+   have it.
+
+---
+
+## Bundle persistence
+
+When the session reaches a terminal status, the server automatically:
+
+1. Saves `run_state.json` (full conversation + `tool_logs` + metadata).
+2. Saves `run_state.md` (human-readable transcript).
+3. Snapshots `/workspace` into `agent_files/` (any code/data the tutor
+   wrote).
+4. Writes `manifest.json` (v1.0.0 bundle contract from issue #46).
+
+Bundle path:
+```
+bench/results/server/{task_id}/{persona_id}/{YYYYMMDD_HHMMSS}_{session_id[:8]}/
+```
+
+Print the session id and expected bundle path at the end of your run so
+the operator knows where to find it.
+
+Since #54, `DELETE /session/{sid}` also persists the bundle. Natural
+terminal is still preferable for cleaner audit metadata.
+
+---
+
+## Eval is out of band
+
+You do **not** trigger evaluation from the agent loop. After the session
+terminates, the bundle is ready for offline scoring via:
+
+```bash
+# Single-bundle:
+python -m server.evaluator --bundle <bundle_dir>
+
+# Or batched against many bundles (issue #47):
+python -m server.evaluator --all-pending --concurrency 4
+```
+
+The agent's job ends at the terminal `send_message`. Mention this to the
+operator when you finish, and point them at the bundle path.
+
+---
+
+## Pre-flight checklist
+
+Before driving a non-trivial session, confirm:
+
+- [ ] `BASE` is set to the right server. **Default is the production VPS:
+      `https://217-15-165-83.sslip.io`.** Only use `http://localhost:8765`
+      if you started the server yourself for development.
+- [ ] `task_id` exists under `bench/tasks/.../*.json` and the persona
+      you chose is in that task's `persona_ids`.
+- [ ] Your `compose_reply` strategy is wired to a real LLM (not a static
+      queue). If you're an LLM doing this in-session, the strategy is
+      "read `student_message`, think, respond".
+- [ ] HTTP client timeout ≥ 900 s on `/send`.
+- [ ] You're prepared for the session to take many turns (15 for I01,
+      higher for E-series). Don't bail early.
+
+---
+
+## Reference files in this repo
+
+- `.claude/skills/quanttutorbench-agent/SKILL.md` — Claude Code skill (thin shim pointing here)
+- `bench/scripts/agent_in_loop_example.py` — runnable reference driver
+- `bench/spec/PROTOCOL.md` — protocol surface
+- `bench/server/api/protocol.py` — phase machine + permission rules
+- `bench/server/storage/BUNDLE_SCHEMA.md` — bundle layout and v1.0.0 contract
+- `bench/server/evaluator/__main__.py` — batch eval CLI for scoring bundles
+- `docs/architecture.md` — overall system map

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,6 +78,16 @@ the API layer:
   (`run_state.json` and the sibling `evaluations/server/...` tree); they
   back the `/ops/session/{sid}/...` REST routes.
 
+For agents that drive sessions externally (your LLM as the tutor, the
+server's `student_sim` as the student), the canonical reference is
+`docs/agent_in_loop.md` — it covers the four-call lifecycle, termination
+semantics, workspace tools, bundle persistence, and the five empirical
+pitfalls. The runnable example is `bench/scripts/agent_in_loop_example.py`.
+Claude Code agents in this repo also see a thin invocation shim at
+`.claude/skills/quanttutorbench-agent/SKILL.md` that points back at the
+doc. Codex / Cursor / other-agent users should read the doc directly.
+Issue #57 captures the design.
+
 ## Storage layer (`bench/server/storage/`)
 
 | File | Role |


### PR DESCRIPTION
## Summary

Closes #57. Three artifacts so any agent (Claude, Codex, Cursor, Gemini, custom) can drive a QuantTutorBench session without reverse-engineering the server source:

- **\`docs/agent_in_loop.md\`** — agent-agnostic source-of-truth doc. Production VPS URL is the unambiguous default; local dev is an opt-in footnote. Real reason strings (\`objectives_met\` / \`max_turns\` / \`timeout\` for \`completed\`; \`agent_stuck\` / \`student_sim_error:*\` for \`failed\`; \`agent_abandoned\` from DELETE). Both \`run_backtest\` and \`run_lean_backtest\` documented as async (HEAVY_TOOLS, return 202 + poll_url). Send response shape pinned to what \`TutoringSession._result\` actually returns. Five real pitfalls grounded in live sessions \`01e84317\` and \`42e74d3a\`.
- **\`.claude/skills/quanttutorbench-agent/SKILL.md\`** — Claude Code shim that points at the doc. Auto-invoked by Claude Code agents in this repo. Tracked via \`.claude/*\` + \`!.claude/skills/\` gitignore exception so it ships with the repo while user-local settings stay private.
- **\`bench/scripts/agent_in_loop_example.py\`** — runnable driver. \`--base-url\` default flipped to production VPS so any operator/agent using it as a template lands on the right host. \`compose_reply\` is the LLM extension point. Includes \`--safety-turn-cap\` using the #54 DELETE-with-persist path; default HTTP timeout 900s.

\`docs/architecture.md\` grows one paragraph naming all three so a cold-start agent finds them from the architecture map.

Codex review: 3 P2 findings, all accepted and fixed inline before commit (terminal-status table reasons, \`run_backtest\` also async, send response shape).

## Test plan

- [x] \`docs/agent_in_loop.md\` cross-checked against \`bench/server/core/session.py::TutoringSession\` (reasons, response shape) and \`bench/server/api/limits.py\` (HEAVY_TOOLS).
- [x] \`bench/scripts/agent_in_loop_example.py\` Python syntax check passes.
- [x] Skill file lives under tracked path; \`git check-ignore\` confirms it is not ignored.
- [ ] Drive a fresh I02 session via Path 1 (real LLM in compose_reply) against prod to validate the doc end-to-end. Deferred — same flow already validated via session \`42e74d3a\` for I01.

Closes #57.