### PR TITLE
Promote LEAN template guardrails to production

### DIFF
--- a/bench/mcp_servers/core/tools.py
+++ b/bench/mcp_servers/core/tools.py
@@ -54,6 +54,19 @@ def _session_context() -> dict:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def _lean_template_context() -> dict:
+    """Return internal LEAN template metadata for current session."""
+    raw = os.environ.get("QTB_LEAN_TEMPLATE_CONTEXT_JSON", "").strip()
+    if raw:
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            parsed = {}
+        if isinstance(parsed, dict):
+            return parsed
+    return _session_context()
+
+
 def _infer_csharp_entrypoint(source_path: str) -> dict[str, str]:
     """Infer namespace/class entrypoint from a C# QCAlgorithm source file."""
     try:
@@ -2396,6 +2409,253 @@ def get_environment_info() -> str:
     return json.dumps(info, indent=2)
 
 
+def _lean_common_rules() -> str:
+    return """Production harness rules:
+- Namespace: QuantConnect.Algorithm.CSharp
+- Entrypoint: public class Algorithm : QCAlgorithm
+- Subscribe with AddCryptoFuture(ticker, Resolution.Daily, Market.Binance) for Binance perpetual futures data.
+- Store the returned Symbol and use it as the key for indicators, readiness, regime, and positions.
+- Trade with SetHoldings(symbol, targetWeight) and Liquidate(symbol).
+- Leave brokerage model selection to the benchmark harness for custom-data backtests.
+- Use SetWarmUp(...) plus per-symbol readiness checks before trading."""
+
+
+def _single_symbol_lean_template() -> str:
+    return r'''using QuantConnect;
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class Algorithm : QCAlgorithm
+    {
+        private Symbol _symbol;
+        private SimpleMovingAverage _sma;
+
+        public override void Initialize()
+        {
+            SetStartDate(2022, 1, 1);
+            SetEndDate(2025, 12, 31);
+            SetAccountCurrency("USDT");
+            SetCash("USDT", 100000m);
+
+            _symbol = AddCryptoFuture("BTCUSDT", Resolution.Daily, Market.Binance).Symbol;
+            _sma = SMA(_symbol, 20, Resolution.Daily);
+
+            SetWarmUp(20, Resolution.Daily);
+        }
+
+        public override void OnData(Slice data)
+        {
+            if (IsWarmingUp) return;
+            if (!data.ContainsKey(_symbol)) return;
+            if (!_sma.IsReady) return;
+
+            var price = Securities[_symbol].Price;
+            if (price > _sma.Current.Value)
+            {
+                SetHoldings(_symbol, 1.0m);
+            }
+            else if (Portfolio[_symbol].Invested)
+            {
+                Liquidate(_symbol);
+            }
+        }
+    }
+}'''
+
+
+def _multi_symbol_lean_template() -> str:
+    return r'''using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using QuantConnect;
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class Algorithm : QCAlgorithm
+    {
+        private readonly List<Symbol> _symbols = new List<Symbol>();
+        private readonly Dictionary<Symbol, SymbolState> _state =
+            new Dictionary<Symbol, SymbolState>();
+
+        public override void Initialize()
+        {
+            SetStartDate(2022, 1, 1);
+            SetEndDate(2025, 12, 31);
+            SetAccountCurrency("USDT");
+            SetCash("USDT", 100000m);
+
+            foreach (var ticker in LoadUniverse())
+            {
+                var security = AddCryptoFuture(ticker, Resolution.Daily, Market.Binance);
+                var symbol = security.Symbol;
+                _symbols.Add(symbol);
+                _state[symbol] = new SymbolState(
+                    SMA(symbol, 10, Resolution.Daily),
+                    SMA(symbol, 30, Resolution.Daily)
+                );
+            }
+
+            SetWarmUp(30, Resolution.Daily);
+        }
+
+        public override void OnData(Slice data)
+        {
+            if (IsWarmingUp) return;
+
+            var changed = false;
+            foreach (var symbol in data.Keys)
+            {
+                SymbolState st;
+                if (!_state.TryGetValue(symbol, out st)) continue;
+                if (!st.Fast.IsReady || !st.Slow.IsReady) continue;
+                if (Securities[symbol].Price <= 0) continue;
+
+                var regime = st.Fast.Current.Value > st.Slow.Current.Value ? 1 : -1;
+                if (!st.HasRegime || st.Regime != regime)
+                {
+                    st.Regime = regime;
+                    st.HasRegime = true;
+                    changed = true;
+                }
+            }
+
+            if (changed)
+            {
+                Rebalance();
+            }
+        }
+
+        private void Rebalance()
+        {
+            var active = _symbols
+                .Where(s => _state[s].HasRegime
+                    && _state[s].Fast.IsReady
+                    && _state[s].Slow.IsReady
+                    && Securities[s].Price > 0)
+                .ToList();
+
+            if (active.Count == 0) return;
+
+            var weight = 1.0m / active.Count;
+            foreach (var symbol in active)
+            {
+                SetHoldings(symbol, _state[symbol].Regime * weight);
+            }
+        }
+
+        private List<string> LoadUniverse()
+        {
+            var json = File.ReadAllText("/data/universe.json");
+            return JsonConvert.DeserializeObject<List<string>>(json)
+                .Select(x => x.Trim().ToUpperInvariant())
+                .Where(x => x.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private sealed class SymbolState
+        {
+            public SimpleMovingAverage Fast { get; }
+            public SimpleMovingAverage Slow { get; }
+            public bool HasRegime { get; set; }
+            public int Regime { get; set; }
+
+            public SymbolState(SimpleMovingAverage fast, SimpleMovingAverage slow)
+            {
+                Fast = fast;
+                Slow = slow;
+            }
+        }
+    }
+}'''
+
+
+def _framework_lean_template() -> str:
+    return r'''using QuantConnect;
+using QuantConnect.Algorithm;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class Algorithm : QCAlgorithm
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2022, 1, 1);
+            SetEndDate(2025, 12, 31);
+            SetAccountCurrency("USDT");
+            SetCash("USDT", 100000m);
+
+            AddCryptoFuture("BTCUSDT", Resolution.Daily, Market.Binance);
+            SetAlpha(new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, System.TimeSpan.FromDays(1)));
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            SetExecution(new ImmediateExecutionModel());
+            SetWarmUp(30, Resolution.Daily);
+        }
+    }
+}'''
+
+
+def _debug_lean_template() -> str:
+    return """Debug-session template:
+1. Inspect the mounted code first with file_list(directory="student_code") and file_read(path="student_code/<file>.cs").
+2. Copy the code into the workspace, apply the smallest fix, and keep the namespace/class entrypoint production-safe.
+3. Use SetWarmUp(...) and if (IsWarmingUp) return; when the bug involves indicator readiness.
+4. Run run_lean_backtest on the workspace copy, then inspect results with analyze_lean_results."""
+
+
+def get_lean_template() -> str:
+    """Return a production-safe LEAN C# skeleton for the current session."""
+    context = _lean_template_context()
+    template_type = str(context.get("template_type", "")).lower()
+    task_id = str(context.get("task_id", "")).upper()
+    category = str(context.get("category", "")).lower()
+    data_files = {str(item).lower() for item in context.get("data_files", [])}
+
+    if category == "debug" or context.get("student_code_available"):
+        template_name = "debug-fix workflow"
+        template = _debug_lean_template()
+    elif template_type == "single_symbol" or task_id.startswith("I01"):
+        template_name = "single-symbol SMA skeleton"
+        template = _single_symbol_lean_template()
+    elif template_type == "framework" or task_id.startswith(("I07", "I08", "I09", "I10")):
+        template_name = "Algorithm Framework skeleton"
+        template = _framework_lean_template()
+    elif (
+        template_type == "multi_symbol"
+        or "universe.json" in data_files
+        or task_id.startswith(("I02", "I03", "I04", "I05", "I06"))
+    ):
+        template_name = "multi-symbol universe skeleton"
+        template = _multi_symbol_lean_template()
+    else:
+        template_name = "single-symbol LEAN skeleton"
+        template = _single_symbol_lean_template()
+
+    payload = {
+        "template": template_name,
+        "session": {
+            "category": context.get("category", ""),
+            "sandbox_image": context.get("sandbox_image", ""),
+            "template_type": context.get("template_type", ""),
+            "student_code_available": bool(context.get("student_code_available")),
+        },
+        "rules": _lean_common_rules(),
+        "code": template,
+    }
+    return json.dumps(payload, indent=2)
+
+
 def compare_backtest_results(
     data_paths: list,
     labels: Optional[list] = None,
@@ -3527,6 +3787,11 @@ CORE_TOOLS = {
         "description": "Return directory paths, mounted files, installed packages, and truthful session runtime context such as student_code availability or tracked trial budget when present.",
         "params": {},
     },
+    "get_lean_template": {
+        "func": get_lean_template,
+        "description": "Return a production-safe LEAN C# algorithm skeleton for the current benchmark session.",
+        "params": {},
+    },
     "construct_signal": {
         "func": construct_signal,
         "description": (
@@ -3970,6 +4235,93 @@ def _get_trial_manager() -> "TrialManager":
     return _trial_managers[workspace]
 
 
+def _split_csharp_args(arg_text: str) -> list[str]:
+    """Split a C# call argument list on top-level commas."""
+    args: list[str] = []
+    current: list[str] = []
+    depth = 0
+    in_string = False
+    escape = False
+    for ch in arg_text:
+        if in_string:
+            current.append(ch)
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            current.append(ch)
+            continue
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}" and depth > 0:
+            depth -= 1
+        if ch == "," and depth == 0:
+            args.append("".join(current).strip())
+            current = []
+            continue
+        current.append(ch)
+    tail = "".join(current).strip()
+    if tail:
+        args.append(tail)
+    return args
+
+
+def _lean_preflight_target_expects_universe(context: dict) -> bool:
+    if context.get("expects_universe"):
+        return True
+    task_id = str(context.get("task_id", "")).upper()
+    return task_id.startswith(("I02", "I03", "I04", "I05", "I06"))
+
+
+def _preflight_lean_source(source: str, context: dict | None = None) -> list[str]:
+    """Return source issues that should be fixed before a tracked LEAN trial."""
+    context = context or {}
+    issues: list[str] = []
+
+    if not re.search(r"\bnamespace\s+QuantConnect\.Algorithm\.CSharp\b", source):
+        issues.append(
+            "Use namespace QuantConnect.Algorithm.CSharp for the benchmark LEAN entrypoint."
+        )
+
+    if not re.search(
+        r"\bpublic\s+class\s+Algorithm\s*:\s*[^{\n]*\bQCAlgorithm\b",
+        source,
+    ):
+        issues.append(
+            "Declare public class Algorithm : QCAlgorithm so the session runner can load the entrypoint."
+        )
+
+    if re.search(r"\bSetBrokerageModel\s*\(", source):
+        issues.append(
+            "Leave brokerage model selection unset; the benchmark harness supplies custom-data securities for LEAN backtests."
+        )
+
+    for match in re.finditer(r"\bSetHoldings\s*\((?P<args>[^;]+)\)\s*;", source, re.S):
+        if len(_split_csharp_args(match.group("args"))) >= 3:
+            issues.append(
+                "Use SetHoldings(symbol, targetWeight) for the deployed benchmark LEAN build."
+            )
+            break
+
+    if _lean_preflight_target_expects_universe(context):
+        uses_universe_file = "universe.json" in source.lower()
+        hardcoded_subs = re.findall(
+            r"\bAddCrypto(?:Future)?\s*\(\s*\"([A-Za-z0-9]+)\"",
+            source,
+        )
+        if hardcoded_subs and len(set(hardcoded_subs)) < 5 and not uses_universe_file:
+            issues.append(
+                "Load the session universe file and subscribe dynamically for universe-scale LEAN tasks."
+            )
+
+    return list(dict.fromkeys(issues))
+
+
 def run_lean_backtest(
     algorithm_path: str,
     params_json: str = "",
@@ -4006,6 +4358,22 @@ def run_lean_backtest(
     resolved_algorithm_path = _resolve_path(algorithm_path)
     if not resolved_algorithm_path or not os.path.isfile(resolved_algorithm_path):
         return f"Error: Algorithm file not found: {requested_path}"
+
+    try:
+        with open(resolved_algorithm_path, encoding="utf-8") as f:
+            source = f.read()
+    except OSError as exc:
+        return f"Error: Could not read algorithm file: {exc}"
+
+    preflight_issues = _preflight_lean_source(source, _lean_template_context())
+    if preflight_issues:
+        lines = ["Preflight failed:"]
+        lines.extend(f"- {issue}" for issue in preflight_issues)
+        lines.append("")
+        lines.append(
+            "Call get_lean_template() for a production-safe LEAN skeleton for this session."
+        )
+        return "\n".join(lines)
 
     if data_mode and data_mode != "custom":
         return (

--- a/bench/mcp_servers/mcp_server.py
+++ b/bench/mcp_servers/mcp_server.py
@@ -13,6 +13,7 @@ Usage (from orchestrator):
 """
 
 import asyncio
+import json
 import logging
 from typing import Any
 
@@ -149,19 +150,55 @@ def _build_standalone_server(task_id: str, persona_id: str, use_docker: bool = T
         custom_data_dir=custom_data_dir,
     )
 
+    max_bt = task.environment.max_backtest_trials if task.environment else 0
+    task_core_tools = list(task.environment.core_mcp_tools if task.environment else [])
+    sandbox_image = task.environment.sandbox_image if task.environment else ""
+    is_lean_task = "lean" in str(sandbox_image).lower() or "run_lean_backtest" in task_core_tools
+    if is_lean_task and "get_lean_template" not in task_core_tools:
+        task_core_tools.append("get_lean_template")
+
+    session_context = {
+        "category": task.category.value,
+        "requires_code": bool(task.requires_code),
+        "docs_available": list(docs_available),
+        "max_backtest_trials": max_bt,
+        "sandbox_image": sandbox_image,
+        "student_code_available": bool(student_code_dir),
+    }
+    task_id_upper = task_id.upper()
+    if task.category.value == "debug" or task.sample_code:
+        template_type = "debug"
+    elif task_id_upper.startswith("I01"):
+        template_type = "single_symbol"
+    elif task_id_upper.startswith(("I07", "I08", "I09", "I10")):
+        template_type = "framework"
+    elif task_id_upper.startswith(("I02", "I03", "I04", "I05", "I06")):
+        template_type = "multi_symbol"
+    else:
+        template_type = "generic"
+    lean_template_context = {
+        "category": task.category.value,
+        "requires_code": bool(task.requires_code),
+        "template_type": template_type,
+        "expects_universe": template_type == "multi_symbol",
+        "sandbox_image": sandbox_image,
+        "student_code_available": bool(student_code_dir),
+    }
+
     if container_manager.use_docker:
-        max_bt = task.environment.max_backtest_trials if task.environment else 0
         container_manager.start_executor(
             container.container_id,
             env_vars={
                 "QTB_MAX_BACKTEST_TRIALS": str(max_bt),
                 "LEAN_RUN_TIMEOUT": "300",
+                "QTB_SESSION_CONTEXT_JSON": json.dumps(session_context),
+                "QTB_LEAN_TEMPLATE_CONTEXT_JSON": json.dumps(lean_template_context),
             },
         )
 
     # Create proxy with tools
     proxy = create_proxy_for_task(
-        core_tool_names=task.environment.core_mcp_tools,
+        core_tool_names=task_core_tools,
         convenient_tool_names=(
             task.ground_truth.convenient_tools if task.ground_truth else []
         ),

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -109,6 +109,50 @@ def _resolve_persona_pin(task_id: str, persona_ids: list[str]) -> Optional[str]:
     return None
 
 
+def _task_is_lean(task) -> bool:
+    environment = getattr(task, "environment", None)
+    if environment is None:
+        return False
+    sandbox_image = str(getattr(environment, "sandbox_image", "") or "").lower()
+    core_tools = list(getattr(environment, "core_mcp_tools", []) or [])
+    return "lean" in sandbox_image or "run_lean_backtest" in core_tools
+
+
+def _effective_core_tool_names(task) -> list[str]:
+    environment = getattr(task, "environment", None)
+    names = list(getattr(environment, "core_mcp_tools", []) or [])
+    if _task_is_lean(task) and "get_lean_template" not in names:
+        names.append("get_lean_template")
+    return names
+
+
+def _lean_template_type(task) -> str:
+    task_id = str(getattr(task, "task_id", "") or "").upper()
+    category = str(getattr(getattr(task, "category", None), "value", "") or "").lower()
+    if category == "debug" or getattr(task, "sample_code", None):
+        return "debug"
+    if task_id.startswith("I01"):
+        return "single_symbol"
+    if task_id.startswith(("I07", "I08", "I09", "I10")):
+        return "framework"
+    if task_id.startswith(("I02", "I03", "I04", "I05", "I06")):
+        return "multi_symbol"
+    return "generic"
+
+
+def _lean_template_context(task, *, student_code_dir: Optional[str | Path]) -> dict:
+    environment = getattr(task, "environment", None)
+    template_type = _lean_template_type(task)
+    return {
+        "category": task.category.value,
+        "requires_code": bool(task.requires_code),
+        "template_type": template_type,
+        "expects_universe": template_type == "multi_symbol",
+        "sandbox_image": environment.sandbox_image if environment else "",
+        "student_code_available": bool(student_code_dir),
+    }
+
+
 class SessionState:
     """Per-session state for one benchmark session.
 
@@ -296,6 +340,10 @@ class SessionState:
         }
         if student_code_dir:
             env["QTB_STUDENT_CODE_DIR"] = str(student_code_dir)
+        if self.task and _task_is_lean(self.task):
+            env["QTB_LEAN_TEMPLATE_CONTEXT_JSON"] = json.dumps(
+                _lean_template_context(self.task, student_code_dir=student_code_dir)
+            )
         return env
 
     # ------------------------------------------------------------------
@@ -335,9 +383,7 @@ class SessionState:
 
             self.task = task
             self.task_id = task_id
-            self._task_core_tool_names = tuple(
-                task.environment.core_mcp_tools if task.environment else ()
-            )
+            self._task_core_tool_names = tuple(_effective_core_tool_names(task))
             self._task_convenient_tool_names = tuple(
                 task.ground_truth.convenient_tools if task.ground_truth else ()
             )
@@ -465,9 +511,7 @@ class SessionState:
             self.proxy = MCPProxy(workspace_path=self.container.workspace_path)
             populate_proxy_for_task(
                 proxy=self.proxy,
-                core_tool_names=(
-                    task.environment.core_mcp_tools if task.environment else []
-                ),
+                core_tool_names=list(self._task_core_tool_names),
                 convenient_tool_names=(
                     task.ground_truth.convenient_tools if task.ground_truth else []
                 ),
@@ -738,7 +782,7 @@ class SessionState:
         if task is None:
             return []
 
-        core_names = list(task.environment.core_mcp_tools if task.environment else [])
+        core_names = _effective_core_tool_names(task)
         convenient_names = list(
             task.ground_truth.convenient_tools if task.ground_truth else []
         )

--- a/bench/server/core/tools/tools.py
+++ b/bench/server/core/tools/tools.py
@@ -54,6 +54,19 @@ def _session_context() -> dict:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def _lean_template_context() -> dict:
+    """Return internal LEAN template metadata for current session."""
+    raw = os.environ.get("QTB_LEAN_TEMPLATE_CONTEXT_JSON", "").strip()
+    if raw:
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            parsed = {}
+        if isinstance(parsed, dict):
+            return parsed
+    return _session_context()
+
+
 def _infer_csharp_entrypoint(source_path: str) -> dict[str, str]:
     """Infer namespace/class entrypoint from a C# QCAlgorithm source file."""
     try:
@@ -2410,6 +2423,253 @@ def get_environment_info() -> str:
     return json.dumps(info, indent=2)
 
 
+def _lean_common_rules() -> str:
+    return """Production harness rules:
+- Namespace: QuantConnect.Algorithm.CSharp
+- Entrypoint: public class Algorithm : QCAlgorithm
+- Subscribe with AddCryptoFuture(ticker, Resolution.Daily, Market.Binance) for Binance perpetual futures data.
+- Store the returned Symbol and use it as the key for indicators, readiness, regime, and positions.
+- Trade with SetHoldings(symbol, targetWeight) and Liquidate(symbol).
+- Leave brokerage model selection to the benchmark harness for custom-data backtests.
+- Use SetWarmUp(...) plus per-symbol readiness checks before trading."""
+
+
+def _single_symbol_lean_template() -> str:
+    return r'''using QuantConnect;
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class Algorithm : QCAlgorithm
+    {
+        private Symbol _symbol;
+        private SimpleMovingAverage _sma;
+
+        public override void Initialize()
+        {
+            SetStartDate(2022, 1, 1);
+            SetEndDate(2025, 12, 31);
+            SetAccountCurrency("USDT");
+            SetCash("USDT", 100000m);
+
+            _symbol = AddCryptoFuture("BTCUSDT", Resolution.Daily, Market.Binance).Symbol;
+            _sma = SMA(_symbol, 20, Resolution.Daily);
+
+            SetWarmUp(20, Resolution.Daily);
+        }
+
+        public override void OnData(Slice data)
+        {
+            if (IsWarmingUp) return;
+            if (!data.ContainsKey(_symbol)) return;
+            if (!_sma.IsReady) return;
+
+            var price = Securities[_symbol].Price;
+            if (price > _sma.Current.Value)
+            {
+                SetHoldings(_symbol, 1.0m);
+            }
+            else if (Portfolio[_symbol].Invested)
+            {
+                Liquidate(_symbol);
+            }
+        }
+    }
+}'''
+
+
+def _multi_symbol_lean_template() -> str:
+    return r'''using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using QuantConnect;
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.Indicators;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class Algorithm : QCAlgorithm
+    {
+        private readonly List<Symbol> _symbols = new List<Symbol>();
+        private readonly Dictionary<Symbol, SymbolState> _state =
+            new Dictionary<Symbol, SymbolState>();
+
+        public override void Initialize()
+        {
+            SetStartDate(2022, 1, 1);
+            SetEndDate(2025, 12, 31);
+            SetAccountCurrency("USDT");
+            SetCash("USDT", 100000m);
+
+            foreach (var ticker in LoadUniverse())
+            {
+                var security = AddCryptoFuture(ticker, Resolution.Daily, Market.Binance);
+                var symbol = security.Symbol;
+                _symbols.Add(symbol);
+                _state[symbol] = new SymbolState(
+                    SMA(symbol, 10, Resolution.Daily),
+                    SMA(symbol, 30, Resolution.Daily)
+                );
+            }
+
+            SetWarmUp(30, Resolution.Daily);
+        }
+
+        public override void OnData(Slice data)
+        {
+            if (IsWarmingUp) return;
+
+            var changed = false;
+            foreach (var symbol in data.Keys)
+            {
+                SymbolState st;
+                if (!_state.TryGetValue(symbol, out st)) continue;
+                if (!st.Fast.IsReady || !st.Slow.IsReady) continue;
+                if (Securities[symbol].Price <= 0) continue;
+
+                var regime = st.Fast.Current.Value > st.Slow.Current.Value ? 1 : -1;
+                if (!st.HasRegime || st.Regime != regime)
+                {
+                    st.Regime = regime;
+                    st.HasRegime = true;
+                    changed = true;
+                }
+            }
+
+            if (changed)
+            {
+                Rebalance();
+            }
+        }
+
+        private void Rebalance()
+        {
+            var active = _symbols
+                .Where(s => _state[s].HasRegime
+                    && _state[s].Fast.IsReady
+                    && _state[s].Slow.IsReady
+                    && Securities[s].Price > 0)
+                .ToList();
+
+            if (active.Count == 0) return;
+
+            var weight = 1.0m / active.Count;
+            foreach (var symbol in active)
+            {
+                SetHoldings(symbol, _state[symbol].Regime * weight);
+            }
+        }
+
+        private List<string> LoadUniverse()
+        {
+            var json = File.ReadAllText("/data/universe.json");
+            return JsonConvert.DeserializeObject<List<string>>(json)
+                .Select(x => x.Trim().ToUpperInvariant())
+                .Where(x => x.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private sealed class SymbolState
+        {
+            public SimpleMovingAverage Fast { get; }
+            public SimpleMovingAverage Slow { get; }
+            public bool HasRegime { get; set; }
+            public int Regime { get; set; }
+
+            public SymbolState(SimpleMovingAverage fast, SimpleMovingAverage slow)
+            {
+                Fast = fast;
+                Slow = slow;
+            }
+        }
+    }
+}'''
+
+
+def _framework_lean_template() -> str:
+    return r'''using QuantConnect;
+using QuantConnect.Algorithm;
+using QuantConnect.Algorithm.Framework.Alphas;
+using QuantConnect.Algorithm.Framework.Execution;
+using QuantConnect.Algorithm.Framework.Portfolio;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class Algorithm : QCAlgorithm
+    {
+        public override void Initialize()
+        {
+            SetStartDate(2022, 1, 1);
+            SetEndDate(2025, 12, 31);
+            SetAccountCurrency("USDT");
+            SetCash("USDT", 100000m);
+
+            AddCryptoFuture("BTCUSDT", Resolution.Daily, Market.Binance);
+            SetAlpha(new ConstantAlphaModel(InsightType.Price, InsightDirection.Up, System.TimeSpan.FromDays(1)));
+            SetPortfolioConstruction(new EqualWeightingPortfolioConstructionModel());
+            SetExecution(new ImmediateExecutionModel());
+            SetWarmUp(30, Resolution.Daily);
+        }
+    }
+}'''
+
+
+def _debug_lean_template() -> str:
+    return """Debug-session template:
+1. Inspect the mounted code first with file_list(directory="student_code") and file_read(path="student_code/<file>.cs").
+2. Copy the code into the workspace, apply the smallest fix, and keep the namespace/class entrypoint production-safe.
+3. Use SetWarmUp(...) and if (IsWarmingUp) return; when the bug involves indicator readiness.
+4. Run run_lean_backtest on the workspace copy, then inspect results with analyze_lean_results."""
+
+
+def get_lean_template() -> str:
+    """Return a production-safe LEAN C# skeleton for the current session."""
+    context = _lean_template_context()
+    template_type = str(context.get("template_type", "")).lower()
+    task_id = str(context.get("task_id", "")).upper()
+    category = str(context.get("category", "")).lower()
+    data_files = {str(item).lower() for item in context.get("data_files", [])}
+
+    if category == "debug" or context.get("student_code_available"):
+        template_name = "debug-fix workflow"
+        template = _debug_lean_template()
+    elif template_type == "single_symbol" or task_id.startswith("I01"):
+        template_name = "single-symbol SMA skeleton"
+        template = _single_symbol_lean_template()
+    elif template_type == "framework" or task_id.startswith(("I07", "I08", "I09", "I10")):
+        template_name = "Algorithm Framework skeleton"
+        template = _framework_lean_template()
+    elif (
+        template_type == "multi_symbol"
+        or "universe.json" in data_files
+        or task_id.startswith(("I02", "I03", "I04", "I05", "I06"))
+    ):
+        template_name = "multi-symbol universe skeleton"
+        template = _multi_symbol_lean_template()
+    else:
+        template_name = "single-symbol LEAN skeleton"
+        template = _single_symbol_lean_template()
+
+    payload = {
+        "template": template_name,
+        "session": {
+            "category": context.get("category", ""),
+            "sandbox_image": context.get("sandbox_image", ""),
+            "template_type": context.get("template_type", ""),
+            "student_code_available": bool(context.get("student_code_available")),
+        },
+        "rules": _lean_common_rules(),
+        "code": template,
+    }
+    return json.dumps(payload, indent=2)
+
+
 def compare_backtest_results(
     data_paths: list,
     labels: Optional[list] = None,
@@ -3566,6 +3826,11 @@ CORE_TOOLS = {
         "description": "Return directory paths, mounted files, installed packages, and truthful session runtime context such as student_code availability or tracked trial budget when present.",
         "params": {},
     },
+    "get_lean_template": {
+        "func": get_lean_template,
+        "description": "Return a production-safe LEAN C# algorithm skeleton for the current benchmark session.",
+        "params": {},
+    },
     "construct_signal": {
         "func": construct_signal,
         "description": (
@@ -4009,6 +4274,93 @@ def _get_trial_manager() -> "TrialManager":
     return _trial_managers[workspace]
 
 
+def _split_csharp_args(arg_text: str) -> list[str]:
+    """Split a C# call argument list on top-level commas."""
+    args: list[str] = []
+    current: list[str] = []
+    depth = 0
+    in_string = False
+    escape = False
+    for ch in arg_text:
+        if in_string:
+            current.append(ch)
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            current.append(ch)
+            continue
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}" and depth > 0:
+            depth -= 1
+        if ch == "," and depth == 0:
+            args.append("".join(current).strip())
+            current = []
+            continue
+        current.append(ch)
+    tail = "".join(current).strip()
+    if tail:
+        args.append(tail)
+    return args
+
+
+def _lean_preflight_target_expects_universe(context: dict) -> bool:
+    if context.get("expects_universe"):
+        return True
+    task_id = str(context.get("task_id", "")).upper()
+    return task_id.startswith(("I02", "I03", "I04", "I05", "I06"))
+
+
+def _preflight_lean_source(source: str, context: dict | None = None) -> list[str]:
+    """Return source issues that should be fixed before a tracked LEAN trial."""
+    context = context or {}
+    issues: list[str] = []
+
+    if not re.search(r"\bnamespace\s+QuantConnect\.Algorithm\.CSharp\b", source):
+        issues.append(
+            "Use namespace QuantConnect.Algorithm.CSharp for the benchmark LEAN entrypoint."
+        )
+
+    if not re.search(
+        r"\bpublic\s+class\s+Algorithm\s*:\s*[^{\n]*\bQCAlgorithm\b",
+        source,
+    ):
+        issues.append(
+            "Declare public class Algorithm : QCAlgorithm so the session runner can load the entrypoint."
+        )
+
+    if re.search(r"\bSetBrokerageModel\s*\(", source):
+        issues.append(
+            "Leave brokerage model selection unset; the benchmark harness supplies custom-data securities for LEAN backtests."
+        )
+
+    for match in re.finditer(r"\bSetHoldings\s*\((?P<args>[^;]+)\)\s*;", source, re.S):
+        if len(_split_csharp_args(match.group("args"))) >= 3:
+            issues.append(
+                "Use SetHoldings(symbol, targetWeight) for the deployed benchmark LEAN build."
+            )
+            break
+
+    if _lean_preflight_target_expects_universe(context):
+        uses_universe_file = "universe.json" in source.lower()
+        hardcoded_subs = re.findall(
+            r"\bAddCrypto(?:Future)?\s*\(\s*\"([A-Za-z0-9]+)\"",
+            source,
+        )
+        if hardcoded_subs and len(set(hardcoded_subs)) < 5 and not uses_universe_file:
+            issues.append(
+                "Load the session universe file and subscribe dynamically for universe-scale LEAN tasks."
+            )
+
+    return list(dict.fromkeys(issues))
+
+
 def run_lean_backtest(
     algorithm_path: str,
     params_json: str = "",
@@ -4038,6 +4390,22 @@ def run_lean_backtest(
     resolved_algorithm_path = _resolve_path(algorithm_path)
     if not resolved_algorithm_path or not os.path.isfile(resolved_algorithm_path):
         return f"Error: Algorithm file not found: {requested_path}"
+
+    try:
+        with open(resolved_algorithm_path, encoding="utf-8") as f:
+            source = f.read()
+    except OSError as exc:
+        return f"Error: Could not read algorithm file: {exc}"
+
+    preflight_issues = _preflight_lean_source(source, _lean_template_context())
+    if preflight_issues:
+        lines = ["Preflight failed:"]
+        lines.extend(f"- {issue}" for issue in preflight_issues)
+        lines.append("")
+        lines.append(
+            "Call get_lean_template() for a production-safe LEAN skeleton for this session."
+        )
+        return "\n".join(lines)
 
     inferred_entrypoint = _infer_csharp_entrypoint(resolved_algorithm_path)
     if not full_type_name and inferred_entrypoint.get("full_type_name"):

--- a/bench/server/tooling/catalog.py
+++ b/bench/server/tooling/catalog.py
@@ -51,6 +51,7 @@ _FAMILY_BY_NAME: dict[str, ToolFamily] = {
     "breakdown_pnl": "backtest",
     "split_walkforward_windows": "backtest",
     "run_lean_backtest": "lean_trials",
+    "get_lean_template": "lean_trials",
     "submit_trial": "lean_trials",
     "select_submission": "lean_trials",
     "get_trial_status": "lean_trials",
@@ -91,6 +92,7 @@ _LOW_LEVEL_TOOLS = frozenset(
 
 _HIGH_LEVEL_TOOLS = frozenset(
     {
+        "get_lean_template",
         "fetch_market_data",
         "compute_indicator",
         "run_backtest",
@@ -288,12 +290,15 @@ def _default_related_tools(name: str, family: ToolFamily) -> tuple[str, ...]:
         return ("file_read", "shell_exec")
     if name == "shell_exec":
         return ("get_environment_info", "file_read", "file_write")
+    if name == "get_lean_template":
+        return ("file_write", "run_lean_backtest", "analyze_lean_results")
     if family == "analysis":
         return ("file_read", "shell_exec")
     if family == "backtest":
         return ("analyze_backtest_results", "plot_chart", "shell_exec")
     if family == "lean_trials":
         return (
+            "get_lean_template",
             "run_lean_backtest",
             "get_trial_status",
             "select_submission",

--- a/bench/tests/test_lean_template_tool.py
+++ b/bench/tests/test_lean_template_tool.py
@@ -1,0 +1,110 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_get_lean_template_schema_is_generic():
+    from server.core.tools.tools import CORE_TOOLS
+    from server.tooling import get_canonical_tool_spec
+
+    assert CORE_TOOLS["get_lean_template"]["params"] == {}
+
+    spec = get_canonical_tool_spec("get_lean_template")
+    assert spec.input_schema == {"type": "object", "properties": {}}
+    assert "I02" not in json.dumps(spec.input_schema)
+
+
+def test_get_lean_template_uses_session_context(monkeypatch):
+    from server.core.tools.tools import get_lean_template
+
+    monkeypatch.setenv(
+        "QTB_LEAN_TEMPLATE_CONTEXT_JSON",
+        json.dumps(
+            {
+                "category": "implementation",
+                "template_type": "multi_symbol",
+                "expects_universe": True,
+                "sandbox_image": "quant-tutor-env:v2.2-lean",
+                "student_code_available": False,
+            }
+        ),
+    )
+
+    payload = json.loads(get_lean_template())
+
+    assert payload["template"] == "multi-symbol universe skeleton"
+    assert "public class Algorithm : QCAlgorithm" in payload["code"]
+    assert "File.ReadAllText(\"/data/universe.json\")" in payload["code"]
+    assert payload["session"]["template_type"] == "multi_symbol"
+    assert "task_id" not in payload["session"]
+    assert "SetHoldings(symbol, _state[symbol].Regime * weight)" in payload["code"]
+    assert "Leave brokerage model selection" in payload["rules"]
+
+
+def test_lean_tasks_expose_template_tool_before_register():
+    from server.api.session_api import SessionState
+
+    bench_root = Path(__file__).resolve().parents[1]
+    state = SessionState("session-for-tool-list", use_docker=False, bench_root=bench_root)
+    state._run_task_id = "I01_implement_sma"
+
+    names = {tool.name for tool in state.get_visible_tools()}
+
+    assert "get_lean_template" in names
+    assert "run_lean_backtest" in names
+
+
+def test_run_lean_backtest_preflight_blocks_common_harness_mismatch(
+    monkeypatch, tmp_path
+):
+    from server.core.tools import tools
+
+    source = """
+using QuantConnect;
+using QuantConnect.Algorithm;
+using QuantConnect.Brokerages;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class Algorithm : QCAlgorithm
+    {
+        public override void Initialize()
+        {
+            SetBrokerageModel(BrokerageName.BinanceFutures, AccountType.Margin);
+            AddCryptoFuture("BTCUSDT", Resolution.Daily, Market.Binance);
+        }
+
+        public override void OnData(QuantConnect.Data.Slice data)
+        {
+            SetHoldings(Symbol("BTCUSDT"), 1.0m, true, "tag");
+        }
+    }
+}
+"""
+    (tmp_path / "Algorithm.cs").write_text(source, encoding="utf-8")
+
+    monkeypatch.setenv("QTB_WORKSPACE_DIR", str(tmp_path))
+    monkeypatch.setenv("QTB_MAX_BACKTEST_TRIALS", "5")
+    monkeypatch.setenv(
+        "QTB_LEAN_TEMPLATE_CONTEXT_JSON",
+        json.dumps(
+            {
+                "category": "implementation",
+                "template_type": "multi_symbol",
+                "expects_universe": True,
+            }
+        ),
+    )
+    tools._trial_managers.clear()
+
+    with patch.object(tools, "shell_exec") as shell_exec:
+        result = tools.run_lean_backtest("Algorithm.cs")
+
+    shell_exec.assert_not_called()
+    assert result.startswith("Preflight failed:")
+    assert "Leave brokerage model selection unset" in result
+    assert "Use SetHoldings(symbol, targetWeight)" in result
+    assert "Load the session universe file" in result
+    assert not (tmp_path / ".backtest_runs.jsonl").exists()
+
+    tools._trial_managers.clear()


### PR DESCRIPTION
## Summary
- promote issue #60 LEAN template and preflight guardrails from dev to production
- includes the generic get_lean_template tool and run_lean_backtest preflight checks

## Tests
- python3 -m py_compile bench/server/core/tools/tools.py bench/mcp_servers/core/tools.py bench/server/api/session_api.py bench/mcp_servers/mcp_server.py bench/tests/test_lean_template_tool.py
- pytest bench/tests/test_lean_template_tool.py bench/tests/test_server_session_runtime.py bench/tests/test_trial_budget.py bench/tests/test_tool_jobs.py bench/tests/test_rest_transport_jobs.py bench/tests/test_lean_config.py -q