### PR TITLE
feat(auth): add GitHub OAuth owner-scoped access

### DIFF
--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -26,13 +26,16 @@ from uuid import uuid4
 import anyio
 from mcp.server import Server
 from mcp.server.streamable_http import StreamableHTTPServerTransport
+from mcp.types import TextContent
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import FileResponse, JSONResponse, Response
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
+from server.audit import record_event
 from server.config.bootstrap import load_server_env
+from server.quota import QuotaExceeded, QuotaManager
 from server.run import JobStore, RunService, RunStore, TaskCatalog
 from server.run.jobs import (
     JOB_STATUS_COMPLETED,
@@ -57,6 +60,41 @@ _SWEEPER_INTERVAL: int = 30
 _UNREGISTERED_IDLE_TIMEOUT: int = 300  # 5 min
 _REGISTERED_IDLE_TIMEOUT: int = 300  # 5 min
 _COMPLETED_IDLE_TIMEOUT: int = 3600  # 1 hour
+
+
+def _audit_user_from_run(run) -> dict:
+    return {
+        "user_id": getattr(run, "owner_user_id", "") or "",
+        "github_login": getattr(run, "owner_github_login", "") or "",
+        "email": getattr(run, "owner_email", "") or "",
+        "role": "user",
+    }
+
+
+def _audit_user_from_state(state: SessionState) -> dict:
+    return {
+        "user_id": state.owner_user_id,
+        "github_login": state.owner_github_login,
+        "email": state.owner_email,
+        "role": "user",
+    }
+
+
+def _mcp_tool_success(contents: list[TextContent]) -> bool:
+    if not contents:
+        return True
+    text = getattr(contents[0], "text", "")
+    try:
+        payload = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return True
+    if not isinstance(payload, dict):
+        return True
+    if payload.get("success") is False:
+        return False
+    if payload.get("error"):
+        return False
+    return True
 
 
 class NoCacheStaticFiles(StaticFiles):
@@ -105,6 +143,7 @@ class BenchSessionManager:
 
         # Job layer — async tool dispatch (slice 2)
         self._job_store = JobStore(self.bench_root / "results" / "jobs")
+        self._quota_manager = QuotaManager(self.bench_root)
         # Strong refs for background tasks so the event loop does not GC them
         # mid-flight (asyncio.create_task caveat).
         self._job_tasks: dict[str, asyncio.Task] = {}
@@ -428,6 +467,10 @@ class BenchSessionManager:
         # Bind to Run
         state.run_id = run.run_id
         state._run_task_id = run.task_id
+        state.owner_user_id = run.owner_user_id
+        state.owner_github_login = run.owner_github_login
+        state.owner_email = run.owner_email
+        state.visibility = run.visibility
         state._on_registered = lambda sid: self._run_service.bind_session(
             run.run_id, sid
         )
@@ -499,9 +542,79 @@ class BenchSessionManager:
         @server.call_tool()
         async def handle_call_tool(name: str, arguments: dict):
             async with state._request_lock:
-                return await state.handle_tool_call(name, arguments)
+                return await self._handle_mcp_tool_call(state, name, arguments)
 
         return server
+
+    async def _handle_mcp_tool_call(
+        self, state: SessionState, name: str, arguments: dict
+    ) -> list[TextContent]:
+        """Run one MCP tool call with per-user quota checks for heavy tools."""
+        if name not in HEAVY_TOOLS:
+            return await state.handle_tool_call(name, arguments)
+
+        quota_reservation: str | None = None
+        try:
+            quota_reservation = self._quota_manager.reserve_heavy_job(
+                owner_user_id=state.owner_user_id,
+                run_id=state.run_id or "",
+                session_id=state.session_id,
+                tool_name=name,
+            )
+        except QuotaExceeded as exc:
+            record_event(
+                self.bench_root,
+                _audit_user_from_state(state),
+                "tool.call",
+                run_id=state.run_id or "",
+                session_id=state.session_id,
+                task_id=state.task_id,
+                success=False,
+                payload={"tool": name, "transport": "mcp", "error": str(exc)},
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "success": False,
+                            "error": str(exc),
+                            "current_phase": state.phase.value,
+                        }
+                    ),
+                )
+            ]
+
+        try:
+            contents = await state.handle_tool_call(name, arguments)
+            record_event(
+                self.bench_root,
+                _audit_user_from_state(state),
+                "tool.call",
+                run_id=state.run_id or "",
+                session_id=state.session_id,
+                task_id=state.task_id,
+                success=_mcp_tool_success(contents),
+                payload={"tool": name, "transport": "mcp"},
+            )
+            return contents
+        except Exception as exc:
+            record_event(
+                self.bench_root,
+                _audit_user_from_state(state),
+                "tool.call",
+                run_id=state.run_id or "",
+                session_id=state.session_id,
+                task_id=state.task_id,
+                success=False,
+                payload={"tool": name, "transport": "mcp", "error": str(exc)},
+            )
+            raise
+        finally:
+            self._quota_manager.release_heavy_job(
+                owner_user_id=state.owner_user_id,
+                reservation_id=quota_reservation,
+            )
 
     # ------------------------------------------------------------------
     # Session cleanup
@@ -873,6 +986,10 @@ async def rest_register(request: Request) -> JSONResponse:
     state = manager.create_rest_session()
     state.run_id = run.run_id
     state._run_task_id = run.task_id
+    state.owner_user_id = run.owner_user_id
+    state.owner_github_login = run.owner_github_login
+    state.owner_email = run.owner_email
+    state.visibility = run.visibility
     state._on_completed = lambda result_dir: manager._run_service.mark_completed(
         run.run_id, result_dir
     )
@@ -889,12 +1006,32 @@ async def rest_register(request: Request) -> JSONResponse:
             state.persona_id,
             run.run_id,
         )
+        record_event(
+            manager.bench_root,
+            _audit_user_from_run(run),
+            "session.register",
+            request=request,
+            run_id=run.run_id,
+            session_id=state.session_id,
+            task_id=task_id,
+            success=True,
+        )
         return JSONResponse(result)
     else:
         state.cleanup()
         logger.warning("[REST] register failed: %s", result.get("error"))
         error = result.get("error", "")
         code = 404 if "not found" in error.lower() else 400
+        record_event(
+            manager.bench_root,
+            _audit_user_from_run(run),
+            "session.register",
+            request=request,
+            run_id=run.run_id,
+            task_id=task_id,
+            success=False,
+            payload={"error": error},
+        )
         return JSONResponse(result, status_code=code)
 
 
@@ -918,6 +1055,15 @@ async def rest_start(request: Request) -> JSONResponse:
         state._last_activity = time.time()
         result = await asyncio.to_thread(state.start)
     logger.info("[REST:%s] session started", sid[:8])
+    record_event(
+        manager.bench_root,
+        _audit_user_from_state(state),
+        "session.start",
+        request=request,
+        run_id=state.run_id or "",
+        session_id=sid,
+        task_id=state.task_id,
+    )
     return JSONResponse(result)
 
 
@@ -982,6 +1128,27 @@ async def rest_tool_call(request: Request) -> JSONResponse:
     state._last_activity = time.time()
 
     if name in HEAVY_TOOLS:
+        try:
+            quota_reservation = manager._quota_manager.reserve_heavy_job(
+                owner_user_id=state.owner_user_id,
+                run_id=state.run_id or "",
+                session_id=sid,
+                tool_name=name,
+            )
+        except QuotaExceeded as exc:
+            record_event(
+                manager.bench_root,
+                _audit_user_from_state(state),
+                "tool.job_enqueued",
+                request=request,
+                run_id=state.run_id or "",
+                session_id=sid,
+                task_id=state.task_id,
+                success=False,
+                payload={"tool": name, "error": str(exc)},
+            )
+            return JSONResponse({"error": str(exc)}, status_code=429)
+
         # Async dispatch — return 202 immediately so the client is not
         # holding an HTTP connection open for the full backtest window.
         #
@@ -995,9 +1162,20 @@ async def rest_tool_call(request: Request) -> JSONResponse:
         try:
             job = manager._job_store.create(sid, name, body)
             task = asyncio.create_task(
-                _execute_tool_job(manager, state, job["job_id"], name, body)
+                _execute_tool_job(
+                    manager,
+                    state,
+                    job["job_id"],
+                    name,
+                    body,
+                    quota_reservation=quota_reservation,
+                )
             )
         except BaseException:
+            manager._quota_manager.release_heavy_job(
+                owner_user_id=state.owner_user_id,
+                reservation_id=quota_reservation,
+            )
             state._request_lock.release()
             raise
         manager._job_tasks[job["job_id"]] = task
@@ -1009,6 +1187,16 @@ async def rest_tool_call(request: Request) -> JSONResponse:
             sid[:8],
             job["job_id"][:8],
             name,
+        )
+        record_event(
+            manager.bench_root,
+            _audit_user_from_state(state),
+            "tool.job_enqueued",
+            request=request,
+            run_id=state.run_id or "",
+            session_id=sid,
+            task_id=state.task_id,
+            payload={"tool": name, "job_id": job["job_id"]},
         )
         return JSONResponse(
             {
@@ -1027,6 +1215,17 @@ async def rest_tool_call(request: Request) -> JSONResponse:
         parsed = json.loads(result)
     except (json.JSONDecodeError, TypeError):
         parsed = {"success": True, "output": result}
+    record_event(
+        manager.bench_root,
+        _audit_user_from_state(state),
+        "tool.call",
+        request=request,
+        run_id=state.run_id or "",
+        session_id=sid,
+        task_id=state.task_id,
+        success=bool(parsed.get("success", True)),
+        payload={"tool": name},
+    )
     return JSONResponse(parsed)
 
 
@@ -1036,6 +1235,8 @@ async def _execute_tool_job(
     job_id: str,
     name: str,
     body: dict,
+    *,
+    quota_reservation: str | None = None,
 ) -> None:
     """Background worker for heavy tool invocations.
 
@@ -1069,6 +1270,16 @@ async def _execute_tool_job(
         logger.info(
             "[REST:%s] job %s (%s) completed", sid[:8], job_id[:8], name
         )
+        record_event(
+            manager.bench_root,
+            _audit_user_from_state(state),
+            "tool.job_completed",
+            run_id=state.run_id or "",
+            session_id=sid,
+            task_id=state.task_id,
+            success=bool(parsed.get("success", True)),
+            payload={"tool": name, "job_id": job_id},
+        )
     except Exception as exc:
         logger.exception("[REST:%s] job %s failed", sid[:8], job_id[:8])
         store.update(
@@ -1077,7 +1288,21 @@ async def _execute_tool_job(
             completed_at=time.time(),
             error=f"{type(exc).__name__}: {exc}",
         )
+        record_event(
+            manager.bench_root,
+            _audit_user_from_state(state),
+            "tool.job_completed",
+            run_id=state.run_id or "",
+            session_id=sid,
+            task_id=state.task_id,
+            success=False,
+            payload={"tool": name, "job_id": job_id, "error": str(exc)},
+        )
     finally:
+        manager._quota_manager.release_heavy_job(
+            owner_user_id=state.owner_user_id,
+            reservation_id=quota_reservation,
+        )
         state._request_lock.release()
 
 

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -208,6 +208,10 @@ class SessionState:
         # Run layer binding (set by http_app when connected via run token).
         self.run_id: Optional[str] = None
         self._run_task_id: Optional[str] = None  # task_id from RunAssignment
+        self.owner_user_id: str = ""
+        self.owner_github_login: str = ""
+        self.owner_email: str = ""
+        self.visibility: str = "private"
         # Callback invoked after successful register(). Used by http_app to
         # bind the session to a RunAssignment without injecting RunService
         # into SessionState.
@@ -287,6 +291,11 @@ class SessionState:
 
         state._result_dir = result_dir
         state.phase = SessionPhase.COMPLETED
+        state.run_id = str(run_state.get("run_id") or "")
+        state.owner_user_id = str(run_state.get("owner_user_id") or "")
+        state.owner_github_login = str(run_state.get("owner_github_login") or "")
+        state.owner_email = str(run_state.get("owner_email") or "")
+        state.visibility = str(run_state.get("visibility") or "private")
 
         # Eval state is no longer held in memory — ``get_eval_scores`` reads
         # the bundle's sibling tree on demand (issue #46 slice 4).
@@ -1041,6 +1050,10 @@ class SessionState:
             ),
             run_id=self.run_id or "",
             public_task_label=(self.task_id.split("_")[0] if self.task_id else ""),
+            owner_user_id=self.owner_user_id,
+            owner_github_login=self.owner_github_login,
+            owner_email=self.owner_email,
+            visibility=self.visibility,
         )
         logger.info("Results saved: %s", result_dir)
 

--- a/bench/server/audit.py
+++ b/bench/server/audit.py
@@ -1,0 +1,87 @@
+"""Append-only audit log helpers."""
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_LOCK = threading.Lock()
+
+
+def record_event(
+    bench_root: str | Path,
+    user: Any,
+    action: str,
+    *,
+    run_id: str = "",
+    session_id: str = "",
+    task_id: str = "",
+    request=None,
+    success: bool = True,
+    payload: dict | None = None,
+) -> None:
+    """Append one compact JSONL audit event."""
+    try:
+        root = Path(bench_root)
+        path = root / "results" / "audit" / "events.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        user_data = _user_dict(user)
+        event = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "user_id": user_data.get("user_id", ""),
+            "github_login": user_data.get("github_login", ""),
+            "email": user_data.get("email", ""),
+            "role": user_data.get("role", ""),
+            "ip": _client_ip(request),
+            "user_agent": _user_agent(request),
+            "run_id": run_id,
+            "session_id": session_id,
+            "task_id": task_id,
+            "action": action,
+            "success": bool(success),
+            "payload": payload or {},
+        }
+        line = json.dumps(event, ensure_ascii=False, default=str)
+        with _LOCK:
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+    except Exception:
+        return
+
+
+def _user_dict(user: Any) -> dict:
+    if user is None:
+        return {}
+    if is_dataclass(user):
+        return asdict(user)
+    if isinstance(user, dict):
+        return user
+    to_dict = getattr(user, "to_dict", None)
+    if callable(to_dict):
+        try:
+            value = to_dict()
+            if isinstance(value, dict):
+                return value
+        except Exception:
+            return {}
+    return {}
+
+
+def _client_ip(request) -> str:
+    if request is None:
+        return ""
+    forwarded = request.headers.get("x-forwarded-for", "")
+    if forwarded:
+        return forwarded.split(",", 1)[0].strip()
+    client = getattr(request, "client", None)
+    return str(getattr(client, "host", "") or "")
+
+
+def _user_agent(request) -> str:
+    if request is None:
+        return ""
+    return str(request.headers.get("user-agent", ""))

--- a/bench/server/auth.py
+++ b/bench/server/auth.py
@@ -1,0 +1,437 @@
+"""GitHub OAuth and cookie-backed user sessions for the web UI."""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+import secrets
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal
+from urllib.parse import urlencode
+
+import requests
+from starlette.requests import Request
+from starlette.responses import JSONResponse, RedirectResponse, Response
+
+
+SESSION_COOKIE = "qtb_session"
+SESSION_TTL_SECONDS = 7 * 24 * 60 * 60
+OAUTH_STATE_TTL_SECONDS = 10 * 60
+GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_API_URL = "https://api.github.com"
+
+
+@dataclass(frozen=True)
+class UserContext:
+    user_id: str
+    github_login: str
+    email: str
+    display_name: str
+    avatar_url: str
+    role: Literal["admin", "user"] = "user"
+
+    @property
+    def is_admin(self) -> bool:
+        return self.role == "admin"
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "UserContext":
+        return cls(
+            user_id=str(data.get("user_id") or ""),
+            github_login=str(data.get("github_login") or ""),
+            email=str(data.get("email") or ""),
+            display_name=str(data.get("display_name") or ""),
+            avatar_url=str(data.get("avatar_url") or ""),
+            role="admin" if data.get("role") == "admin" else "user",
+        )
+
+
+class AuthStore:
+    """Tiny JSON-backed store for sessions and OAuth state."""
+
+    def __init__(self, bench_root: str | Path):
+        root = Path(bench_root)
+        self._dir = root / "results" / "auth"
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._sessions_path = self._dir / "sessions.json"
+        self._states_path = self._dir / "oauth_states.json"
+        self._lock = threading.Lock()
+
+    def create_session(self, user: UserContext) -> str:
+        session_id = secrets.token_urlsafe(32)
+        now = time.time()
+        with self._lock:
+            sessions = self._read_locked(self._sessions_path)
+            sessions[session_id] = {
+                "user": user.to_dict(),
+                "created_at": now,
+                "expires_at": now + SESSION_TTL_SECONDS,
+            }
+            self._write_locked(self._sessions_path, sessions)
+        return session_id
+
+    def get_session(self, session_id: str) -> UserContext | None:
+        if not session_id:
+            return None
+        now = time.time()
+        with self._lock:
+            sessions = self._read_locked(self._sessions_path)
+            record = sessions.get(session_id)
+            if not isinstance(record, dict):
+                return None
+            if float(record.get("expires_at") or 0.0) < now:
+                sessions.pop(session_id, None)
+                self._write_locked(self._sessions_path, sessions)
+                return None
+            user = record.get("user")
+            if not isinstance(user, dict):
+                return None
+            return UserContext.from_dict(user)
+
+    def delete_session(self, session_id: str) -> None:
+        if not session_id:
+            return
+        with self._lock:
+            sessions = self._read_locked(self._sessions_path)
+            if session_id in sessions:
+                sessions.pop(session_id, None)
+                self._write_locked(self._sessions_path, sessions)
+
+    def create_state(self, next_url: str = "/") -> str:
+        state = secrets.token_urlsafe(32)
+        now = time.time()
+        with self._lock:
+            states = self._read_locked(self._states_path)
+            states[state] = {
+                "next": _sanitize_next_url(next_url),
+                "created_at": now,
+                "expires_at": now + OAUTH_STATE_TTL_SECONDS,
+            }
+            self._write_locked(self._states_path, states)
+        return state
+
+    def pop_state(self, state: str) -> str | None:
+        if not state:
+            return None
+        now = time.time()
+        with self._lock:
+            states = self._read_locked(self._states_path)
+            record = states.pop(state, None)
+            self._write_locked(self._states_path, states)
+        if not isinstance(record, dict):
+            return None
+        if float(record.get("expires_at") or 0.0) < now:
+            return None
+        return _sanitize_next_url(str(record.get("next") or "/"))
+
+    def _read_locked(self, path: Path) -> dict:
+        if not path.exists():
+            return {}
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    def _write_locked(self, path: Path, payload: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        tmp.replace(path)
+
+
+class AuthService:
+    """Request helpers for the web UI auth boundary."""
+
+    def __init__(self, bench_root: str | Path):
+        self.bench_root = Path(bench_root)
+        self.store = AuthStore(self.bench_root)
+
+    @property
+    def mode(self) -> str:
+        return os.environ.get("QTB_AUTH_MODE", "disabled").strip().lower()
+
+    @property
+    def enabled(self) -> bool:
+        return self.mode == "github"
+
+    def get_current_user(self, request: Request) -> UserContext | None:
+        if not self.enabled:
+            return _local_dev_user()
+        session_id = request.cookies.get(SESSION_COOKIE, "")
+        return self.store.get_session(session_id)
+
+    def require_user(self, request: Request) -> tuple[UserContext | None, JSONResponse | None]:
+        user = self.get_current_user(request)
+        if user is None:
+            return None, JSONResponse(
+                {"error": "Authentication required", "login_url": "/auth/login"},
+                status_code=401,
+            )
+        return user, None
+
+    def require_admin(
+        self, request: Request
+    ) -> tuple[UserContext | None, JSONResponse | None]:
+        automation = self._automation_admin(request)
+        if automation is not None:
+            return automation, None
+        user, err = self.require_user(request)
+        if err is not None:
+            return None, err
+        if user and user.is_admin:
+            return user, None
+        return None, JSONResponse({"error": "Admin access required"}, status_code=403)
+
+    def me_payload(self, request: Request) -> dict:
+        user = self.get_current_user(request)
+        return {
+            "auth_mode": "github" if self.enabled else "disabled",
+            "authenticated": user is not None,
+            "user": user.to_dict() if user else None,
+        }
+
+    async def login(self, request: Request) -> Response:
+        next_url = request.query_params.get("next") or "/"
+        if not self.enabled:
+            return RedirectResponse(_sanitize_next_url(next_url), status_code=302)
+
+        client_id = os.environ.get("QTB_GITHUB_CLIENT_ID", "").strip()
+        if not client_id:
+            return JSONResponse(
+                {"error": "QTB_GITHUB_CLIENT_ID is required"}, status_code=500
+            )
+
+        state = self.store.create_state(next_url)
+        redirect_uri = self._callback_url(request)
+        query = urlencode(
+            {
+                "client_id": client_id,
+                "redirect_uri": redirect_uri,
+                "scope": "read:user user:email read:org",
+                "state": state,
+            }
+        )
+        return RedirectResponse(f"{GITHUB_AUTHORIZE_URL}?{query}", status_code=302)
+
+    async def callback(self, request: Request) -> Response:
+        if not self.enabled:
+            return RedirectResponse("/", status_code=302)
+
+        code = request.query_params.get("code", "")
+        state = request.query_params.get("state", "")
+        next_url = self.store.pop_state(state)
+        if not next_url:
+            return JSONResponse({"error": "Invalid OAuth state"}, status_code=400)
+        if not code:
+            return JSONResponse({"error": "Missing OAuth code"}, status_code=400)
+
+        token = self._exchange_code(code, self._callback_url(request))
+        profile = self._fetch_profile(token)
+        if not self._is_allowed(profile, token):
+            return JSONResponse({"error": "GitHub account is outside allowlist"}, 403)
+
+        user = self._build_user(profile)
+        session_id = self.store.create_session(user)
+        response = RedirectResponse(next_url, status_code=302)
+        self._set_session_cookie(request, response, session_id)
+
+        from server.audit import record_event
+
+        record_event(
+            self.bench_root,
+            user,
+            "auth.login",
+            request=request,
+            success=True,
+            payload={"role": user.role},
+        )
+        return response
+
+    async def logout(self, request: Request) -> Response:
+        user = self.get_current_user(request)
+        session_id = request.cookies.get(SESSION_COOKIE, "")
+        self.store.delete_session(session_id)
+        response = JSONResponse({"status": "logged_out"})
+        response.delete_cookie(SESSION_COOKIE, path="/")
+
+        from server.audit import record_event
+
+        record_event(
+            self.bench_root,
+            user,
+            "auth.logout",
+            request=request,
+            success=True,
+        )
+        return response
+
+    def _automation_admin(self, request: Request) -> UserContext | None:
+        expected = os.environ.get("QTB_ADMIN_TOKEN", "")
+        if not expected:
+            return None
+        auth = request.headers.get("authorization", "")
+        raw = auth[7:].strip() if auth.lower().startswith("bearer ") else ""
+        if raw and hmac.compare_digest(expected, raw):
+            return UserContext(
+                user_id="automation-admin",
+                github_login="automation-admin",
+                email="",
+                display_name="Automation Admin",
+                avatar_url="",
+                role="admin",
+            )
+        return None
+
+    def _exchange_code(self, code: str, redirect_uri: str) -> str:
+        client_id = os.environ.get("QTB_GITHUB_CLIENT_ID", "").strip()
+        client_secret = os.environ.get("QTB_GITHUB_CLIENT_SECRET", "").strip()
+        response = requests.post(
+            GITHUB_TOKEN_URL,
+            headers={"Accept": "application/json"},
+            data={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "code": code,
+                "redirect_uri": redirect_uri,
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        token = str(payload.get("access_token") or "")
+        if not token:
+            raise PermissionError("GitHub OAuth token exchange failed")
+        return token
+
+    def _fetch_profile(self, token: str) -> dict:
+        user = self._github_get(token, "/user")
+        emails = self._github_get(token, "/user/emails")
+        if isinstance(emails, list):
+            primary = next(
+                (
+                    item
+                    for item in emails
+                    if item.get("primary") and item.get("verified")
+                ),
+                None,
+            )
+            if primary and primary.get("email"):
+                user["email"] = primary["email"]
+        return user
+
+    def _github_get(self, token: str, path: str):
+        response = requests.get(
+            f"{GITHUB_API_URL}{path}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _is_allowed(self, profile: dict, token: str) -> bool:
+        login = str(profile.get("login") or "")
+        allowed_logins = _csv_env("QTB_GITHUB_ALLOWED_LOGINS")
+        if allowed_logins and login.lower() in allowed_logins:
+            return True
+
+        allowed_orgs = _csv_env("QTB_GITHUB_ALLOWED_ORGS")
+        allowed_teams = _csv_env("QTB_GITHUB_ALLOWED_TEAMS")
+        if not allowed_orgs and not allowed_teams and not allowed_logins:
+            allowed_orgs = {"varsity-tech-product"}
+
+        if allowed_orgs:
+            orgs = self._github_get(token, "/user/orgs")
+            org_logins = {
+                str(org.get("login") or "").lower()
+                for org in orgs
+                if isinstance(org, dict)
+            }
+            if org_logins & allowed_orgs:
+                return True
+
+        if allowed_teams:
+            teams = self._github_get(token, "/user/teams")
+            for team in teams if isinstance(teams, list) else []:
+                if not isinstance(team, dict):
+                    continue
+                slug = str(team.get("slug") or "").lower()
+                org = team.get("organization") or {}
+                org_login = str(org.get("login") or "").lower()
+                if slug in allowed_teams or f"{org_login}/{slug}" in allowed_teams:
+                    return True
+        return False
+
+    def _build_user(self, profile: dict) -> UserContext:
+        login = str(profile.get("login") or "")
+        email = str(profile.get("email") or "")
+        admin_logins = _csv_env("QTB_ADMIN_GITHUB_LOGINS")
+        admin_emails = _csv_env("QTB_ADMIN_EMAILS")
+        role: Literal["admin", "user"] = "admin" if (
+            login.lower() in admin_logins or email.lower() in admin_emails
+        ) else "user"
+        return UserContext(
+            user_id=f"github:{login.lower()}",
+            github_login=login,
+            email=email,
+            display_name=str(profile.get("name") or login),
+            avatar_url=str(profile.get("avatar_url") or ""),
+            role=role,
+        )
+
+    def _callback_url(self, request: Request) -> str:
+        public_base = os.environ.get("QTB_PUBLIC_BASE_URL", "").strip().rstrip("/")
+        base = public_base or str(request.base_url).rstrip("/")
+        return f"{base}/auth/callback"
+
+    def _set_session_cookie(
+        self, request: Request, response: Response, session_id: str
+    ) -> None:
+        public_base = os.environ.get("QTB_PUBLIC_BASE_URL", "").strip().lower()
+        secure_env = os.environ.get("QTB_COOKIE_SECURE", "").strip().lower()
+        secure = secure_env in {"1", "true", "yes"} or public_base.startswith("https:")
+        if request.url.scheme == "https":
+            secure = True
+        response.set_cookie(
+            SESSION_COOKIE,
+            session_id,
+            max_age=SESSION_TTL_SECONDS,
+            path="/",
+            httponly=True,
+            secure=secure,
+            samesite="lax",
+        )
+
+
+def _csv_env(name: str) -> set[str]:
+    raw = os.environ.get(name, "")
+    return {item.strip().lower() for item in raw.split(",") if item.strip()}
+
+
+def _sanitize_next_url(next_url: str) -> str:
+    value = (next_url or "/").strip()
+    if not value.startswith("/") or value.startswith("//"):
+        return "/"
+    return value
+
+
+def _local_dev_user() -> UserContext:
+    return UserContext(
+        user_id="local-dev",
+        github_login="local-dev",
+        email="",
+        display_name="Local Dev",
+        avatar_url="",
+        role="admin",
+    )

--- a/bench/server/quota.py
+++ b/bench/server/quota.py
@@ -1,0 +1,126 @@
+"""Per-user quota checks for UI-created benchmark runs and heavy jobs."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+
+class QuotaExceeded(ValueError):
+    """Raised when a user quota would be exceeded."""
+
+
+def quota_subject_enabled(owner_user_id: str) -> bool:
+    owner = str(owner_user_id or "")
+    return bool(owner and owner != "local-dev")
+
+
+def max_active_runs_per_user() -> int:
+    return _int_env("QTB_MAX_ACTIVE_RUNS_PER_USER", 2)
+
+
+class QuotaManager:
+    def __init__(self, bench_root: str | Path):
+        self.bench_root = Path(bench_root)
+        self._dir = self.bench_root / "results" / "quotas"
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+
+    def reserve_heavy_job(
+        self,
+        *,
+        owner_user_id: str,
+        run_id: str,
+        session_id: str,
+        tool_name: str,
+        job_id: str = "",
+    ) -> str | None:
+        if not quota_subject_enabled(owner_user_id):
+            return None
+
+        max_running = _int_env("QTB_MAX_RUNNING_JOBS_PER_USER", 1)
+        daily_limit = _int_env("QTB_DAILY_BACKTEST_LIMIT_PER_USER", 20)
+        reservation_id = job_id or uuid4().hex
+        now = time.time()
+
+        with self._lock:
+            path = self._today_path()
+            data = self._read_locked(path)
+            running = data.setdefault("running_jobs", {})
+            daily = data.setdefault("daily_counts", {})
+            user_running = [
+                job
+                for job in running.get(owner_user_id, [])
+                if isinstance(job, dict)
+            ]
+
+            if max_running > 0 and len(user_running) >= max_running:
+                raise QuotaExceeded(
+                    f"User has reached the active heavy-job limit ({max_running})"
+                )
+            current_count = int(daily.get(owner_user_id, 0) or 0)
+            if daily_limit > 0 and current_count >= daily_limit:
+                raise QuotaExceeded(
+                    f"User has reached the daily backtest limit ({daily_limit})"
+                )
+
+            user_running.append(
+                {
+                    "reservation_id": reservation_id,
+                    "run_id": run_id,
+                    "session_id": session_id,
+                    "tool_name": tool_name,
+                    "started_at": now,
+                }
+            )
+            running[owner_user_id] = user_running
+            daily[owner_user_id] = current_count + 1
+            self._write_locked(path, data)
+        return reservation_id
+
+    def release_heavy_job(self, *, owner_user_id: str, reservation_id: str | None) -> None:
+        if not quota_subject_enabled(owner_user_id) or not reservation_id:
+            return
+        with self._lock:
+            path = self._today_path()
+            data = self._read_locked(path)
+            running = data.setdefault("running_jobs", {})
+            user_running = [
+                job
+                for job in running.get(owner_user_id, [])
+                if isinstance(job, dict)
+                and str(job.get("reservation_id") or "") != reservation_id
+            ]
+            running[owner_user_id] = user_running
+            self._write_locked(path, data)
+
+    def _today_path(self) -> Path:
+        day = datetime.now(timezone.utc).strftime("%Y%m%d")
+        return self._dir / f"{day}.json"
+
+    def _read_locked(self, path: Path) -> dict:
+        if not path.exists():
+            return {}
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    def _write_locked(self, path: Path, payload: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        tmp.replace(path)
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default

--- a/bench/server/run/models.py
+++ b/bench/server/run/models.py
@@ -41,6 +41,12 @@ class RunAssignment:
     control_token_hint: str = ""
     control_token_hash: str = ""
 
+    # UI owner and sharing scope
+    owner_user_id: str = ""
+    owner_github_login: str = ""
+    owner_email: str = ""
+    visibility: str = "private"
+
     # Binding (set after claim)
     client_info: Optional[dict] = None
     session_id: Optional[str] = None
@@ -92,6 +98,9 @@ class RunAssignment:
             "session_id": self.session_id,
             "persona_id": self.persona_id,
             "eval_status": self.eval_status,
+            "owner_user_id": self.owner_user_id,
+            "owner_github_login": self.owner_github_login,
+            "visibility": self.visibility,
             "error": self.error,
             "created_at": self.created_at,
             "updated_at": self.updated_at,

--- a/bench/server/run/service.py
+++ b/bench/server/run/service.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 from .catalog import TaskCatalog
 from .models import TERMINAL_STATUSES, RunAssignment, RunStatus
 from .store import RunStore
+from server.quota import QuotaExceeded, max_active_runs_per_user, quota_subject_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,10 @@ class RunService:
         mode: str = "agent",
         persona_policy: str = "auto",
         token_ttl_minutes: int = 30,
+        owner_user_id: str = "",
+        owner_github_login: str = "",
+        owner_email: str = "",
+        visibility: str = "private",
     ) -> tuple[RunAssignment, str, str]:
         """Create a RunAssignment + generate both tokens.
 
@@ -59,6 +64,15 @@ class RunService:
         entry = self._catalog.resolve(task)
         if entry is None:
             raise ValueError(f"Unknown task: {task}")
+
+        owner_user_id = str(owner_user_id or "")
+        if quota_subject_enabled(owner_user_id):
+            limit = max_active_runs_per_user()
+            active_count = self._count_active_runs(owner_user_id)
+            if limit > 0 and active_count >= limit:
+                raise QuotaExceeded(
+                    f"User has reached the active run limit ({limit})"
+                )
 
         raw_token = f"qtb_{secrets.token_urlsafe(24)}"
         token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
@@ -85,6 +99,10 @@ class RunService:
             token_expires_at=expires_at,
             control_token_hint=control_token_hint,
             control_token_hash=control_token_hash,
+            owner_user_id=owner_user_id,
+            owner_github_login=str(owner_github_login or ""),
+            owner_email=str(owner_email or ""),
+            visibility=visibility if visibility in ("private", "org") else "private",
             persona_policy=persona_policy,
             created_at=now,
             updated_at=now,
@@ -105,6 +123,10 @@ class RunService:
         client_info: Optional[dict] = None,
         mode: str = "agent",
         persona_policy: str = "auto",
+        owner_user_id: str = "",
+        owner_github_login: str = "",
+        owner_email: str = "",
+        visibility: str = "private",
     ) -> tuple[RunAssignment, str, str]:
         """Create + immediately claim. For client-initiated runs.
 
@@ -112,7 +134,13 @@ class RunService:
         status already CLAIMED.
         """
         assignment, raw_token, raw_control_token = self.create_run(
-            task=task, mode=mode, persona_policy=persona_policy
+            task=task,
+            mode=mode,
+            persona_policy=persona_policy,
+            owner_user_id=owner_user_id,
+            owner_github_login=owner_github_login,
+            owner_email=owner_email,
+            visibility=visibility,
         )
         now = _now_iso()
         assignment.status = RunStatus.CLAIMED
@@ -275,12 +303,40 @@ class RunService:
         self,
         status: Optional[str] = None,
         task: Optional[str] = None,
+        owner_user_id: Optional[str] = None,
+        include_all: bool = False,
+        include_org: bool = False,
     ) -> list[RunAssignment]:
         status_enum = RunStatus(status) if status else None
         runs = self._store.list_runs(status=status_enum)
         if task:
             runs = [r for r in runs if r.public_task_label == task]
+        if owner_user_id is not None and not include_all:
+            owner = str(owner_user_id or "")
+            if include_org:
+                runs = [
+                    r
+                    for r in runs
+                    if r.owner_user_id == owner
+                    or (r.visibility == "org" and bool(r.owner_user_id))
+                ]
+            else:
+                runs = [r for r in runs if r.owner_user_id == owner]
         return runs
+
+    def get_run_for_user(self, run_id: str, user) -> Optional[RunAssignment]:
+        assignment = self._store.get(run_id)
+        if assignment is None:
+            return None
+        if self._run_visible_to_user(assignment, user):
+            return assignment
+        return None
+
+    def assert_run_owner_or_admin(self, run_id: str, user) -> RunAssignment:
+        assignment = self._get_or_raise(run_id)
+        if not self._run_visible_to_user(assignment, user):
+            raise PermissionError("Run access denied")
+        return assignment
 
     def resolve_token(self, raw_token: str) -> Optional[RunAssignment]:
         """Find a run by raw run_token. Does NOT change state."""
@@ -313,3 +369,20 @@ class RunService:
         if assignment is None:
             raise ValueError(f"Run not found: {run_id}")
         return assignment
+
+    def _count_active_runs(self, owner_user_id: str) -> int:
+        return sum(
+            1
+            for run in self._store.list_runs()
+            if run.owner_user_id == owner_user_id and run.status not in TERMINAL_STATUSES
+        )
+
+    def _run_visible_to_user(self, assignment: RunAssignment, user) -> bool:
+        if user is None:
+            return False
+        if bool(getattr(user, "is_admin", False)):
+            return True
+        return bool(
+            assignment.owner_user_id
+            and assignment.owner_user_id == str(getattr(user, "user_id", "") or "")
+        )

--- a/bench/server/storage/result_writer.py
+++ b/bench/server/storage/result_writer.py
@@ -45,6 +45,10 @@ def save_run_state(
     artifact_debug_history: Optional[list[dict]] = None,
     run_id: str = "",
     public_task_label: str = "",
+    owner_user_id: str = "",
+    owner_github_login: str = "",
+    owner_email: str = "",
+    visibility: str = "private",
 ) -> Path:
     """Save ``run_state.json`` + ``run_state.md``."""
     result_dir = Path(result_dir)
@@ -100,6 +104,10 @@ def save_run_state(
     state = {
         "run_id": run_id,
         "public_task_label": public_task_label,
+        "owner_user_id": owner_user_id,
+        "owner_github_login": owner_github_login,
+        "owner_email": owner_email,
+        "visibility": visibility,
         "task_id": task_id,
         "session_id": session_id,
         "persona_id": persona_id,

--- a/bench/server/web/static/css/styles.css
+++ b/bench/server/web/static/css/styles.css
@@ -127,6 +127,51 @@ code {
   gap: 8px;
 }
 
+.nav-user {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 120px;
+}
+
+.nav-user-card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.nav-avatar,
+.nav-avatar-fallback {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+
+.nav-avatar {
+  object-fit: cover;
+}
+
+.nav-avatar-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.nav-user-name {
+  max-width: 140px;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .nav-link {
   padding: 9px 14px;
   border-radius: var(--radius-pill);
@@ -146,6 +191,11 @@ code {
   background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
   color: #fff;
   box-shadow: 0 8px 18px rgba(179, 92, 30, 0.2);
+}
+
+.btn-small {
+  padding: 7px 10px;
+  font-size: 12px;
 }
 
 #app {

--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -3,8 +3,14 @@
 
   var app = document.getElementById('app');
   if (!app) return;
+  window.QTB = window.QTB || {};
 
   var state = {
+    auth: {
+      loaded: false,
+      authMode: 'disabled',
+      user: null
+    },
     results: null,
     tasksPayload: null,
     detailCache: {},
@@ -53,8 +59,29 @@
     return '<pre>' + escapeHtml(markdown) + '</pre>';
   }
 
+  function loginUrl() {
+    return '/auth/login?next=' + encodeURIComponent(
+      window.location.pathname + window.location.search + window.location.hash
+    );
+  }
+
+  function redirectToLogin() {
+    window.location.href = loginUrl();
+  }
+
+  function authFetch(path, options) {
+    return fetch(path, options).then(function (response) {
+      if (response.status === 401) {
+        redirectToLogin();
+      }
+      return response;
+    });
+  }
+
+  window.QTB.authFetch = authFetch;
+
   function api(path) {
-    return fetch('/ui' + path).then(function (response) {
+    return authFetch('/ui' + path).then(function (response) {
       if (!response.ok) {
         return response.text().then(function (text) {
           throw new Error(text || ('HTTP ' + response.status));
@@ -70,7 +97,7 @@
       {'Content-Type': 'application/json'},
       options.headers || {}
     );
-    return fetch(path, options).then(function (response) {
+    return authFetch(path, options).then(function (response) {
       return response.text().then(function (text) {
         var payload = {};
         if (text) {
@@ -87,6 +114,54 @@
         return payload;
       });
     });
+  }
+
+  function loadMe() {
+    return fetch('/ui/me')
+      .then(function (response) { return response.json(); })
+      .then(function (payload) {
+        state.auth.loaded = true;
+        state.auth.authMode = payload.auth_mode || 'disabled';
+        state.auth.user = payload.user || null;
+        renderNavUser();
+        if (state.auth.authMode === 'github' && !payload.authenticated) {
+          redirectToLogin();
+        }
+        return payload;
+      })
+      .catch(function () {
+        state.auth.loaded = true;
+        renderNavUser();
+      });
+  }
+
+  function renderNavUser() {
+    var target = document.getElementById('nav-user');
+    if (!target) return;
+    var user = state.auth.user;
+    if (!user) {
+      target.innerHTML = '<a class="btn btn-secondary btn-small" href="' + loginUrl() + '">Log in</a>';
+      return;
+    }
+    var avatar = user.avatar_url
+      ? '<img class="nav-avatar" src="' + escapeHtml(user.avatar_url) + '" alt="">'
+      : '<span class="nav-avatar-fallback">' + escapeHtml((user.github_login || 'U').slice(0, 1).toUpperCase()) + '</span>';
+    target.innerHTML =
+      '<div class="nav-user-card">' +
+        avatar +
+        '<span class="nav-user-name">' + escapeHtml(user.github_login || user.display_name || 'User') + '</span>' +
+        (user.role === 'admin' ? '<span class="badge">Admin</span>' : '') +
+        '<button class="btn btn-secondary btn-small" id="auth-logout-btn" type="button">Logout</button>' +
+      '</div>';
+    var logout = document.getElementById('auth-logout-btn');
+    if (logout) {
+      logout.addEventListener('click', function () {
+        fetch('/auth/logout', {method: 'POST'}).then(function () {
+          state.auth.user = null;
+          redirectToLogin();
+        });
+      });
+    }
   }
 
   function formatDuration(value) {
@@ -594,7 +669,7 @@
 
   function ensureRuns(force) {
     if (runsState.runs && !force) return Promise.resolve(runsState.runs);
-    return fetch('/ui/runs').then(function (r) { return r.json(); })
+    return authFetch('/ui/runs').then(function (r) { return r.json(); })
       .then(function (data) {
         runsState.runs = data.runs || [];
         return runsState.runs;
@@ -2035,5 +2110,7 @@
   }
 
   window.addEventListener('hashchange', onRouteChange);
-  window.addEventListener('load', onRouteChange);
+  window.addEventListener('load', function () {
+    loadMe().then(onRouteChange);
+  });
 })();

--- a/bench/server/web/static/js/flow-demo.js
+++ b/bench/server/web/static/js/flow-demo.js
@@ -29,6 +29,13 @@
     search: ''
   };
 
+  function authFetch(url, options) {
+    if (window.QTB && typeof window.QTB.authFetch === 'function') {
+      return window.QTB.authFetch(url, options);
+    }
+    return fetch(url, options);
+  }
+
   window.QTB.renderFlowDemoPage = function (app) {
     _root = app;
     render();
@@ -53,13 +60,13 @@
   }
 
   function refresh() {
-    return fetch('/ui/runs/live')
+    return authFetch('/ui/runs/live')
       .then(function (resp) {
         if (!resp.ok) throw new Error('HTTP ' + resp.status);
         return resp.json();
       })
       .catch(function () {
-        return fetch('/ui/runs').then(function (resp) {
+        return authFetch('/ui/runs').then(function (resp) {
           if (!resp.ok) throw new Error('HTTP ' + resp.status);
           return resp.json();
         });

--- a/bench/server/web/static/js/run-agent.js
+++ b/bench/server/web/static/js/run-agent.js
@@ -56,6 +56,13 @@
     if (tok) {
       options.headers['Authorization'] = 'Bearer ' + tok;
     }
+    return _authFetch(url, options);
+  }
+
+  function _authFetch(url, options) {
+    if (window.QTB && typeof window.QTB.authFetch === 'function') {
+      return window.QTB.authFetch(url, options);
+    }
     return fetch(url, options);
   }
 
@@ -80,7 +87,7 @@
 
   function loadCatalog(callback) {
     if (_catalog) { callback(_catalog); return; }
-    fetch('/ui/tasks/catalog/labels')
+    _authFetch('/ui/tasks/catalog/labels')
       .then(function (r) { return r.json(); })
       .then(function (data) {
         _catalog = data.tasks || [];
@@ -157,7 +164,7 @@
         createBtn.textContent = 'Creating...';
         errorDiv.style.display = 'none';
 
-        fetch('/ui/runs', {
+        _authFetch('/ui/runs', {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
           body: JSON.stringify({task: task, mode: 'agent'})

--- a/bench/server/web/templates/index.html
+++ b/bench/server/web/templates/index.html
@@ -22,6 +22,7 @@
       <a href="#/results" class="nav-link" data-route="results">Results</a>
       <a href="#/tasks" class="nav-link" data-route="tasks">Tasks</a>
     </div>
+    <div id="nav-user" class="nav-user"></div>
   </nav>
 
   <main id="app"></main>
@@ -29,8 +30,8 @@
   <script src="/static/js/render.js?v=20260421a"></script>
   <script src="/static/js/chat.js?v=20260421a"></script>
   <script src="/static/js/tools.js?v=20260421a"></script>
-  <script src="/static/js/run-agent.js?v=20260421a"></script>
-  <script src="/static/js/flow-demo.js?v=20260422b"></script>
-  <script src="/static/js/app.js?v=20260421a"></script>
+  <script src="/static/js/run-agent.js?v=20260422c"></script>
+  <script src="/static/js/flow-demo.js?v=20260422c"></script>
+  <script src="/static/js/app.js?v=20260422c"></script>
 </body>
 </html>

--- a/bench/server/web/ui_app.py
+++ b/bench/server/web/ui_app.py
@@ -16,6 +16,9 @@ import math
 import os
 from dataclasses import asdict
 
+from server.audit import record_event
+from server.auth import AuthService
+from server.quota import QuotaExceeded
 from starlette.requests import Request
 from starlette.responses import FileResponse, JSONResponse
 from starlette.routing import Route
@@ -112,16 +115,57 @@ def ui_routes(manager) -> list[Route]:
     """
 
     indexer = ResultIndexer(manager.bench_root)
+    auth = AuthService(manager.bench_root)
+
+    def _scope_flags(request: Request, user) -> tuple[bool, bool]:
+        scope = request.query_params.get("scope", "").strip().lower()
+        include_all = bool(getattr(user, "is_admin", False)) and scope in ("", "all")
+        include_org = scope == "org"
+        return include_all, include_org
+
+    def _run_access_from_cookie(run_service, run_id: str, user):
+        if user is None:
+            return None
+        try:
+            return run_service.assert_run_owner_or_admin(run_id, user)
+        except PermissionError:
+            return None
+        except ValueError:
+            raise
+
+    async def auth_login(request: Request):
+        return await auth.login(request)
+
+    async def auth_callback(request: Request):
+        try:
+            return await auth.callback(request)
+        except PermissionError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=401)
+        except Exception as exc:
+            logger.warning("OAuth callback failed: %s", exc, exc_info=True)
+            return JSONResponse({"error": "OAuth callback failed"}, status_code=502)
+
+    async def auth_logout(request: Request):
+        return await auth.logout(request)
+
+    async def ui_me(request: Request) -> JSONResponse:
+        return JSONResponse(auth.me_payload(request))
 
     # -----------------------------------------------------------------------
     # Existing: /ui/tasks, /ui/results/*
     # -----------------------------------------------------------------------
 
     async def list_tasks(request: Request) -> JSONResponse:
-        _ = request
+        _, err = auth.require_user(request)
+        if err is not None:
+            return err
         return JSONResponse(_sanitize_for_json(indexer.list_tasks()))
 
     async def list_results(request: Request) -> JSONResponse:
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
+        include_all, include_org = _scope_flags(request, user)
         return JSONResponse(
             _sanitize_for_json(
                 {
@@ -129,48 +173,111 @@ def ui_routes(manager) -> list[Route]:
                         category=request.query_params.get("category"),
                         task_id=request.query_params.get("task_id"),
                         eval_status=request.query_params.get("eval_status"),
+                        owner_user_id=None if include_all else user.user_id,
+                        user=user,
+                        include_all=include_all,
+                        include_org=include_org,
                     ),
                 }
             )
         )
 
     async def get_detail(request: Request) -> JSONResponse:
-        detail = indexer.get_detail(request.path_params["session_id"])
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
+        include_all, include_org = _scope_flags(request, user)
+        try:
+            detail = indexer.get_detail(
+                request.path_params["session_id"],
+                user=user,
+                include_all=include_all,
+                include_org=include_org,
+            )
+        except PermissionError:
+            return JSONResponse({"error": "Result access denied"}, status_code=403)
         if detail is None:
             return JSONResponse({"error": "Session not found"}, status_code=404)
+        record_event(
+            manager.bench_root,
+            user,
+            "result.view",
+            request=request,
+            run_id=str(detail.get("run_id") or ""),
+            session_id=str(detail.get("session_id") or ""),
+            task_id=str(detail.get("task_id") or ""),
+        )
         return JSONResponse(_sanitize_for_json(detail))
 
     async def get_workspace(request: Request) -> JSONResponse:
-        payload = indexer.get_workspace_index(request.path_params["session_id"])
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
+        include_all, include_org = _scope_flags(request, user)
+        try:
+            payload = indexer.get_workspace_index(
+                request.path_params["session_id"],
+                user=user,
+                include_all=include_all,
+                include_org=include_org,
+            )
+        except PermissionError:
+            return JSONResponse({"error": "Result access denied"}, status_code=403)
         if payload is None:
             return JSONResponse({"error": "Session not found"}, status_code=404)
         return JSONResponse(_sanitize_for_json(payload))
 
     async def get_workspace_preview(request: Request) -> JSONResponse:
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
+        include_all, include_org = _scope_flags(request, user)
         try:
             payload = indexer.get_workspace_preview(
                 request.path_params["session_id"],
                 request.path_params["path"],
+                user=user,
+                include_all=include_all,
+                include_org=include_org,
             )
         except ValueError:
             return JSONResponse({"error": "Invalid path"}, status_code=400)
+        except PermissionError:
+            return JSONResponse({"error": "Result access denied"}, status_code=403)
 
         if payload is None:
             return JSONResponse({"error": "Not found"}, status_code=404)
         return JSONResponse(_sanitize_for_json(payload))
 
     async def get_file(request: Request) -> JSONResponse | FileResponse:
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
+        include_all, include_org = _scope_flags(request, user)
         try:
             full_path = indexer.resolve_agent_file(
                 request.path_params["session_id"],
                 request.path_params["path"],
+                user=user,
+                include_all=include_all,
+                include_org=include_org,
             )
         except ValueError:
             return JSONResponse({"error": "Invalid path"}, status_code=400)
+        except PermissionError:
+            return JSONResponse({"error": "Result access denied"}, status_code=403)
 
         if full_path is None:
             return JSONResponse({"error": "Not found"}, status_code=404)
 
+        record_event(
+            manager.bench_root,
+            user,
+            "result.file_read",
+            request=request,
+            session_id=request.path_params["session_id"],
+            payload={"path": request.path_params["path"]},
+        )
         return FileResponse(str(full_path))
 
     # -----------------------------------------------------------------------
@@ -182,7 +289,9 @@ def ui_routes(manager) -> list[Route]:
 
         Used by Results UI. Do not wire this into the Run/exam UI.
         """
-        _ = request
+        _, err = auth.require_user(request)
+        if err is not None:
+            return err
         run_service = getattr(manager, "_run_service", None)
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
@@ -190,7 +299,9 @@ def ui_routes(manager) -> list[Route]:
 
     async def task_catalog_labels(request: Request) -> JSONResponse:
         """Run/exam-mode catalog — labels only, no category or difficulty."""
-        _ = request
+        _, err = auth.require_user(request)
+        if err is not None:
+            return err
         run_service = getattr(manager, "_run_service", None)
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
@@ -202,6 +313,9 @@ def ui_routes(manager) -> list[Route]:
 
     async def create_run(request: Request) -> JSONResponse:
         """``POST /ui/runs`` — create a new run assignment."""
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
         run_service = getattr(manager, "_run_service", None)
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
@@ -218,6 +332,7 @@ def ui_routes(manager) -> list[Route]:
         mode = body.get("mode", "agent")
         persona_policy = body.get("persona_policy", "auto")
         token_ttl = body.get("token_ttl_minutes", 30)
+        visibility = body.get("visibility", "private")
 
         try:
             assignment, raw_token, raw_control_token = run_service.create_run(
@@ -225,7 +340,21 @@ def ui_routes(manager) -> list[Route]:
                 mode=mode,
                 persona_policy=persona_policy,
                 token_ttl_minutes=token_ttl,
+                owner_user_id=user.user_id,
+                owner_github_login=user.github_login,
+                owner_email=user.email,
+                visibility=visibility,
             )
+        except QuotaExceeded as exc:
+            record_event(
+                manager.bench_root,
+                user,
+                "run.create",
+                request=request,
+                success=False,
+                payload={"error": str(exc), "task": task},
+            )
+            return JSONResponse({"error": str(exc)}, 429)
         except ValueError as exc:
             return JSONResponse({"error": str(exc)}, 400)
 
@@ -233,6 +362,15 @@ def ui_routes(manager) -> list[Route]:
         base_url = str(request.base_url).rstrip("/")
         mcp_url = f"{base_url}/mcp"
 
+        record_event(
+            manager.bench_root,
+            user,
+            "run.create",
+            request=request,
+            run_id=assignment.run_id,
+            task_id=assignment.task_id,
+            payload={"visibility": assignment.visibility},
+        )
         return JSONResponse(
             {
                 "run_id": assignment.run_id,
@@ -251,22 +389,24 @@ def ui_routes(manager) -> list[Route]:
         )
 
     async def list_runs(request: Request) -> JSONResponse:
-        """``GET /ui/runs`` — list runs with optional filters.
-
-        Requires ``Authorization: Bearer <admin_token>`` when
-        ``QTB_ADMIN_TOKEN`` is set; otherwise allowed (local dev).
-        """
+        """``GET /ui/runs`` — list owner-visible runs with optional filters."""
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
         run_service = getattr(manager, "_run_service", None)
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
 
-        err = _authorize_admin_token(request)
-        if err is not None:
-            return err
-
         status = request.query_params.get("status")
         task = request.query_params.get("task")
-        runs = run_service.list_runs(status=status, task=task)
+        include_all, include_org = _scope_flags(request, user)
+        runs = run_service.list_runs(
+            status=status,
+            task=task,
+            owner_user_id=user.user_id,
+            include_all=include_all,
+            include_org=include_org,
+        )
         return JSONResponse({"runs": [r.public_dict() for r in runs]})
 
     async def get_run(request: Request) -> JSONResponse:
@@ -276,8 +416,18 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse({"error": "Run service not initialized"}, 503)
 
         run_id = request.path_params["run_id"]
+        user = auth.get_current_user(request) if auth.enabled else None
+        try:
+            run = _run_access_from_cookie(run_service, run_id, user)
+        except ValueError:
+            return JSONResponse({"error": "Run not found"}, 404)
+        if run is not None:
+            return JSONResponse(run.public_dict())
+
         err, run = _authorize_control_token(request, run_service, run_id)
         if err is not None:
+            if user is not None:
+                return JSONResponse({"error": "Run access denied"}, status_code=403)
             return err
         return JSONResponse(run.public_dict())
 
@@ -288,9 +438,17 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse({"error": "Run service not initialized"}, 503)
 
         run_id = request.path_params["run_id"]
-        err, run = _authorize_control_token(request, run_service, run_id)
-        if err is not None:
-            return err
+        user = auth.get_current_user(request) if auth.enabled else None
+        try:
+            run = _run_access_from_cookie(run_service, run_id, user)
+        except ValueError:
+            return JSONResponse({"error": "Run not found"}, 404)
+        if run is None:
+            err, run = _authorize_control_token(request, run_service, run_id)
+            if err is not None:
+                if user is not None:
+                    return JSONResponse({"error": "Run access denied"}, status_code=403)
+                return err
 
         # Terminal or pre-active states
         if run.status.value in (
@@ -303,6 +461,7 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse(
                 {
                     "run_status": run.status.value,
+                    "session_id": run.session_id,
                     "session_phase": None,
                 }
             )
@@ -312,6 +471,7 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse(
                 {
                     "run_status": run.status.value,
+                    "session_id": run.session_id,
                     "session_phase": None,
                 }
             )
@@ -321,6 +481,7 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse(
                 {
                     "run_status": run.status.value,
+                    "session_id": run.session_id,
                     "session_phase": None,
                 }
             )
@@ -344,6 +505,7 @@ def ui_routes(manager) -> list[Route]:
             _sanitize_for_json(
                 {
                     "run_status": run.status.value,
+                    "session_id": run.session_id,
                     "session_phase": session.phase.value,
                     "turn": turn,
                     "conversation": conversation,
@@ -395,13 +557,20 @@ def ui_routes(manager) -> list[Route]:
 
     async def observe_runs_live(request: Request) -> JSONResponse:
         """``GET /ui/runs/live`` — passive read-only monitor snapshot."""
-        _ = request
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
         run_service = getattr(manager, "_run_service", None)
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
 
+        include_all, include_org = _scope_flags(request, user)
         runs = sorted(
-            run_service.list_runs(),
+            run_service.list_runs(
+                owner_user_id=user.user_id,
+                include_all=include_all,
+                include_org=include_org,
+            ),
             key=lambda run: run.created_at or "",
             reverse=True,
         )[:50]
@@ -420,9 +589,17 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse({"error": "Run service not initialized"}, 503)
 
         run_id = request.path_params["run_id"]
-        err, _ = _authorize_control_token(request, run_service, run_id)
-        if err is not None:
-            return err
+        user = auth.get_current_user(request) if auth.enabled else None
+        try:
+            run = _run_access_from_cookie(run_service, run_id, user)
+        except ValueError:
+            return JSONResponse({"error": "Run not found"}, 404)
+        if run is None:
+            err, _ = _authorize_control_token(request, run_service, run_id)
+            if err is not None:
+                if user is not None:
+                    return JSONResponse({"error": "Run access denied"}, status_code=403)
+                return err
         try:
             await manager.cancel_run(run_id)
         except ValueError as exc:
@@ -432,6 +609,15 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse({"error": f"Cancel failed: {exc}"}, 500)
 
         run = run_service.get_run(run_id)
+        record_event(
+            manager.bench_root,
+            user,
+            "run.cancel",
+            request=request,
+            run_id=run_id,
+            session_id=run.session_id if run else "",
+            success=True,
+        )
         return JSONResponse(run.public_dict() if run else {"status": "cancelled"})
 
     # -----------------------------------------------------------------------
@@ -461,6 +647,15 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse({"error": str(exc)}, 401)
 
         base_url = str(request.base_url).rstrip("/")
+        record_event(
+            manager.bench_root,
+            None,
+            "run.claim",
+            request=request,
+            run_id=assignment.run_id,
+            task_id=assignment.task_id,
+            payload={"client": client_info or {}},
+        )
 
         return JSONResponse(
             {
@@ -497,6 +692,15 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse({"error": str(exc)}, 400)
 
         base_url = str(request.base_url).rstrip("/")
+        record_event(
+            manager.bench_root,
+            None,
+            "run.create",
+            request=request,
+            run_id=assignment.run_id,
+            task_id=assignment.task_id,
+            payload={"source": "client_start"},
+        )
 
         return JSONResponse(
             {
@@ -545,6 +749,11 @@ def ui_routes(manager) -> list[Route]:
     # -----------------------------------------------------------------------
 
     return [
+        # Auth
+        Route("/auth/login", auth_login, methods=["GET"]),
+        Route("/auth/callback", auth_callback, methods=["GET"]),
+        Route("/auth/logout", auth_logout, methods=["POST"]),
+        Route("/ui/me", ui_me, methods=["GET"]),
         # Existing: results + tasks
         Route("/ui/tasks", list_tasks, methods=["GET"]),
         Route("/ui/results", list_results, methods=["GET"]),

--- a/bench/server/web/ui_indexer.py
+++ b/bench/server/web/ui_indexer.py
@@ -87,6 +87,10 @@ class ResultIndexer:
         category: str | None = None,
         task_id: str | None = None,
         eval_status: str | None = None,
+        owner_user_id: str | None = None,
+        include_all: bool = False,
+        include_org: bool = False,
+        user: Any | None = None,
     ) -> list[dict[str, Any]]:
         normalized_category = self._normalize_filter(category)
         normalized_task_id = self._normalize_filter(task_id)
@@ -96,6 +100,15 @@ class ResultIndexer:
         for result_dir in self._iter_result_dirs():
             summary = self._build_summary(result_dir)
             if not summary:
+                continue
+            if not self._owner_fields_visible(
+                owner_user_id=str(summary.get("owner_user_id") or ""),
+                visibility=str(summary.get("visibility") or "private"),
+                user=user,
+                filter_owner_user_id=owner_user_id,
+                include_all=include_all,
+                include_org=include_org,
+            ):
                 continue
 
             if normalized_category and summary.get("category") != normalized_category:
@@ -119,7 +132,14 @@ class ResultIndexer:
         )
         return results
 
-    def get_detail(self, session_id: str) -> dict[str, Any] | None:
+    def get_detail(
+        self,
+        session_id: str,
+        *,
+        user: Any | None = None,
+        include_all: bool = False,
+        include_org: bool = False,
+    ) -> dict[str, Any] | None:
         result_dir = self._find_result_dir(session_id)
         if result_dir is None:
             return None
@@ -127,6 +147,10 @@ class ResultIndexer:
         run_state = self._load_json(result_dir / "run_state.json")
         if not isinstance(run_state, dict):
             return None
+        if not self._run_state_visible(
+            run_state, user=user, include_all=include_all, include_org=include_org
+        ):
+            raise PermissionError("Result access denied")
 
         task_id = str(run_state.get("task_id") or result_dir.parent.name)
         task_meta = self._task_meta_cache.get(
@@ -164,6 +188,10 @@ class ResultIndexer:
 
         detail = {
             "session_id": str(run_state.get("session_id") or session_id),
+            "run_id": str(run_state.get("run_id") or ""),
+            "owner_user_id": str(run_state.get("owner_user_id") or ""),
+            "owner_github_login": str(run_state.get("owner_github_login") or ""),
+            "visibility": str(run_state.get("visibility") or "private"),
             "task_id": task_id,
             "category": task_meta.get("category", "unknown"),
             "difficulty": task_meta.get("difficulty", "unknown"),
@@ -226,10 +254,23 @@ class ResultIndexer:
         }
         return detail
 
-    def resolve_agent_file(self, session_id: str, relative_path: str) -> Path | None:
+    def resolve_agent_file(
+        self,
+        session_id: str,
+        relative_path: str,
+        *,
+        user: Any | None = None,
+        include_all: bool = False,
+        include_org: bool = False,
+    ) -> Path | None:
         result_dir = self._find_result_dir(session_id)
         if result_dir is None:
             return None
+        run_state = self._load_json(result_dir / "run_state.json")
+        if isinstance(run_state, dict) and not self._run_state_visible(
+            run_state, user=user, include_all=include_all, include_org=include_org
+        ):
+            raise PermissionError("Result access denied")
 
         agent_files_root = (result_dir / "agent_files").resolve()
         full_path = (agent_files_root / relative_path).resolve()
@@ -243,12 +284,23 @@ class ResultIndexer:
             return None
         return full_path
 
-    def get_workspace_index(self, session_id: str) -> dict[str, Any] | None:
+    def get_workspace_index(
+        self,
+        session_id: str,
+        *,
+        user: Any | None = None,
+        include_all: bool = False,
+        include_org: bool = False,
+    ) -> dict[str, Any] | None:
         result_dir = self._find_result_dir(session_id)
         if result_dir is None:
             return None
 
         run_state = self._load_json(result_dir / "run_state.json")
+        if isinstance(run_state, dict) and not self._run_state_visible(
+            run_state, user=user, include_all=include_all, include_org=include_org
+        ):
+            raise PermissionError("Result access denied")
         workspace_files = self._extract_workspace_files(run_state, result_dir)
         entries = self._build_workspace_entries(session_id, result_dir, workspace_files)
 
@@ -260,9 +312,21 @@ class ResultIndexer:
         }
 
     def get_workspace_preview(
-        self, session_id: str, relative_path: str
+        self,
+        session_id: str,
+        relative_path: str,
+        *,
+        user: Any | None = None,
+        include_all: bool = False,
+        include_org: bool = False,
     ) -> dict[str, Any] | None:
-        resolved = self.resolve_agent_file(session_id, relative_path)
+        resolved = self.resolve_agent_file(
+            session_id,
+            relative_path,
+            user=user,
+            include_all=include_all,
+            include_org=include_org,
+        )
         if resolved is None:
             return None
 
@@ -426,6 +490,9 @@ class ResultIndexer:
         return {
             "run_id": str(run_state.get("run_id") or ""),
             "public_task_label": str(run_state.get("public_task_label") or ""),
+            "owner_user_id": str(run_state.get("owner_user_id") or ""),
+            "owner_github_login": str(run_state.get("owner_github_login") or ""),
+            "visibility": str(run_state.get("visibility") or "private"),
             "session_id": session_id,
             "task_id": task_id,
             "category": task_meta.get("category", "unknown"),
@@ -452,6 +519,49 @@ class ResultIndexer:
             "timestamp": timestamp_text,
             "_sort_ts": sort_ts,
         }
+
+    def _run_state_visible(
+        self,
+        run_state: dict[str, Any],
+        *,
+        user: Any | None,
+        include_all: bool,
+        include_org: bool,
+    ) -> bool:
+        return self._owner_fields_visible(
+            owner_user_id=str(run_state.get("owner_user_id") or ""),
+            visibility=str(run_state.get("visibility") or "private"),
+            user=user,
+            filter_owner_user_id=None,
+            include_all=include_all,
+            include_org=include_org,
+        )
+
+    def _owner_fields_visible(
+        self,
+        *,
+        owner_user_id: str,
+        visibility: str,
+        user: Any | None,
+        filter_owner_user_id: str | None,
+        include_all: bool,
+        include_org: bool,
+    ) -> bool:
+        if include_all:
+            return True
+        if filter_owner_user_id is not None:
+            owner = str(filter_owner_user_id or "")
+            if owner_user_id == owner:
+                return True
+            return bool(include_org and visibility == "org" and owner_user_id)
+        if user is None:
+            return True
+        if bool(getattr(user, "is_admin", False)):
+            return True
+        user_id = str(getattr(user, "user_id", "") or "")
+        if owner_user_id and owner_user_id == user_id:
+            return True
+        return bool(include_org and visibility == "org" and owner_user_id)
 
     def _load_client_trace(self, session_id: str) -> dict[str, Any] | None:
         """Best-effort load of client-side trace (thinking blocks, cost).

--- a/bench/tests/test_github_oauth_auth.py
+++ b/bench/tests/test_github_oauth_auth.py
@@ -1,0 +1,120 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from server.auth import AuthService, SESSION_COOKIE
+
+
+class GithubOAuthAuthTests(unittest.TestCase):
+    def test_callback_success_creates_session_cookie(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_AUTH_MODE": "github",
+                    "QTB_GITHUB_CLIENT_ID": "cid",
+                    "QTB_GITHUB_CLIENT_SECRET": "secret",
+                    "QTB_GITHUB_ALLOWED_ORGS": "varsity-tech-product",
+                    "QTB_ADMIN_GITHUB_LOGINS": "alice",
+                },
+                clear=False,
+            ):
+                auth = AuthService(root)
+                state = auth.store.create_state("/#/results")
+
+                async def callback(request):
+                    return await auth.callback(request)
+
+                app = Starlette(routes=[Route("/auth/callback", callback)])
+                with patch.object(auth, "_exchange_code", return_value="tok"), patch.object(
+                    auth,
+                    "_fetch_profile",
+                    return_value={
+                        "login": "alice",
+                        "email": "alice@example.com",
+                        "name": "Alice",
+                        "avatar_url": "https://example/avatar.png",
+                    },
+                ), patch.object(auth, "_is_allowed", return_value=True):
+                    client = TestClient(app)
+                    response = client.get(
+                        f"/auth/callback?code=abc&state={state}",
+                        follow_redirects=False,
+                    )
+
+                self.assertEqual(response.status_code, 302)
+                self.assertIn(SESSION_COOKIE, response.headers.get("set-cookie", ""))
+                cookie_value = response.cookies.get(SESSION_COOKIE)
+                user = auth.store.get_session(cookie_value)
+                self.assertIsNotNone(user)
+                self.assertEqual(user.github_login, "alice")
+                self.assertEqual(user.role, "admin")
+
+    def test_invalid_state_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict("os.environ", {"QTB_AUTH_MODE": "github"}, clear=False):
+                auth = AuthService(Path(tmp))
+
+                async def callback(request):
+                    return await auth.callback(request)
+
+                client = TestClient(Starlette(routes=[Route("/auth/callback", callback)]))
+                response = client.get("/auth/callback?code=abc&state=bad")
+                self.assertEqual(response.status_code, 400)
+
+    def test_org_allowlist_accepts_member(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {"QTB_GITHUB_ALLOWED_ORGS": "varsity-tech-product"},
+                clear=False,
+            ):
+                auth = AuthService(Path(tmp))
+                with patch.object(
+                    auth,
+                    "_github_get",
+                    return_value=[{"login": "varsity-tech-product"}],
+                ):
+                    self.assertTrue(auth._is_allowed({"login": "alice"}, "tok"))
+
+    def test_org_allowlist_rejects_outsider(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {"QTB_GITHUB_ALLOWED_ORGS": "varsity-tech-product"},
+                clear=False,
+            ):
+                auth = AuthService(Path(tmp))
+                with patch.object(auth, "_github_get", return_value=[{"login": "other"}]):
+                    self.assertFalse(auth._is_allowed({"login": "alice"}, "tok"))
+
+    def test_admin_role_can_match_email(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {"QTB_ADMIN_EMAILS": "alice@example.com"},
+                clear=False,
+            ):
+                auth = AuthService(Path(tmp))
+                user = auth._build_user(
+                    {
+                        "login": "alice",
+                        "email": "alice@example.com",
+                        "name": "Alice",
+                    }
+                )
+                self.assertEqual(user.role, "admin")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/tests/test_result_owner_filtering.py
+++ b/bench/tests/test_result_owner_filtering.py
@@ -1,0 +1,112 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from server.auth import UserContext
+from server.web.ui_indexer import ResultIndexer
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_result(root: Path, session_id: str, owner_user_id: str = "") -> None:
+    result_dir = root / "results" / "server" / "D01_demo" / session_id
+    _write_json(
+        result_dir / "run_state.json",
+        {
+            "session_id": session_id,
+            "task_id": "D01_demo",
+            "persona_id": "p",
+            "owner_user_id": owner_user_id,
+            "owner_github_login": owner_user_id.rsplit(":", 1)[-1] if owner_user_id else "",
+            "owner_email": "",
+            "visibility": "private",
+            "conversation": [],
+            "tool_logs": [],
+            "workspace_files": ["report.md"],
+        },
+    )
+    files_dir = result_dir / "agent_files"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    (files_dir / "report.md").write_text("report", encoding="utf-8")
+
+
+class ResultOwnerFilteringTests(unittest.TestCase):
+    def test_user_sees_own_result_and_admin_sees_legacy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_json(
+                root / "tasks" / "layer2" / "data" / "D01_demo.json",
+                {
+                    "task_id": "D01_demo",
+                    "category": "data",
+                    "difficulty": "easy",
+                    "description": "demo",
+                },
+            )
+            _write_result(root, "sess-a", "github:alice")
+            _write_result(root, "sess-b", "github:bob")
+            _write_result(root, "legacy")
+
+            indexer = ResultIndexer(root)
+            alice = UserContext("github:alice", "alice", "a@example.com", "Alice", "")
+            admin = UserContext(
+                "github:admin",
+                "admin",
+                "admin@example.com",
+                "Admin",
+                "",
+                role="admin",
+            )
+
+            alice_results = indexer.list_results(user=alice)
+            self.assertEqual([item["session_id"] for item in alice_results], ["sess-a"])
+            self.assertNotIn("owner_email", alice_results[0])
+
+            admin_results = indexer.list_results(user=admin)
+            self.assertEqual(
+                {item["session_id"] for item in admin_results},
+                {"sess-a", "sess-b", "legacy"},
+            )
+            self.assertTrue(all("owner_email" not in item for item in admin_results))
+
+    def test_user_cannot_read_other_user_result_or_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_json(
+                root / "tasks" / "layer2" / "data" / "D01_demo.json",
+                {"task_id": "D01_demo", "category": "data"},
+            )
+            _write_result(root, "sess-b", "github:bob")
+            indexer = ResultIndexer(root)
+            alice = UserContext("github:alice", "alice", "a@example.com", "Alice", "")
+
+            with self.assertRaises(PermissionError):
+                indexer.get_detail("sess-b", user=alice)
+            with self.assertRaises(PermissionError):
+                indexer.resolve_agent_file("sess-b", "report.md", user=alice)
+
+    def test_detail_payload_excludes_owner_email(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_json(
+                root / "tasks" / "layer2" / "data" / "D01_demo.json",
+                {"task_id": "D01_demo", "category": "data"},
+            )
+            _write_result(root, "sess-a", "github:alice")
+            indexer = ResultIndexer(root)
+            alice = UserContext("github:alice", "alice", "a@example.com", "Alice", "")
+
+            detail = indexer.get_detail("sess-a", user=alice)
+            self.assertNotIn("owner_email", detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/tests/test_run_owner_filtering.py
+++ b/bench/tests/test_run_owner_filtering.py
@@ -1,0 +1,129 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from server.auth import AuthService, SESSION_COOKIE, UserContext
+from server.run.catalog import TaskCatalog
+from server.run.service import RunService
+from server.run.store import RunStore
+from server.web.ui_app import ui_routes
+
+
+def _write_task(root: Path) -> None:
+    task_path = root / "tasks" / "layer2" / "data" / "D01_demo.json"
+    task_path.parent.mkdir(parents=True, exist_ok=True)
+    task_path.write_text(
+        json.dumps(
+            {
+                "task_id": "D01_demo",
+                "category": "data",
+                "difficulty": "easy",
+                "description": "demo",
+                "persona_ids": ["p"],
+                "max_turns": 4,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class _Manager:
+    def __init__(self, root: Path):
+        self.bench_root = root
+        self._run_service = RunService(TaskCatalog(root), RunStore(root / "runs"))
+        self._sessions = {}
+
+    def get_session(self, sid):
+        return self._sessions.get(sid)
+
+    async def cancel_run(self, run_id):
+        self._run_service.cancel_run(run_id)
+
+
+def _session_cookie(root: Path, user: UserContext) -> str:
+    return AuthService(root).store.create_session(user)
+
+
+class RunOwnerFilteringTests(unittest.TestCase):
+    def test_user_lists_only_owned_runs_and_admin_lists_all(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_task(root)
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_AUTH_MODE": "github",
+                    "QTB_MAX_ACTIVE_RUNS_PER_USER": "10",
+                },
+                clear=False,
+            ):
+                manager = _Manager(root)
+                client = TestClient(Starlette(routes=ui_routes(manager)))
+                alice = UserContext("github:alice", "alice", "a@example.com", "Alice", "")
+                bob = UserContext("github:bob", "bob", "b@example.com", "Bob", "")
+                admin = UserContext(
+                    "github:admin",
+                    "admin",
+                    "admin@example.com",
+                    "Admin",
+                    "",
+                    role="admin",
+                )
+
+                client.cookies.set(SESSION_COOKIE, _session_cookie(root, alice))
+                alice_run = client.post("/ui/runs", json={"task": "D01"}).json()
+
+                client.cookies.set(SESSION_COOKIE, _session_cookie(root, bob))
+                bob_run = client.post("/ui/runs", json={"task": "D01"}).json()
+
+                client.cookies.set(SESSION_COOKIE, _session_cookie(root, alice))
+                owned = client.get("/ui/runs").json()["runs"]
+                self.assertEqual([run["run_id"] for run in owned], [alice_run["run_id"]])
+                self.assertNotIn("owner_email", owned[0])
+
+                denied = client.get(f"/ui/runs/{bob_run['run_id']}")
+                self.assertEqual(denied.status_code, 403)
+
+                client.cookies.set(SESSION_COOKIE, _session_cookie(root, admin))
+                all_runs = client.get("/ui/runs?scope=all").json()["runs"]
+                self.assertEqual(
+                    {run["run_id"] for run in all_runs},
+                    {alice_run["run_id"], bob_run["run_id"]},
+                )
+                self.assertTrue(all("owner_email" not in run for run in all_runs))
+
+    def test_control_token_still_authorizes_owner_monitor_endpoint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_task(root)
+            with patch.dict(
+                "os.environ",
+                {"QTB_AUTH_MODE": "github", "QTB_MAX_ACTIVE_RUNS_PER_USER": "10"},
+                clear=False,
+            ):
+                manager = _Manager(root)
+                client = TestClient(Starlette(routes=ui_routes(manager)))
+                alice = UserContext("github:alice", "alice", "a@example.com", "Alice", "")
+                client.cookies.set(SESSION_COOKIE, _session_cookie(root, alice))
+                body = client.post("/ui/runs", json={"task": "D01"}).json()
+                client.cookies.clear()
+
+                response = client.get(
+                    f"/ui/runs/{body['run_id']}",
+                    headers={"Authorization": f"Bearer {body['control_token']}"},
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json()["run_id"], body["run_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/tests/test_user_quota.py
+++ b/bench/tests/test_user_quota.py
@@ -1,0 +1,204 @@
+import json
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from mcp.types import TextContent
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from server.quota import QuotaExceeded, QuotaManager
+from server.api.http_app import BenchSessionManager
+from server.run.catalog import TaskCatalog
+from server.run.service import RunService
+from server.run.store import RunStore
+
+
+def _write_task(root: Path) -> None:
+    path = root / "tasks" / "layer2" / "data" / "D01_demo.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "task_id": "D01_demo",
+                "category": "data",
+                "difficulty": "easy",
+                "description": "demo",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class UserQuotaTests(unittest.TestCase):
+    def test_active_run_limit_is_per_user(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_task(root)
+            service = RunService(TaskCatalog(root), RunStore(root / "runs"))
+            with patch.dict(
+                "os.environ",
+                {"QTB_MAX_ACTIVE_RUNS_PER_USER": "1"},
+                clear=False,
+            ):
+                service.create_run("D01", owner_user_id="github:alice")
+                with self.assertRaises(QuotaExceeded):
+                    service.create_run("D01", owner_user_id="github:alice")
+                service.create_run("D01", owner_user_id="github:bob")
+
+    def test_heavy_job_running_limit_releases_on_finish(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = QuotaManager(Path(tmp))
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_MAX_RUNNING_JOBS_PER_USER": "1",
+                    "QTB_DAILY_BACKTEST_LIMIT_PER_USER": "10",
+                },
+                clear=False,
+            ):
+                reservation = manager.reserve_heavy_job(
+                    owner_user_id="github:alice",
+                    run_id="run-a",
+                    session_id="sess-a",
+                    tool_name="run_backtest",
+                )
+                with self.assertRaises(QuotaExceeded):
+                    manager.reserve_heavy_job(
+                        owner_user_id="github:alice",
+                        run_id="run-a",
+                        session_id="sess-a",
+                        tool_name="run_backtest",
+                    )
+                manager.release_heavy_job(
+                    owner_user_id="github:alice", reservation_id=reservation
+                )
+                manager.reserve_heavy_job(
+                    owner_user_id="github:alice",
+                    run_id="run-a",
+                    session_id="sess-a",
+                    tool_name="run_backtest",
+                )
+
+    def test_daily_backtest_limit_counts_accepted_jobs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = QuotaManager(Path(tmp))
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_MAX_RUNNING_JOBS_PER_USER": "2",
+                    "QTB_DAILY_BACKTEST_LIMIT_PER_USER": "1",
+                },
+                clear=False,
+            ):
+                reservation = manager.reserve_heavy_job(
+                    owner_user_id="github:alice",
+                    run_id="run-a",
+                    session_id="sess-a",
+                    tool_name="run_backtest",
+                )
+                manager.release_heavy_job(
+                    owner_user_id="github:alice", reservation_id=reservation
+                )
+                with self.assertRaises(QuotaExceeded):
+                    manager.reserve_heavy_job(
+                        owner_user_id="github:alice",
+                        run_id="run-a",
+                        session_id="sess-a",
+                        tool_name="run_backtest",
+                    )
+
+    def test_mcp_heavy_tool_uses_user_quota(self):
+        class _State:
+            session_id = "sess-a"
+            run_id = "run-a"
+            task_id = "D01_demo"
+            owner_user_id = "github:alice"
+            owner_github_login = "alice"
+            owner_email = "alice@example.com"
+            phase = type("Phase", (), {"value": "in_session"})()
+            calls = 0
+
+            async def handle_tool_call(self, name, arguments):
+                self.calls += 1
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps({"success": True, "tool": name}),
+                    )
+                ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_task(root)
+            manager = BenchSessionManager(use_docker=False, bench_root=root)
+            state = _State()
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_MAX_RUNNING_JOBS_PER_USER": "1",
+                    "QTB_DAILY_BACKTEST_LIMIT_PER_USER": "10",
+                },
+                clear=False,
+            ):
+                manager._quota_manager.reserve_heavy_job(
+                    owner_user_id="github:alice",
+                    run_id="run-existing",
+                    session_id="sess-existing",
+                    tool_name="run_backtest",
+                    job_id="existing",
+                )
+                response = asyncio.run(
+                    manager._handle_mcp_tool_call(state, "run_backtest", {})
+                )
+
+            self.assertEqual(state.calls, 0)
+            payload = json.loads(response[0].text)
+            self.assertFalse(payload["success"])
+
+    def test_mcp_heavy_tool_releases_quota_after_call(self):
+        class _State:
+            session_id = "sess-a"
+            run_id = "run-a"
+            task_id = "D01_demo"
+            owner_user_id = "github:alice"
+            owner_github_login = "alice"
+            owner_email = "alice@example.com"
+            phase = type("Phase", (), {"value": "in_session"})()
+
+            async def handle_tool_call(self, name, arguments):
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps({"success": True, "tool": name}),
+                    )
+                ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_task(root)
+            manager = BenchSessionManager(use_docker=False, bench_root=root)
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_MAX_RUNNING_JOBS_PER_USER": "1",
+                    "QTB_DAILY_BACKTEST_LIMIT_PER_USER": "2",
+                },
+                clear=False,
+            ):
+                asyncio.run(manager._handle_mcp_tool_call(_State(), "run_backtest", {}))
+                reservation = manager._quota_manager.reserve_heavy_job(
+                    owner_user_id="github:alice",
+                    run_id="run-b",
+                    session_id="sess-b",
+                    tool_name="run_backtest",
+                )
+                self.assertTrue(reservation)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add GitHub OAuth login/session handling for internal UI users
- Scope runs, flow, results, files, and workspace previews by owner/admin
- Preserve agent run-token flows while adding owner metadata to sessions/results
- Add audit JSONL logging and per-user active run/heavy-job quotas
- Enforce heavy-tool quotas for both REST and MCP calls
- Keep private GitHub emails out of public run/result payloads

## Verification
- pytest bench/tests/test_github_oauth_auth.py bench/tests/test_run_owner_filtering.py bench/tests/test_result_owner_filtering.py bench/tests/test_user_quota.py bench/tests/test_run_control_token.py bench/tests/test_server_web_ui.py bench/tests/api/test_session_lifecycle.py bench/tests/api/test_session_completion_api.py bench/tests/test_bundle_schema.py bench/tests/test_run_state_transitions.py bench/tests/test_tool_jobs.py bench/tests/test_health.py
- node --check bench/server/web/static/js/app.js
- node --check bench/server/web/static/js/run-agent.js
- node --check bench/server/web/static/js/flow-demo.js

Fixes #69