### PR TITLE
chore: promote auth Vercel hotfix to master

### DIFF
--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -140,7 +140,11 @@
     if (!target) return;
     var user = state.auth.user;
     if (!user) {
-      target.innerHTML = '<a class="btn btn-secondary btn-small" href="' + loginUrl() + '">Log in</a>';
+      if (state.auth.authMode === 'github') {
+        target.innerHTML = '<a class="btn btn-secondary btn-small" href="' + loginUrl() + '">Log in</a>';
+      } else {
+        target.innerHTML = '<span class="badge">Auth disabled</span>';
+      }
       return;
     }
     var avatar = user.avatar_url
@@ -151,7 +155,7 @@
         avatar +
         '<span class="nav-user-name">' + escapeHtml(user.github_login || user.display_name || 'User') + '</span>' +
         (user.role === 'admin' ? '<span class="badge">Admin</span>' : '') +
-        '<button class="btn btn-secondary btn-small" id="auth-logout-btn" type="button">Logout</button>' +
+        (state.auth.authMode === 'github' ? '<button class="btn btn-secondary btn-small" id="auth-logout-btn" type="button">Logout</button>' : '<span class="badge">Auth disabled</span>') +
       '</div>';
     var logout = document.getElementById('auth-logout-btn');
     if (logout) {

--- a/vercel-frontend/vercel.json
+++ b/vercel-frontend/vercel.json
@@ -5,6 +5,7 @@
   "rewrites": [
     { "source": "/", "destination": "https://217-15-165-83.sslip.io/" },
     { "source": "/health", "destination": "https://217-15-165-83.sslip.io/health" },
+    { "source": "/auth/:path*", "destination": "https://217-15-165-83.sslip.io/auth/:path*" },
     { "source": "/session/:path*", "destination": "https://217-15-165-83.sslip.io/session/:path*" },
     { "source": "/client/:path*", "destination": "https://217-15-165-83.sslip.io/client/:path*" },
     { "source": "/ui/:path*", "destination": "https://217-15-165-83.sslip.io/ui/:path*" },


### PR DESCRIPTION
## Summary
Promote the auth routing hotfix from dev to master.

Included via #72:
- Forward /auth/* through Vercel to backend
- Hide logout when QTB_AUTH_MODE=disabled

## Verification
- node --check bench/server/web/static/js/app.js
- vercel-frontend/vercel.json parses as JSON