### PR TITLE
feat(ui): export result run state

### DIFF
--- a/bench/server/web/static/css/styles.css
+++ b/bench/server/web/static/css/styles.css
@@ -1212,6 +1212,7 @@ h1 {
   color: var(--text);
   font-size: 13px;
   font-weight: 700;
+  text-decoration: none;
   cursor: pointer;
   transition: all var(--duration-fast) var(--ease);
 }

--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -1454,6 +1454,12 @@
 
   function buildDetailActions(detail) {
     var buttons = [];
+    var exportUrl = '/ui/results/' + encodeURIComponent(detail.session_id) + '/export';
+    buttons.push(
+      '<a class="detail-report-btn" href="' + escapeHtml(exportUrl) + '" download="' +
+      escapeHtml((detail.session_id || 'session') + '_run_state.json') +
+      '">Export JSON</a>'
+    );
     // Server / Client / Eval History
     buttons.push('<button class="detail-report-btn" id="detail-server-btn">Server</button>');
     buttons.push(

--- a/bench/server/web/ui_app.py
+++ b/bench/server/web/ui_app.py
@@ -227,6 +227,42 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse({"error": "Session not found"}, status_code=404)
         return JSONResponse(_sanitize_for_json(payload))
 
+    async def export_run_state(request: Request) -> JSONResponse | FileResponse:
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
+        include_all, include_org = _scope_flags(request, user)
+        session_id = request.path_params["session_id"]
+        try:
+            full_path = indexer.resolve_run_state_file(
+                session_id,
+                user=user,
+                include_all=include_all,
+                include_org=include_org,
+            )
+        except PermissionError:
+            return JSONResponse({"error": "Result access denied"}, status_code=403)
+
+        if full_path is None:
+            return JSONResponse({"error": "Session not found"}, status_code=404)
+
+        safe_session_id = "".join(
+            ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in session_id
+        )
+        record_event(
+            manager.bench_root,
+            user,
+            "result.export",
+            request=request,
+            session_id=session_id,
+            payload={"file": "run_state.json"},
+        )
+        return FileResponse(
+            str(full_path),
+            media_type="application/json",
+            filename=f"{safe_session_id}_run_state.json",
+        )
+
     async def get_workspace_preview(request: Request) -> JSONResponse:
         user, err = auth.require_user(request)
         if err is not None:
@@ -758,6 +794,7 @@ def ui_routes(manager) -> list[Route]:
         Route("/ui/tasks", list_tasks, methods=["GET"]),
         Route("/ui/results", list_results, methods=["GET"]),
         Route("/ui/results/{session_id}", get_detail, methods=["GET"]),
+        Route("/ui/results/{session_id}/export", export_run_state, methods=["GET"]),
         Route("/ui/results/{session_id}/workspace", get_workspace, methods=["GET"]),
         Route(
             "/ui/results/{session_id}/workspace/preview/{path:path}",

--- a/bench/server/web/ui_indexer.py
+++ b/bench/server/web/ui_indexer.py
@@ -284,6 +284,30 @@ class ResultIndexer:
             return None
         return full_path
 
+    def resolve_run_state_file(
+        self,
+        session_id: str,
+        *,
+        user: Any | None = None,
+        include_all: bool = False,
+        include_org: bool = False,
+    ) -> Path | None:
+        result_dir = self._find_result_dir(session_id)
+        if result_dir is None:
+            return None
+
+        run_state_path = result_dir / "run_state.json"
+        run_state = self._load_json(run_state_path)
+        if not isinstance(run_state, dict):
+            return None
+        if not self._run_state_visible(
+            run_state, user=user, include_all=include_all, include_org=include_org
+        ):
+            raise PermissionError("Result access denied")
+        if not run_state_path.exists() or not run_state_path.is_file():
+            return None
+        return run_state_path
+
     def get_workspace_index(
         self,
         session_id: str,

--- a/bench/tests/test_result_owner_filtering.py
+++ b/bench/tests/test_result_owner_filtering.py
@@ -92,6 +92,23 @@ class ResultOwnerFilteringTests(unittest.TestCase):
                 indexer.get_detail("sess-b", user=alice)
             with self.assertRaises(PermissionError):
                 indexer.resolve_agent_file("sess-b", "report.md", user=alice)
+            with self.assertRaises(PermissionError):
+                indexer.resolve_run_state_file("sess-b", user=alice)
+
+    def test_user_can_export_own_run_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_json(
+                root / "tasks" / "layer2" / "data" / "D01_demo.json",
+                {"task_id": "D01_demo", "category": "data"},
+            )
+            _write_result(root, "sess-a", "github:alice")
+            indexer = ResultIndexer(root)
+            alice = UserContext("github:alice", "alice", "a@example.com", "Alice", "")
+
+            path = indexer.resolve_run_state_file("sess-a", user=alice)
+            self.assertIsNotNone(path)
+            self.assertEqual(path.name, "run_state.json")
 
     def test_detail_payload_excludes_owner_email(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/bench/tests/test_server_web_ui.py
+++ b/bench/tests/test_server_web_ui.py
@@ -428,6 +428,7 @@ class UiRoutesTests(unittest.TestCase):
             tasks_response = client.get("/ui/tasks")
             results_response = client.get("/ui/results")
             detail_response = client.get(f"/ui/results/{session_id}")
+            export_response = client.get(f"/ui/results/{session_id}/export")
             workspace_response = client.get(f"/ui/results/{session_id}/workspace")
             workspace_preview_response = client.get(
                 f"/ui/results/{session_id}/workspace/preview/artifacts/report.md"
@@ -451,12 +452,18 @@ class UiRoutesTests(unittest.TestCase):
             self.assertEqual(tasks_response.status_code, 200)
             self.assertEqual(results_response.status_code, 200)
             self.assertEqual(detail_response.status_code, 200)
+            self.assertEqual(export_response.status_code, 200)
             self.assertEqual(workspace_response.status_code, 200)
             self.assertEqual(workspace_preview_response.status_code, 200)
             self.assertEqual(csv_preview_response.status_code, 200)
             self.assertEqual(image_preview_response.status_code, 200)
             self.assertEqual(file_response.status_code, 200)
             self.assertEqual(file_response.text, "report")
+            self.assertEqual(export_response.json()["session_id"], session_id)
+            self.assertIn(
+                "session-003_run_state.json",
+                export_response.headers.get("content-disposition", ""),
+            )
             self.assertEqual(bad_path_response.status_code, 400)
             self.assertEqual(bad_preview_response.status_code, 400)
 


### PR DESCRIPTION
## Summary
- Add an owner/admin-protected `/ui/results/{session_id}/export` endpoint that downloads `run_state.json`
- Add an Export JSON action to the result detail page
- Record `result.export` audit events
- Cover export success and owner filtering in tests

## Verification
- pytest bench/tests/test_server_web_ui.py bench/tests/test_result_owner_filtering.py bench/tests/test_github_oauth_auth.py
- node --check bench/server/web/static/js/app.js