### PR TITLE
Add REST run API key ownership

### DIFF
--- a/bench/client/__main__.py
+++ b/bench/client/__main__.py
@@ -90,6 +90,7 @@ def _cmd_run(args):
                 adapter_factory=adapter_factory,
                 result_dir=result_dir,
                 protocol=args.protocol,
+                api_key=args.api_key,
             )
         )
         results = [result]
@@ -102,6 +103,7 @@ def _cmd_run(args):
                 workers=args.workers,
                 result_dir=result_dir,
                 protocol=args.protocol,
+                api_key=args.api_key,
             )
         )
 
@@ -190,6 +192,11 @@ def _add_common_args(parser: argparse.ArgumentParser):
         help="Override system prompt",
     )
     parser.add_argument(
+        "--api-key",
+        default="",
+        help="REST API key for creating runs (or QTB_CLIENT_API_KEY env var)",
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -235,6 +242,10 @@ def main():
     )
 
     args = parser.parse_args()
+    if not getattr(args, "api_key", ""):
+        import os
+
+        args.api_key = os.environ.get("QTB_CLIENT_API_KEY", "")
 
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper(), logging.INFO),

--- a/bench/client/runner.py
+++ b/bench/client/runner.py
@@ -186,12 +186,14 @@ async def run_task(
     adapter_factory: Callable,
     result_dir: Optional[Path] = None,
     protocol: str = "mcp",
+    api_key: str = "",
 ) -> dict:
     """Create a run + claim + execute. One-step convenience entry point.
 
     Calls POST /client/runs/start to get a token, then run_via_attach.
     """
     base = server_base_url.rstrip("/")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     async with httpx.AsyncClient(base_url=base, timeout=30.0) as http:
         resp = await http.post(
             "/client/runs/start",
@@ -199,6 +201,7 @@ async def run_task(
                 "task": task,
                 "client": {"name": "baseline_client", "version": "0.1.0"},
             },
+            headers=headers,
         )
         if resp.status_code != 200:
             return {"task_id": task, "error": f"Create run failed: {resp.text}"}
@@ -222,6 +225,7 @@ async def run_multiple_tasks(
     workers: int = 1,
     result_dir: Optional[Path] = None,
     protocol: str = "mcp",
+    api_key: str = "",
 ) -> list[dict]:
     """Run multiple tasks with bounded concurrency."""
     semaphore = asyncio.Semaphore(workers)
@@ -234,6 +238,7 @@ async def run_multiple_tasks(
                 adapter_factory,
                 result_dir,
                 protocol,
+                api_key,
             )
 
     coros = [_run_with_sem(t) for t in tasks]

--- a/bench/scripts/prod_smoke.py
+++ b/bench/scripts/prod_smoke.py
@@ -130,7 +130,7 @@ async def hit(
 
 
 async def wait_for_job_terminal(
-    client: httpx.AsyncClient, sid: str, job_id: str
+    client: httpx.AsyncClient, sid: str, job_id: str, headers: dict | None = None
 ) -> None:
     """Poll the job until it reaches a terminal state or deadline expires.
 
@@ -140,7 +140,10 @@ async def wait_for_job_terminal(
     deadline = time.time() + JOB_TERMINAL_DEADLINE_S
     while time.time() < deadline:
         try:
-            resp = await client.get(f"/session/{sid}/tool/jobs/{job_id}")
+            resp = await client.get(
+                f"/session/{sid}/tool/jobs/{job_id}",
+                headers=headers or {},
+            )
         except (httpx.TimeoutException, httpx.TransportError):
             return
         if resp.status_code != 200:
@@ -150,7 +153,12 @@ async def wait_for_job_terminal(
         await asyncio.sleep(1.0)
 
 
-async def run_smoke(base_url: str, task_label: str, jsonl: Optional[str]) -> int:
+async def run_smoke(
+    base_url: str,
+    task_label: str,
+    jsonl: Optional[str],
+    api_key: str = "",
+) -> int:
     result = SmokeResult(jsonl_path=jsonl)
 
     async with httpx.AsyncClient(
@@ -182,6 +190,7 @@ async def run_smoke(base_url: str, task_label: str, jsonl: Optional[str]) -> int
         resp = await hit(
             client, result, "T2", "POST", "/client/runs/start",
             json={"task": task_label},
+            headers={"Authorization": f"Bearer {api_key}"} if api_key else {},
             expect="2xx",
         )
         if resp is None or resp.status_code != 200:
@@ -214,12 +223,16 @@ async def run_smoke(base_url: str, task_label: str, jsonl: Optional[str]) -> int
             print("Cannot continue: /session/register did not succeed.")
             return _finalise(result)
         sid = resp.json()["session_id"]
+        session_auth = {"Authorization": f"Bearer {token}"}
 
         try:
             await hit(client, result, "T3", "GET", "/session/list")
-            await hit(client, result, "T3", "GET", f"/session/{sid}")
-            await hit(client, result, "T3", "POST", f"/session/{sid}/start", json={})
-            await hit(client, result, "T3", "GET", f"/session/{sid}/tools")
+            await hit(client, result, "T3", "GET", f"/session/{sid}", headers=session_auth)
+            await hit(
+                client, result, "T3", "POST", f"/session/{sid}/start",
+                json={}, headers=session_auth,
+            )
+            await hit(client, result, "T3", "GET", f"/session/{sid}/tools", headers=session_auth)
 
             # ------------------------------------------------------------------
             # T4 — Sync domain tool (fast)
@@ -228,6 +241,7 @@ async def run_smoke(base_url: str, task_label: str, jsonl: Optional[str]) -> int
                 client, result, "T4", "POST",
                 f"/session/{sid}/tool/shell_exec",
                 json={"command": "echo availability"},
+                headers=session_auth,
             )
 
             # ------------------------------------------------------------------
@@ -237,6 +251,7 @@ async def run_smoke(base_url: str, task_label: str, jsonl: Optional[str]) -> int
                 client, result, "T5", "POST",
                 f"/session/{sid}/tool/run_lean_backtest",
                 json={"algorithm_path": "/nonexistent-smoke.cs"},
+                headers=session_auth,
                 expect="202",
             )
             job_id: Optional[str] = None
@@ -256,10 +271,11 @@ async def run_smoke(base_url: str, task_label: str, jsonl: Optional[str]) -> int
                 await hit(
                     client, result, "T5", "GET",
                     f"/session/{sid}/tool/jobs/{job_id}",
+                    headers=session_auth,
                 )
                 # Let the background worker reach a terminal state so the
                 # session lock frees up before we try to DELETE.
-                await wait_for_job_terminal(client, sid, job_id)
+                await wait_for_job_terminal(client, sid, job_id, headers=session_auth)
 
             # ------------------------------------------------------------------
             # T6 — Results + scores (reachable without a completed eval).
@@ -301,7 +317,7 @@ async def run_smoke(base_url: str, task_label: str, jsonl: Optional[str]) -> int
                     f"/ui/runs/{run_id}/cancel",
                     headers=control_auth,
                 )
-            await hit(client, result, "T3", "DELETE", f"/session/{sid}")
+            await hit(client, result, "T3", "DELETE", f"/session/{sid}", headers=session_auth)
 
     return _finalise(result)
 
@@ -320,8 +336,13 @@ def main() -> int:
     p.add_argument("--base-url", default=DEFAULT_BASE, help=f"default: {DEFAULT_BASE}")
     p.add_argument("--task", default=DEFAULT_TASK, help=f"public task label (default: {DEFAULT_TASK})")
     p.add_argument("--jsonl", default=None, help="append-only JSONL log path")
+    p.add_argument(
+        "--api-key",
+        default=os.environ.get("QTB_CLIENT_API_KEY", ""),
+        help="REST API key from the logged-in UI account (default: QTB_CLIENT_API_KEY)",
+    )
     args = p.parse_args()
-    return asyncio.run(run_smoke(args.base_url, args.task, args.jsonl))
+    return asyncio.run(run_smoke(args.base_url, args.task, args.jsonl, args.api_key))
 
 
 if __name__ == "__main__":

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -97,6 +97,69 @@ def _mcp_tool_success(contents: list[TextContent]) -> bool:
     return True
 
 
+def _bool_env(name: str, default: bool) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _rest_session_token_required() -> bool:
+    if os.environ.get("QTB_REQUIRE_SESSION_TOKEN", "").strip():
+        return _bool_env("QTB_REQUIRE_SESSION_TOKEN", False)
+    return (
+        os.environ.get("QTB_AUTH_MODE", "disabled").strip().lower() == "github"
+        or _bool_env("QTB_REQUIRE_CLIENT_AUTH", False)
+        or bool(os.environ.get("QTB_CLIENT_API_KEYS", "").strip())
+    )
+
+
+def _authorize_rest_session_request(
+    request: Request, manager: "BenchSessionManager", state: SessionState
+) -> JSONResponse | None:
+    """Require the run token that owns this REST session when auth is enabled."""
+    if not _rest_session_token_required() or not state.run_id:
+        return None
+
+    raw = extract_bearer_token(request)
+    if not raw:
+        return JSONResponse(
+            {"error": "Authorization: Bearer <token> required"},
+            status_code=401,
+        )
+    run = manager._run_service.resolve_token(raw, allow_expired_bound=True)
+    if run is None:
+        return JSONResponse({"error": "Invalid or expired token"}, status_code=401)
+    if run.run_id != state.run_id:
+        return JSONResponse({"error": "Run token does not own this session"}, 403)
+    return None
+
+
+def _authorize_rest_job_request(
+    request: Request, manager: "BenchSessionManager", sid: str
+) -> JSONResponse | None:
+    """Authorize polling a job by matching bearer run token to session id."""
+    if not _rest_session_token_required():
+        return None
+
+    raw = extract_bearer_token(request)
+    if not raw:
+        return JSONResponse(
+            {"error": "Authorization: Bearer <token> required"},
+            status_code=401,
+        )
+    run = manager._run_service.resolve_token(raw, allow_expired_bound=True)
+    if run is None:
+        return JSONResponse({"error": "Invalid or expired token"}, status_code=401)
+    if run.session_id != sid:
+        return JSONResponse({"error": "Run token does not own this session"}, 403)
+    return None
+
+
 class NoCacheStaticFiles(StaticFiles):
     """StaticFiles variant that forces browser revalidation for UI assets."""
 
@@ -1043,6 +1106,10 @@ async def rest_start(request: Request) -> JSONResponse:
     if not state:
         return JSONResponse({"error": "Session not found"}, 404)
 
+    auth_err = _authorize_rest_session_request(request, manager, state)
+    if auth_err is not None:
+        return auth_err
+
     allowed, error, ops = check_permission(state.phase, "start_session")
     if not allowed:
         logger.debug("[REST:%s] DENIED start in phase %s", sid[:8], state.phase.value)
@@ -1074,6 +1141,10 @@ async def rest_tools(request: Request) -> JSONResponse:
     if not state:
         return JSONResponse({"error": "Session not found"}, 404)
 
+    auth_err = _authorize_rest_session_request(request, manager, state)
+    if auth_err is not None:
+        return auth_err
+
     tools = state.get_visible_tools()
     return JSONResponse(
         {
@@ -1096,6 +1167,10 @@ async def rest_tool_call(request: Request) -> JSONResponse:
     state = manager.get_session(sid)
     if not state:
         return JSONResponse({"error": "Session not found"}, 404)
+
+    auth_err = _authorize_rest_session_request(request, manager, state)
+    if auth_err is not None:
+        return auth_err
 
     name = request.path_params["name"]
 
@@ -1324,6 +1399,9 @@ async def rest_tool_job_status(request: Request) -> JSONResponse:
     job = manager._job_store.get(job_id)
     if job is None or job.get("session_id") != sid:
         return JSONResponse({"error": "Job not found"}, 404)
+    auth_err = _authorize_rest_job_request(request, manager, sid)
+    if auth_err is not None:
+        return auth_err
     # Trim the echoed arguments — they can be large (full source files).
     return JSONResponse(
         {
@@ -1346,6 +1424,10 @@ async def rest_send(request: Request) -> JSONResponse:
     state = manager.get_session(sid)
     if not state:
         return JSONResponse({"error": "Session not found"}, 404)
+
+    auth_err = _authorize_rest_session_request(request, manager, state)
+    if auth_err is not None:
+        return auth_err
 
     allowed, error, ops = check_permission(state.phase, "send_message")
     if not allowed:
@@ -1543,6 +1625,9 @@ async def rest_session_status(request: Request) -> JSONResponse | Response:
     if request.method == "DELETE":
         if not state:
             return JSONResponse({"error": "Session not found"}, 404)
+        auth_err = _authorize_rest_session_request(request, manager, state)
+        if auth_err is not None:
+            return auth_err
         logger.info("[REST:%s] DELETE — cancelling session", sid[:8])
         # persist_partial=True so an active session's conversation + tool
         # logs land as a bundle under results/server/... before the
@@ -1556,6 +1641,9 @@ async def rest_session_status(request: Request) -> JSONResponse | Response:
         state = manager.get_or_restore_session(sid)
     if not state:
         return JSONResponse({"error": "Session not found"}, 404)
+    auth_err = _authorize_rest_session_request(request, manager, state)
+    if auth_err is not None:
+        return auth_err
     return JSONResponse(
         {
             "session_id": sid,
@@ -1570,7 +1658,23 @@ async def rest_list(request: Request) -> JSONResponse:
     """``GET /session/list[?task_id=X01]``"""
     manager: BenchSessionManager = request.app.state.manager
     task_id = request.query_params.get("task_id", "")
-    return JSONResponse({"sessions": manager.list_sessions(task_id)})
+    sessions = manager.list_sessions(task_id)
+    if _rest_session_token_required():
+        raw = extract_bearer_token(request)
+        if not raw:
+            return JSONResponse(
+                {"error": "Authorization: Bearer <token> required"},
+                status_code=401,
+            )
+        run = manager._run_service.resolve_token(raw, allow_expired_bound=True)
+        if run is None:
+            return JSONResponse({"error": "Invalid or expired token"}, status_code=401)
+        sessions = [
+            session
+            for session in sessions
+            if session.get("session_id") == run.session_id
+        ]
+    return JSONResponse({"sessions": sessions})
 
 
 # ---------------------------------------------------------------------------

--- a/bench/server/auth.py
+++ b/bench/server/auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hmac
+import hashlib
 import json
 import os
 import secrets
@@ -63,6 +64,7 @@ class AuthStore:
         self._dir.mkdir(parents=True, exist_ok=True)
         self._sessions_path = self._dir / "sessions.json"
         self._states_path = self._dir / "oauth_states.json"
+        self._api_keys_path = self._dir / "api_keys.json"
         self._lock = threading.Lock()
 
     def create_session(self, user: UserContext) -> str:
@@ -104,6 +106,77 @@ class AuthStore:
             if session_id in sessions:
                 sessions.pop(session_id, None)
                 self._write_locked(self._sessions_path, sessions)
+
+    def rotate_api_key(self, user: UserContext) -> tuple[str, dict]:
+        """Create a new user API key and revoke prior active keys for the user."""
+        raw_key = f"qtbu_{secrets.token_urlsafe(32)}"
+        key_hash = _hash_secret(raw_key)
+        now = time.time()
+        with self._lock:
+            keys = self._read_locked(self._api_keys_path)
+            for record in keys.values():
+                if (
+                    isinstance(record, dict)
+                    and (record.get("user") or {}).get("user_id") == user.user_id
+                    and not record.get("revoked_at")
+                ):
+                    record["revoked_at"] = now
+            record = {
+                "key_hint": raw_key[:14],
+                "user": user.to_dict(),
+                "created_at": now,
+                "revoked_at": None,
+            }
+            keys[key_hash] = record
+            self._write_locked(self._api_keys_path, keys)
+        return raw_key, _api_key_public_record(record)
+
+    def get_api_key_status(self, user: UserContext) -> dict:
+        with self._lock:
+            keys = self._read_locked(self._api_keys_path)
+            active = [
+                record
+                for record in keys.values()
+                if isinstance(record, dict)
+                and (record.get("user") or {}).get("user_id") == user.user_id
+                and not record.get("revoked_at")
+            ]
+        if not active:
+            return {"has_key": False}
+        active.sort(key=lambda item: float(item.get("created_at") or 0), reverse=True)
+        payload = _api_key_public_record(active[0])
+        payload["has_key"] = True
+        return payload
+
+    def revoke_api_key(self, user: UserContext) -> dict:
+        revoked = False
+        now = time.time()
+        with self._lock:
+            keys = self._read_locked(self._api_keys_path)
+            for record in keys.values():
+                if (
+                    isinstance(record, dict)
+                    and (record.get("user") or {}).get("user_id") == user.user_id
+                    and not record.get("revoked_at")
+                ):
+                    record["revoked_at"] = now
+                    revoked = True
+            self._write_locked(self._api_keys_path, keys)
+        return {"revoked": revoked, "has_key": False}
+
+    def get_api_key_user(self, raw_key: str) -> UserContext | None:
+        if not raw_key:
+            return None
+        key_hash = _hash_secret(raw_key)
+        with self._lock:
+            keys = self._read_locked(self._api_keys_path)
+            record = keys.get(key_hash)
+        if not isinstance(record, dict) or record.get("revoked_at"):
+            return None
+        user = record.get("user")
+        if not isinstance(user, dict):
+            return None
+        return UserContext.from_dict(user)
 
     def create_state(self, next_url: str = "/") -> str:
         state = secrets.token_urlsafe(32)
@@ -190,6 +263,40 @@ class AuthService:
         if user and user.is_admin:
             return user, None
         return None, JSONResponse({"error": "Admin access required"}, status_code=403)
+
+    def resolve_client_user(
+        self, request: Request
+    ) -> tuple[UserContext | None, JSONResponse | None]:
+        """Resolve the owner for REST-created client runs.
+
+        Browser-created runs use the GitHub cookie via ``/ui/runs``. External
+        REST clients use API keys declared in ``QTB_CLIENT_API_KEYS``. Local
+        development remains anonymous when auth and API keys are disabled.
+        """
+        cookie_user = self.get_current_user(request)
+        if cookie_user is not None and cookie_user.user_id != "local-dev":
+            return cookie_user, None
+
+        api_keys = _client_api_keys()
+        raw = _extract_bearer(request)
+        stored_user = self.store.get_api_key_user(raw)
+        if stored_user is not None:
+            return stored_user, None
+        if raw and raw in api_keys:
+            return api_keys[raw], None
+
+        auth_required = self.enabled or bool(api_keys) or _bool_env(
+            "QTB_REQUIRE_CLIENT_AUTH", False
+        )
+        if not auth_required:
+            return None, None
+
+        if not raw:
+            return None, JSONResponse(
+                {"error": "Authorization: Bearer <client_api_key> required"},
+                status_code=401,
+            )
+        return None, JSONResponse({"error": "Invalid client API key"}, status_code=401)
 
     def me_payload(self, request: Request) -> dict:
         user = self.get_current_user(request)
@@ -417,6 +524,72 @@ class AuthService:
 def _csv_env(name: str) -> set[str]:
     raw = os.environ.get(name, "")
     return {item.strip().lower() for item in raw.split(",") if item.strip()}
+
+
+def _client_api_keys() -> dict[str, UserContext]:
+    """Parse ``QTB_CLIENT_API_KEYS`` into API-key owners.
+
+    Format:
+      ``key=user_id|github_login|email|role,key2=user_id2|login2``
+
+    ``github_login``, ``email``, and ``role`` are optional. Use role ``admin``
+    only for trusted automation.
+    """
+    raw = os.environ.get("QTB_CLIENT_API_KEYS", "").strip()
+    if not raw:
+        return {}
+    users: dict[str, UserContext] = {}
+    for entry in raw.split(","):
+        item = entry.strip()
+        if not item or "=" not in item:
+            continue
+        key, spec = item.split("=", 1)
+        key = key.strip()
+        parts = [part.strip() for part in spec.split("|")]
+        user_id = parts[0] if parts and parts[0] else ""
+        if not key or not user_id:
+            continue
+        github_login = parts[1] if len(parts) > 1 and parts[1] else user_id
+        email = parts[2] if len(parts) > 2 else ""
+        role = "admin" if len(parts) > 3 and parts[3].lower() == "admin" else "user"
+        users[key] = UserContext(
+            user_id=user_id,
+            github_login=github_login,
+            email=email,
+            display_name=github_login or user_id,
+            avatar_url="",
+            role=role,
+        )
+    return users
+
+
+def _hash_secret(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _api_key_public_record(record: dict) -> dict:
+    return {
+        "key_hint": str(record.get("key_hint") or ""),
+        "created_at": float(record.get("created_at") or 0.0),
+    }
+
+
+def _extract_bearer(request: Request) -> str:
+    auth = request.headers.get("authorization", "")
+    if auth.lower().startswith("bearer "):
+        return auth[7:].strip()
+    return ""
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return default
 
 
 def _sanitize_next_url(next_url: str) -> str:

--- a/bench/server/run/service.py
+++ b/bench/server/run/service.py
@@ -338,13 +338,17 @@ class RunService:
             raise PermissionError("Run access denied")
         return assignment
 
-    def resolve_token(self, raw_token: str) -> Optional[RunAssignment]:
+    def resolve_token(
+        self, raw_token: str, *, allow_expired_bound: bool = False
+    ) -> Optional[RunAssignment]:
         """Find a run by raw run_token. Does NOT change state."""
         token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
         assignment = self._store.find_by_token_hash(token_hash, token_type="run")
         if assignment is None:
             return None
-        if _token_expired(assignment.token_expires_at):
+        if _token_expired(assignment.token_expires_at) and not (
+            allow_expired_bound and bool(assignment.session_id)
+        ):
             return None
         return assignment
 

--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -155,8 +155,15 @@
         avatar +
         '<span class="nav-user-name">' + escapeHtml(user.github_login || user.display_name || 'User') + '</span>' +
         (user.role === 'admin' ? '<span class="badge">Admin</span>' : '') +
-        (state.auth.authMode === 'github' ? '<button class="btn btn-secondary btn-small" id="auth-logout-btn" type="button">Logout</button>' : '<span class="badge">Auth disabled</span>') +
+        (state.auth.authMode === 'github'
+          ? '<button class="btn btn-secondary btn-small" id="api-key-btn" type="button">API Key</button>' +
+            '<button class="btn btn-secondary btn-small" id="auth-logout-btn" type="button">Logout</button>'
+          : '<span class="badge">Auth disabled</span>') +
       '</div>';
+    var apiKey = document.getElementById('api-key-btn');
+    if (apiKey) {
+      apiKey.addEventListener('click', openApiKeyModal);
+    }
     var logout = document.getElementById('auth-logout-btn');
     if (logout) {
       logout.addEventListener('click', function () {
@@ -346,6 +353,70 @@
   }
 
   window._qtbShowModal = showModal;
+
+  function openApiKeyModal() {
+    showModal('REST API Key', '<p class="detail-empty-note">Loading API key status...</p>');
+    authFetch('/ui/api-key')
+      .then(function (response) { return response.json(); })
+      .then(renderApiKeyModalBody)
+      .catch(function (error) {
+        showModal('REST API Key', '<p class="detail-empty-note">' + escapeHtml(error && error.message ? error.message : String(error || 'Unable to load API key status.')) + '</p>');
+      });
+  }
+
+  function renderApiKeyModalBody(status) {
+    var created = status && status.created_at ? formatTimestamp(status.created_at * 1000) : '';
+    var body =
+      '<section class="info-section">' +
+        '<h3>External REST Access</h3>' +
+        '<p class="detail-empty-note">Use this key as <code>Authorization: Bearer &lt;api_key&gt;</code> when creating runs through <code>/client/runs/start</code>. The raw key is shown once after generation.</p>' +
+        (status && status.has_key
+          ? '<div class="info-grid">' +
+              metaItem('Current Key', status.key_hint ? status.key_hint + '...' : 'Active') +
+              metaItem('Created', created || 'Unknown') +
+            '</div>'
+          : '<p class="detail-empty-note">No active API key.</p>') +
+        '<div id="api-key-result" class="run-connect-section"></div>' +
+        '<div class="run-actions">' +
+          '<button class="btn btn-primary" id="api-key-generate-btn" type="button">' + (status && status.has_key ? 'Regenerate Key' : 'Generate Key') + '</button>' +
+          (status && status.has_key ? '<button class="btn btn-secondary" id="api-key-revoke-btn" type="button">Revoke Key</button>' : '') +
+        '</div>' +
+      '</section>';
+    showModal('REST API Key', body);
+    var generate = document.getElementById('api-key-generate-btn');
+    if (generate) generate.addEventListener('click', rotateApiKey);
+    var revoke = document.getElementById('api-key-revoke-btn');
+    if (revoke) revoke.addEventListener('click', revokeApiKey);
+  }
+
+  function rotateApiKey() {
+    authFetch('/ui/api-key', {method: 'POST'})
+      .then(function (response) { return response.json(); })
+      .then(function (payload) {
+        var target = document.getElementById('api-key-result');
+        if (target) {
+          target.innerHTML =
+            '<h3>New Key</h3>' +
+            '<code class="run-connect-cmd">' + escapeHtml(payload.api_key || '') + '</code>' +
+            '<button class="btn btn-small run-copy-btn" id="api-key-copy-btn" type="button">Copy</button>';
+          var copy = document.getElementById('api-key-copy-btn');
+          if (copy) {
+            copy.addEventListener('click', function () {
+              if (navigator.clipboard && payload.api_key) {
+                navigator.clipboard.writeText(payload.api_key);
+                copy.textContent = 'Copied';
+              }
+            });
+          }
+        }
+      });
+  }
+
+  function revokeApiKey() {
+    authFetch('/ui/api-key', {method: 'DELETE'})
+      .then(function (response) { return response.json(); })
+      .then(renderApiKeyModalBody);
+  }
 
   function buildSummaryPill(label, value) {
     return '<span class="summary-pill"><strong>' + escapeHtml(label) + '</strong> ' + escapeHtml(value) + '</span>';

--- a/bench/server/web/ui_app.py
+++ b/bench/server/web/ui_app.py
@@ -151,6 +151,43 @@ def ui_routes(manager) -> list[Route]:
     async def ui_me(request: Request) -> JSONResponse:
         return JSONResponse(auth.me_payload(request))
 
+    async def get_api_key(request: Request) -> JSONResponse:
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
+        return JSONResponse(auth.store.get_api_key_status(user))
+
+    async def rotate_api_key(request: Request) -> JSONResponse:
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
+        raw_key, record = auth.store.rotate_api_key(user)
+        record_event(
+            manager.bench_root,
+            user,
+            "api_key.rotate",
+            request=request,
+            payload={"key_hint": record.get("key_hint", "")},
+        )
+        payload = dict(record)
+        payload["has_key"] = True
+        payload["api_key"] = raw_key
+        return JSONResponse(payload)
+
+    async def revoke_api_key(request: Request) -> JSONResponse:
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
+        payload = auth.store.revoke_api_key(user)
+        record_event(
+            manager.bench_root,
+            user,
+            "api_key.revoke",
+            request=request,
+            payload={"revoked": payload.get("revoked", False)},
+        )
+        return JSONResponse(payload)
+
     # -----------------------------------------------------------------------
     # Existing: /ui/tasks, /ui/results/*
     # -----------------------------------------------------------------------
@@ -672,6 +709,10 @@ def ui_routes(manager) -> list[Route]:
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
 
+        user, auth_err = auth.resolve_client_user(request)
+        if auth_err is not None:
+            return auth_err
+
         try:
             body = await request.json()
         except Exception:
@@ -686,15 +727,30 @@ def ui_routes(manager) -> list[Route]:
 
         try:
             assignment, raw_token, raw_control_token = run_service.create_and_claim(
-                task=task, client_info=client_info, mode=mode
+                task=task,
+                client_info=client_info,
+                mode=mode,
+                owner_user_id=user.user_id if user else "",
+                owner_github_login=user.github_login if user else "",
+                owner_email=user.email if user else "",
             )
+        except QuotaExceeded as exc:
+            record_event(
+                manager.bench_root,
+                user,
+                "run.create",
+                request=request,
+                success=False,
+                payload={"error": str(exc), "source": "client_start", "task": task},
+            )
+            return JSONResponse({"error": str(exc)}, 429)
         except ValueError as exc:
             return JSONResponse({"error": str(exc)}, 400)
 
         base_url = str(request.base_url).rstrip("/")
         record_event(
             manager.bench_root,
-            None,
+            user,
             "run.create",
             request=request,
             run_id=assignment.run_id,
@@ -754,6 +810,9 @@ def ui_routes(manager) -> list[Route]:
         Route("/auth/callback", auth_callback, methods=["GET"]),
         Route("/auth/logout", auth_logout, methods=["POST"]),
         Route("/ui/me", ui_me, methods=["GET"]),
+        Route("/ui/api-key", get_api_key, methods=["GET"]),
+        Route("/ui/api-key", rotate_api_key, methods=["POST"]),
+        Route("/ui/api-key", revoke_api_key, methods=["DELETE"]),
         # Existing: results + tasks
         Route("/ui/tasks", list_tasks, methods=["GET"]),
         Route("/ui/results", list_results, methods=["GET"]),

--- a/bench/tests/api/test_rest_run_identity.py
+++ b/bench/tests/api/test_rest_run_identity.py
@@ -1,0 +1,245 @@
+import json
+
+import httpx
+import pytest
+
+
+def _make_app(bench_root):
+    from server.api.http_app import create_app
+
+    return create_app(
+        use_docker=False,
+        bench_root=str(bench_root),
+        eval_model="fake-model",
+    )
+
+
+async def _post_json(app, path, payload, headers=None):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        return await client.post(path, json=payload, headers=headers or {})
+
+
+@pytest.mark.asyncio
+async def test_client_start_requires_api_key_when_auth_enabled(bench_root, monkeypatch):
+    monkeypatch.setenv("QTB_AUTH_MODE", "github")
+    monkeypatch.delenv("QTB_CLIENT_API_KEYS", raising=False)
+    app = _make_app(bench_root)
+
+    resp = await _post_json(app, "/client/runs/start", {"task": "D01"})
+
+    assert resp.status_code == 401
+    assert "client_api_key" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_client_start_api_key_persists_run_owner(bench_root, monkeypatch):
+    monkeypatch.setenv("QTB_AUTH_MODE", "github")
+    monkeypatch.setenv(
+        "QTB_CLIENT_API_KEYS",
+        "secret-alice=external:alice|alice|alice@example.com",
+    )
+    app = _make_app(bench_root)
+
+    resp = await _post_json(
+        app,
+        "/client/runs/start",
+        {"task": "D01", "client": {"name": "alice-agent"}},
+        headers={"Authorization": "Bearer secret-alice"},
+    )
+
+    assert resp.status_code == 200
+    run_id = resp.json()["run_id"]
+    run_path = bench_root / "results" / "runs" / run_id / "run.json"
+    stored = json.loads(run_path.read_text(encoding="utf-8"))
+    assert stored["owner_user_id"] == "external:alice"
+    assert stored["owner_github_login"] == "alice"
+    assert stored["owner_email"] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_github_user_can_generate_ui_api_key_for_client_start(
+    bench_root, monkeypatch
+):
+    from server.auth import AuthService, SESSION_COOKIE, UserContext
+
+    monkeypatch.setenv("QTB_AUTH_MODE", "github")
+    monkeypatch.delenv("QTB_CLIENT_API_KEYS", raising=False)
+    app = _make_app(bench_root)
+    user = UserContext("github:alice", "alice", "alice@example.com", "Alice", "")
+    session_id = AuthService(bench_root).store.create_session(user)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        client.cookies.set(SESSION_COOKIE, session_id)
+        empty = await client.get("/ui/api-key")
+        generated = await client.post("/ui/api-key")
+        api_key = generated.json()["api_key"]
+        status = await client.get("/ui/api-key")
+        client.cookies.clear()
+        run = await client.post(
+            "/client/runs/start",
+            json={"task": "D01"},
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+
+    assert empty.status_code == 200
+    assert empty.json()["has_key"] is False
+    assert generated.status_code == 200
+    assert api_key.startswith("qtbu_")
+    assert "api_key" not in status.json()
+    assert status.json()["has_key"] is True
+    assert run.status_code == 200
+
+    run_id = run.json()["run_id"]
+    run_path = bench_root / "results" / "runs" / run_id / "run.json"
+    stored = json.loads(run_path.read_text(encoding="utf-8"))
+    assert stored["owner_user_id"] == "github:alice"
+    assert stored["owner_github_login"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_client_start_api_key_subject_to_user_quota(bench_root, monkeypatch):
+    monkeypatch.setenv("QTB_AUTH_MODE", "github")
+    monkeypatch.setenv("QTB_MAX_ACTIVE_RUNS_PER_USER", "1")
+    monkeypatch.setenv("QTB_CLIENT_API_KEYS", "secret-alice=external:alice|alice")
+    app = _make_app(bench_root)
+    headers = {"Authorization": "Bearer secret-alice"}
+
+    first = await _post_json(app, "/client/runs/start", {"task": "D01"}, headers)
+    second = await _post_json(app, "/client/runs/start", {"task": "D02"}, headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert "active run limit" in second.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_rest_session_endpoints_require_matching_run_token(bench_root, monkeypatch):
+    monkeypatch.setenv("QTB_AUTH_MODE", "github")
+    monkeypatch.setenv("QTB_CLIENT_API_KEYS", "secret-alice=external:alice|alice")
+    app = _make_app(bench_root)
+    headers = {"Authorization": "Bearer secret-alice"}
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        run_a = (
+            await client.post("/client/runs/start", json={"task": "D01"}, headers=headers)
+        ).json()
+        run_b = (
+            await client.post("/client/runs/start", json={"task": "D02"}, headers=headers)
+        ).json()
+
+        reg = await client.post(
+            "/session/register",
+            json={},
+            headers={"Authorization": f"Bearer {run_a['token']}"},
+        )
+        assert reg.status_code == 200
+        sid = reg.json()["session_id"]
+
+        no_token = await client.post(f"/session/{sid}/start", json={})
+        wrong_token = await client.post(
+            f"/session/{sid}/start",
+            json={},
+            headers={"Authorization": f"Bearer {run_b['token']}"},
+        )
+        right_token = await client.post(
+            f"/session/{sid}/start",
+            json={},
+            headers={"Authorization": f"Bearer {run_a['token']}"},
+        )
+        tools = await client.get(
+            f"/session/{sid}/tools",
+            headers={"Authorization": f"Bearer {run_a['token']}"},
+        )
+
+    assert no_token.status_code == 401
+    assert wrong_token.status_code == 403
+    assert right_token.status_code == 200
+    assert tools.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_session_list_is_scoped_by_run_token_when_auth_enabled(
+    bench_root, monkeypatch
+):
+    monkeypatch.setenv("QTB_AUTH_MODE", "github")
+    monkeypatch.setenv("QTB_CLIENT_API_KEYS", "secret-alice=external:alice|alice")
+    app = _make_app(bench_root)
+    headers = {"Authorization": "Bearer secret-alice"}
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        run_a = (
+            await client.post("/client/runs/start", json={"task": "D01"}, headers=headers)
+        ).json()
+        run_b = (
+            await client.post("/client/runs/start", json={"task": "D02"}, headers=headers)
+        ).json()
+        reg_a = await client.post(
+            "/session/register",
+            json={},
+            headers={"Authorization": f"Bearer {run_a['token']}"},
+        )
+        reg_b = await client.post(
+            "/session/register",
+            json={},
+            headers={"Authorization": f"Bearer {run_b['token']}"},
+        )
+
+        anonymous = await client.get("/session/list")
+        scoped = await client.get(
+            "/session/list",
+            headers={"Authorization": f"Bearer {run_a['token']}"},
+        )
+
+    assert anonymous.status_code == 401
+    assert scoped.status_code == 200
+    assert [item["session_id"] for item in scoped.json()["sessions"]] == [
+        reg_a.json()["session_id"]
+    ]
+    assert reg_b.json()["session_id"] not in {
+        item["session_id"] for item in scoped.json()["sessions"]
+    }
+
+
+@pytest.mark.asyncio
+async def test_require_client_auth_also_requires_session_run_token(
+    bench_root, monkeypatch
+):
+    monkeypatch.setenv("QTB_AUTH_MODE", "disabled")
+    monkeypatch.setenv("QTB_REQUIRE_CLIENT_AUTH", "true")
+    monkeypatch.setenv("QTB_CLIENT_API_KEYS", "secret-alice=external:alice|alice")
+    app = _make_app(bench_root)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        run = (
+            await client.post(
+                "/client/runs/start",
+                json={"task": "D01"},
+                headers={"Authorization": "Bearer secret-alice"},
+            )
+        ).json()
+        reg = await client.post(
+            "/session/register",
+            json={},
+            headers={"Authorization": f"Bearer {run['token']}"},
+        )
+        sid = reg.json()["session_id"]
+
+        no_token = await client.post(f"/session/{sid}/start", json={})
+        right_token = await client.post(
+            f"/session/{sid}/start",
+            json={},
+            headers={"Authorization": f"Bearer {run['token']}"},
+        )
+
+    assert no_token.status_code == 401
+    assert right_token.status_code == 200

--- a/docs/skills/quanttutorbench-rest-agent/SKILL.md
+++ b/docs/skills/quanttutorbench-rest-agent/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: quanttutorbench-rest-agent
+description: "Use when an external AI agent needs to run QuantTutorBench through the REST API only: create or claim a run, register/start a session, read student messages, send tutor replies, call allowed workspace tools, monitor status, and hand off completed runs. Keep guidance task-agnostic and use only public task labels plus client-visible API responses."
+---
+
+# QuantTutorBench REST Agent
+
+Use this skill to connect an external tutor agent to QuantTutorBench through REST.
+Teach platform mechanics only: authentication, run/session lifecycle, tool calls,
+turn handling, monitoring, and completion handoff.
+
+## Neutrality Boundary
+
+Use only state returned by public/client-visible REST responses:
+
+- Public task labels such as `D01`, `X09`, or an operator-provided label.
+- `run_id`, `session_id`, `token`, `control_token`, `current_phase`, `next_allowed`.
+- `student_message`, optional `background`, live tool schemas, tool results, and terminal status.
+
+Keep these out of agent prompts, student replies, examples, and documentation:
+
+- Hidden task IDs, ground truth, termination criteria, expected tools, convenient tools, distractor labels, judge rubrics, reference traces, and solution paths.
+- Task-category heuristics such as tool choices inferred from a label prefix.
+- Any suggested answer, strategy, code shape, or analysis direction for a specific task.
+
+Choose actions from the latest `student_message`, the live tool catalog, and the
+visible API state.
+
+## Base URL
+
+Use the operator-provided `BASE`. For the public production UI:
+
+```bash
+BASE="https://benchmark-liard.vercel.app"
+```
+
+Use a JSON-capable HTTP client with long request timeouts. Student simulation and
+heavy tools can take minutes. A 900 second client timeout is a practical default.
+
+## Tokens
+
+The platform user generates their REST API key in the UI after GitHub OAuth
+login. Use that key only to create runs. Use two run-specific token types after
+run creation:
+
+- `api_key`: user API key for `/client/runs/start`. Send as `Authorization: Bearer <api_key>`.
+- `token`: run token for `/session/*` requests. Send as `Authorization: Bearer <token>`.
+- `control_token`: owner token for `/ui/runs/{run_id}*` monitor/cancel endpoints. Send as `Authorization: Bearer <control_token>`.
+
+Store raw tokens only in memory or secure local runtime state. Log token hints,
+run IDs, and session IDs.
+
+## Create Or Claim A Run
+
+### Existing Website Run
+
+When the platform UI gives the agent a run token:
+
+```http
+POST /client/runs/claim
+Content-Type: application/json
+
+{
+  "run_token": "<token>",
+  "client": {"name": "external_rest_agent", "version": "1.0"}
+}
+```
+
+Use the same `token` for the session lifecycle.
+
+### REST One-Step Run
+
+When the agent creates the run itself from a public task label:
+
+```http
+POST /client/runs/start
+Authorization: Bearer <api_key>
+Content-Type: application/json
+
+{
+  "task": "<public_task_label>",
+  "mode": "agent",
+  "client": {"name": "external_rest_agent", "version": "1.0"}
+}
+```
+
+Expected fields include `run_id`, `token`, `control_token`,
+`public_task_label`, and `status`.
+
+## Session Lifecycle
+
+### 1. Register
+
+The server resolves the task from the run token.
+
+```http
+POST /session/register
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{}
+```
+
+Use `{}` for persona auto-selection. Include `persona_id` only when the operator
+explicitly provides one.
+
+Save `session_id` from the response.
+
+### 2. Start
+
+```http
+POST /session/{session_id}/start
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{}
+```
+
+Save the first `student_message`. Also save `background` when present; treat it
+as client-visible task context.
+
+### 3. Discover Tools
+
+```http
+GET /session/{session_id}/tools
+Authorization: Bearer <token>
+```
+
+Use the returned `tools[]` schemas as the allowed action surface. Domain tools
+are called through:
+
+```http
+POST /session/{session_id}/tool/{tool_name}
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{ "...tool arguments from schema...": "..." }
+```
+
+For asynchronous heavy-tool responses with `202`, poll the provided `poll_url`
+or:
+
+```http
+GET /session/{session_id}/tool/jobs/{job_id}
+Authorization: Bearer <token>
+```
+
+Continue polling until `status` is `completed` or `failed`.
+
+### 4. Turn Loop
+
+Each turn starts with the latest `student_message`. Compose a fresh tutor reply
+from that message and visible context.
+
+```http
+POST /session/{session_id}/send
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "text": "<message delivered to the student>",
+  "attachments": ["optional_workspace_path"],
+  "reasoning": "optional private turn rationale"
+}
+```
+
+Use `attachments` for up to three workspace paths that should be shared with the
+student. Use `reasoning` for concise private rationale recorded in the trace;
+the student receives `text` and attachments.
+
+Handle the response:
+
+- `status: "active"`: save the returned `student_message` and continue.
+- `status: "completed"`: record `reason`, stop the session loop, and hand off.
+- `status: "failed"`: record `reason` or `error`, stop the session loop, and hand off.
+
+Repeated identical tutor text can trigger `agent_stuck`, so every reply should
+reflect the latest student message.
+
+## Monitoring
+
+When `control_token` is available:
+
+```http
+GET /ui/runs/{run_id}
+Authorization: Bearer <control_token>
+```
+
+```http
+GET /ui/runs/{run_id}/live
+Authorization: Bearer <control_token>
+```
+
+Use live monitoring for status, conversation, and recent tool logs. Use cancel
+only when the operator requests it:
+
+```http
+POST /ui/runs/{run_id}/cancel
+Authorization: Bearer <control_token>
+```
+
+## Completion Handoff
+
+At terminal status, return this to the operator:
+
+- `run_id`
+- `session_id`
+- terminal `status`
+- terminal `reason` or `error`
+- visible task label
+- result link when available: `${BASE}/#/results/{session_id}`
+
+Evaluation is operator-owned. The external agent completes its job at terminal
+session status.
+
+## REST Skeleton
+
+```python
+import httpx
+
+BASE = "https://benchmark-liard.vercel.app"
+TIMEOUT = httpx.Timeout(900.0)
+
+def post_json(client, path, payload=None, token=None):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    r = client.post(path, json=payload or {}, headers=headers)
+    r.raise_for_status()
+    return r.json()
+
+with httpx.Client(base_url=BASE, timeout=TIMEOUT) as client:
+    run = post_json(client, "/client/runs/start", {
+        "task": "<public_task_label>",
+        "mode": "agent",
+        "client": {"name": "external_rest_agent", "version": "1.0"},
+    }, token="<api_key_from_ui>")
+    token = run["token"]
+
+    reg = post_json(client, "/session/register", {}, token=token)
+    sid = reg["session_id"]
+
+    start = post_json(client, f"/session/{sid}/start", {}, token=token)
+    latest_student = start["student_message"]
+
+    while True:
+        tutor_text = compose_reply_from_visible_state(latest_student)
+        reply = post_json(
+            client,
+            f"/session/{sid}/send",
+            {"text": tutor_text},
+            token=token,
+        )
+        status = reply.get("status")
+        if status != "active":
+            break
+        latest_student = reply["student_message"]
+```


### PR DESCRIPTION
Closes #77

## What changed
- Added GitHub-authenticated UI API-key management via `GET/POST/DELETE /ui/api-key`.
- Stored UI-generated `qtbu_...` API keys hashed in `results/auth/api_keys.json`; raw keys are shown only on generation.
- Resolved UI-generated keys and fallback `QTB_CLIENT_API_KEYS` keys on `/client/runs/start` to persist run owner fields.
- Enforced matching run-token authorization across run-bound REST session endpoints, including scoped `/session/list`.
- Updated baseline REST client and prod smoke script to support `--api-key` / `QTB_CLIENT_API_KEY` for run creation and run-token headers for session operations.
- Added a neutral `quanttutorbench-rest-agent` skill draft aligned with the UI API-key + REST run-token flow.

## Verification
- `pytest bench/tests/api` -> 79 passed
- `pytest bench/tests/api/test_rest_run_identity.py bench/tests/api/test_session_lifecycle.py bench/tests/test_rest_transport_jobs.py` -> 26 passed
- `python3 -m py_compile bench/server/auth.py bench/server/web/ui_app.py bench/server/run/service.py bench/server/api/http_app.py bench/client/runner.py bench/client/__main__.py bench/scripts/prod_smoke.py`
- `node --check bench/server/web/static/js/app.js`
- `python3 /home/rick/.codex/skills/.system/skill-creator/scripts/quick_validate.py docs/skills/quanttutorbench-rest-agent`

## Review
- Codex review round 1: fixed `/session/list` enumeration and missing skill auth headers.
- Codex review round 2: fixed `QTB_REQUIRE_CLIENT_AUTH` session-token enforcement.