### PR TITLE
Open GitHub OAuth to public users

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,21 @@
 OPENROUTER_API_KEY=your_key_here
 HF_TOKEN=your_huggingface_token_here
+
+# GitHub OAuth for the web UI
+QTB_AUTH_MODE=disabled
+QTB_PUBLIC_BASE_URL=
+QTB_GITHUB_CLIENT_ID=
+QTB_GITHUB_CLIENT_SECRET=
+QTB_GITHUB_ALLOW_ALL=false
+
+# Empty allowlist vars allow any GitHub account through OAuth.
+# Set QTB_GITHUB_ALLOW_ALL=true for public GitHub OAuth.
+# Set allowlist vars for invite-only access.
+QTB_GITHUB_ALLOWED_LOGINS=
+QTB_GITHUB_ALLOWED_ORGS=
+QTB_GITHUB_ALLOWED_TEAMS=
+
+# Admin users still need an explicit login or email match.
+QTB_ADMIN_GITHUB_LOGINS=
+QTB_ADMIN_EMAILS=
+QTB_COOKIE_SECURE=

--- a/bench/server/auth.py
+++ b/bench/server/auth.py
@@ -448,6 +448,9 @@ class AuthService:
         return response.json()
 
     def _is_allowed(self, profile: dict, token: str) -> bool:
+        if _bool_env("QTB_GITHUB_ALLOW_ALL", False):
+            return True
+
         login = str(profile.get("login") or "")
         allowed_logins = _csv_env("QTB_GITHUB_ALLOWED_LOGINS")
         if allowed_logins and login.lower() in allowed_logins:
@@ -456,7 +459,7 @@ class AuthService:
         allowed_orgs = _csv_env("QTB_GITHUB_ALLOWED_ORGS")
         allowed_teams = _csv_env("QTB_GITHUB_ALLOWED_TEAMS")
         if not allowed_orgs and not allowed_teams and not allowed_logins:
-            allowed_orgs = {"varsity-tech-product"}
+            return True
 
         if allowed_orgs:
             orgs = self._github_get(token, "/user/orgs")

--- a/bench/tests/test_github_oauth_auth.py
+++ b/bench/tests/test_github_oauth_auth.py
@@ -77,7 +77,7 @@ class GithubOAuthAuthTests(unittest.TestCase):
             with patch.dict(
                 "os.environ",
                 {"QTB_GITHUB_ALLOWED_ORGS": "varsity-tech-product"},
-                clear=False,
+                clear=True,
             ):
                 auth = AuthService(Path(tmp))
                 with patch.object(
@@ -87,12 +87,35 @@ class GithubOAuthAuthTests(unittest.TestCase):
                 ):
                     self.assertTrue(auth._is_allowed({"login": "alice"}, "tok"))
 
+    def test_empty_allowlist_accepts_any_github_account(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict("os.environ", {}, clear=True):
+                auth = AuthService(Path(tmp))
+                with patch.object(auth, "_github_get") as github_get:
+                    self.assertTrue(auth._is_allowed({"login": "external"}, "tok"))
+                    github_get.assert_not_called()
+
+    def test_allow_all_accepts_account_with_org_allowlist_configured(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_GITHUB_ALLOW_ALL": "true",
+                    "QTB_GITHUB_ALLOWED_ORGS": "varsity-tech-product",
+                },
+                clear=True,
+            ):
+                auth = AuthService(Path(tmp))
+                with patch.object(auth, "_github_get") as github_get:
+                    self.assertTrue(auth._is_allowed({"login": "external"}, "tok"))
+                    github_get.assert_not_called()
+
     def test_org_allowlist_rejects_outsider(self):
         with tempfile.TemporaryDirectory() as tmp:
             with patch.dict(
                 "os.environ",
                 {"QTB_GITHUB_ALLOWED_ORGS": "varsity-tech-product"},
-                clear=False,
+                clear=True,
             ):
                 auth = AuthService(Path(tmp))
                 with patch.object(auth, "_github_get", return_value=[{"login": "other"}]):


### PR DESCRIPTION
## Summary
- allow public GitHub OAuth with QTB_GITHUB_ALLOW_ALL=true
- allow public GitHub OAuth when login/org/team allowlist vars are empty
- keep invite-only allowlist behavior and explicit admin role configuration
- document GitHub OAuth env vars in .env.template

## Tests
- pytest bench/tests/test_github_oauth_auth.py
- QTB_GITHUB_ALLOW_ALL=true pytest bench/tests/test_github_oauth_auth.py::GithubOAuthAuthTests::test_org_allowlist_rejects_outsider
- codex exec review --uncommitted, two rounds

Closes #81