### PR TITLE
Guard public GitHub OAuth deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,6 +109,8 @@ jobs:
             sudo systemctl is-active quanttutor
             # /health deep probe: docker daemon + LEAN image + disk (returns 503 on any failure)
             curl -sf http://127.0.0.1:8000/health >/dev/null
+            AUTH_POLICY=$(curl -sf http://127.0.0.1:8000/ui/me | ~/benchmark/.venv/bin/python -c 'import json, sys; data = json.load(sys.stdin); print((data.get("auth_mode", "") or "") + ":" + (data.get("github_access_policy", "") or ""))')
+            test "$AUTH_POLICY" = "github:public"
             echo "--- disk ---"
             df -h /home | tail -1
             echo "--- tail log ---"

--- a/bench/scripts/prod_smoke.py
+++ b/bench/scripts/prod_smoke.py
@@ -158,6 +158,7 @@ async def run_smoke(
     task_label: str,
     jsonl: Optional[str],
     api_key: str = "",
+    expect_public_oauth: bool = False,
 ) -> int:
     result = SmokeResult(jsonl_path=jsonl)
 
@@ -183,6 +184,29 @@ async def run_smoke(
         await hit(client, result, "T1", "GET", "/ui/tasks/catalog/labels")
         await hit(client, result, "T1", "GET", "/ui/runs")
         await hit(client, result, "T1", "GET", "/ui/results")
+        me = await hit(client, result, "T1", "GET", "/ui/me", expect="2xx")
+        if expect_public_oauth:
+            status = me.status_code if me is not None else 0
+            auth_mode = ""
+            policy = ""
+            if me is not None:
+                try:
+                    payload = me.json()
+                    auth_mode = str(payload.get("auth_mode") or "")
+                    policy = str(payload.get("github_access_policy") or "")
+                except (ValueError, json.JSONDecodeError):
+                    pass
+            ok = auth_mode == "github" and policy == "public"
+            result.record(
+                "T1",
+                "CHECK",
+                "/ui/me github_access_policy",
+                status,
+                ok,
+                0.0,
+                f"auth_mode={auth_mode or '<missing>'} "
+                f"github_access_policy={policy or '<missing>'}",
+            )
 
         # ------------------------------------------------------------------
         # T2 — Run creation (critical path)
@@ -341,8 +365,21 @@ def main() -> int:
         default=os.environ.get("QTB_CLIENT_API_KEY", ""),
         help="REST API key from the logged-in UI account (default: QTB_CLIENT_API_KEY)",
     )
+    p.add_argument(
+        "--expect-public-oauth",
+        action="store_true",
+        help="require /ui/me to report github_access_policy=public",
+    )
     args = p.parse_args()
-    return asyncio.run(run_smoke(args.base_url, args.task, args.jsonl, args.api_key))
+    return asyncio.run(
+        run_smoke(
+            args.base_url,
+            args.task,
+            args.jsonl,
+            args.api_key,
+            args.expect_public_oauth,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/bench/server/auth.py
+++ b/bench/server/auth.py
@@ -302,9 +302,19 @@ class AuthService:
         user = self.get_current_user(request)
         return {
             "auth_mode": "github" if self.enabled else "disabled",
+            "github_access_policy": self.github_access_policy(),
             "authenticated": user is not None,
             "user": user.to_dict() if user else None,
         }
+
+    def github_access_policy(self) -> Literal["disabled", "public", "invite_only"]:
+        if not self.enabled:
+            return "disabled"
+        if _bool_env("QTB_GITHUB_ALLOW_ALL", False):
+            return "public"
+        if any(self._github_allowlists()):
+            return "invite_only"
+        return "public"
 
     async def login(self, request: Request) -> Response:
         next_url = request.query_params.get("next") or "/"
@@ -452,12 +462,10 @@ class AuthService:
             return True
 
         login = str(profile.get("login") or "")
-        allowed_logins = _csv_env("QTB_GITHUB_ALLOWED_LOGINS")
+        allowed_logins, allowed_orgs, allowed_teams = self._github_allowlists()
         if allowed_logins and login.lower() in allowed_logins:
             return True
 
-        allowed_orgs = _csv_env("QTB_GITHUB_ALLOWED_ORGS")
-        allowed_teams = _csv_env("QTB_GITHUB_ALLOWED_TEAMS")
         if not allowed_orgs and not allowed_teams and not allowed_logins:
             return True
 
@@ -482,6 +490,13 @@ class AuthService:
                 if slug in allowed_teams or f"{org_login}/{slug}" in allowed_teams:
                     return True
         return False
+
+    def _github_allowlists(self) -> tuple[set[str], set[str], set[str]]:
+        return (
+            _csv_env("QTB_GITHUB_ALLOWED_LOGINS"),
+            _csv_env("QTB_GITHUB_ALLOWED_ORGS"),
+            _csv_env("QTB_GITHUB_ALLOWED_TEAMS"),
+        )
 
     def _build_user(self, profile: dict) -> UserContext:
         login = str(profile.get("login") or "")

--- a/bench/tests/test_github_oauth_auth.py
+++ b/bench/tests/test_github_oauth_auth.py
@@ -110,6 +110,33 @@ class GithubOAuthAuthTests(unittest.TestCase):
                     self.assertTrue(auth._is_allowed({"login": "external"}, "tok"))
                     github_get.assert_not_called()
 
+    def test_access_policy_reports_public_when_allow_all_overrides_allowlist(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_AUTH_MODE": "github",
+                    "QTB_GITHUB_ALLOW_ALL": "true",
+                    "QTB_GITHUB_ALLOWED_ORGS": "varsity-tech-product",
+                },
+                clear=True,
+            ):
+                auth = AuthService(Path(tmp))
+                self.assertEqual(auth.github_access_policy(), "public")
+
+    def test_access_policy_reports_invite_only_when_allowlist_is_active(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_AUTH_MODE": "github",
+                    "QTB_GITHUB_ALLOWED_ORGS": "varsity-tech-product",
+                },
+                clear=True,
+            ):
+                auth = AuthService(Path(tmp))
+                self.assertEqual(auth.github_access_policy(), "invite_only")
+
     def test_org_allowlist_rejects_outsider(self):
         with tempfile.TemporaryDirectory() as tmp:
             with patch.dict(


### PR DESCRIPTION
## What changed
- Added `AuthService.github_access_policy()` and exposed `github_access_policy` in `/ui/me`.
- Added `bench/scripts/prod_smoke.py --expect-public-oauth` for strict public OAuth policy checks.
- Added a deploy workflow guard that asserts the restarted VPS reports `github:public`.
- Added regression coverage for public policy reporting and active invite-only policy reporting.

## Production fix
- Updated the VPS `.env` with `QTB_GITHUB_ALLOW_ALL=true`.
- Restarted `quanttutor`.
- Verified the loaded VPS env allows a synthetic external GitHub profile.

## Verification
- `pytest bench/tests/test_github_oauth_auth.py`
- `pytest bench/tests/test_server_web_ui.py bench/tests/test_github_oauth_auth.py`
- `.venv/bin/python -m py_compile bench/scripts/prod_smoke.py`
- `git diff --check`
- `codex exec review --uncommitted`

Closes #81
