### PR TITLE
Limit public GitHub OAuth scopes

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,6 +11,7 @@ QTB_GITHUB_ALLOW_ALL=false
 # Empty allowlist vars allow any GitHub account through OAuth.
 # Set QTB_GITHUB_ALLOW_ALL=true for public GitHub OAuth.
 # Set allowlist vars for invite-only access.
+# Public OAuth requests only GitHub identity/email scopes; org/team gates request read:org.
 QTB_GITHUB_ALLOWED_LOGINS=
 QTB_GITHUB_ALLOWED_ORGS=
 QTB_GITHUB_ALLOWED_TEAMS=

--- a/bench/server/auth.py
+++ b/bench/server/auth.py
@@ -323,7 +323,7 @@ class AuthService:
             {
                 "client_id": client_id,
                 "redirect_uri": redirect_uri,
-                "scope": "read:user user:email read:org",
+                "scope": self._github_oauth_scope(),
                 "state": state,
             }
         )
@@ -452,12 +452,10 @@ class AuthService:
             return True
 
         login = str(profile.get("login") or "")
-        allowed_logins = _csv_env("QTB_GITHUB_ALLOWED_LOGINS")
+        allowed_logins, allowed_orgs, allowed_teams = self._github_allowlists()
         if allowed_logins and login.lower() in allowed_logins:
             return True
 
-        allowed_orgs = _csv_env("QTB_GITHUB_ALLOWED_ORGS")
-        allowed_teams = _csv_env("QTB_GITHUB_ALLOWED_TEAMS")
         if not allowed_orgs and not allowed_teams and not allowed_logins:
             return True
 
@@ -482,6 +480,22 @@ class AuthService:
                 if slug in allowed_teams or f"{org_login}/{slug}" in allowed_teams:
                     return True
         return False
+
+    def _github_allowlists(self) -> tuple[set[str], set[str], set[str]]:
+        return (
+            _csv_env("QTB_GITHUB_ALLOWED_LOGINS"),
+            _csv_env("QTB_GITHUB_ALLOWED_ORGS"),
+            _csv_env("QTB_GITHUB_ALLOWED_TEAMS"),
+        )
+
+    def _github_oauth_scope(self) -> str:
+        scopes = ["read:user", "user:email"]
+        _, allowed_orgs, allowed_teams = self._github_allowlists()
+        if not _bool_env("QTB_GITHUB_ALLOW_ALL", False) and (
+            allowed_orgs or allowed_teams
+        ):
+            scopes.append("read:org")
+        return " ".join(scopes)
 
     def _build_user(self, profile: dict) -> UserContext:
         login = str(profile.get("login") or "")

--- a/bench/tests/test_github_oauth_auth.py
+++ b/bench/tests/test_github_oauth_auth.py
@@ -11,6 +11,8 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from urllib.parse import parse_qs, urlparse
+
 from server.auth import AuthService, SESSION_COOKIE
 
 
@@ -59,6 +61,53 @@ class GithubOAuthAuthTests(unittest.TestCase):
                 self.assertIsNotNone(user)
                 self.assertEqual(user.github_login, "alice")
                 self.assertEqual(user.role, "admin")
+
+    def test_public_login_does_not_request_org_scope(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_AUTH_MODE": "github",
+                    "QTB_GITHUB_CLIENT_ID": "cid",
+                    "QTB_GITHUB_ALLOW_ALL": "true",
+                    "QTB_GITHUB_ALLOWED_ORGS": "varsity-tech-product",
+                },
+                clear=True,
+            ):
+                auth = AuthService(Path(tmp))
+
+                async def login(request):
+                    return await auth.login(request)
+
+                client = TestClient(Starlette(routes=[Route("/auth/login", login)]))
+                response = client.get("/auth/login?next=/", follow_redirects=False)
+
+        self.assertEqual(response.status_code, 302)
+        query = parse_qs(urlparse(response.headers["location"]).query)
+        self.assertEqual(query["scope"], ["read:user user:email"])
+
+    def test_invite_only_org_login_requests_org_scope(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_AUTH_MODE": "github",
+                    "QTB_GITHUB_CLIENT_ID": "cid",
+                    "QTB_GITHUB_ALLOWED_ORGS": "varsity-tech-product",
+                },
+                clear=True,
+            ):
+                auth = AuthService(Path(tmp))
+
+                async def login(request):
+                    return await auth.login(request)
+
+                client = TestClient(Starlette(routes=[Route("/auth/login", login)]))
+                response = client.get("/auth/login?next=/", follow_redirects=False)
+
+        self.assertEqual(response.status_code, 302)
+        query = parse_qs(urlparse(response.headers["location"]).query)
+        self.assertEqual(query["scope"], ["read:user user:email read:org"])
 
     def test_invalid_state_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## What Changed
- Public GitHub OAuth now requests only `read:user user:email`.
- Invite-only org/team gates still request `read:org` when `QTB_GITHUB_ALLOW_ALL=false` and org/team allowlists are configured.
- Shared GitHub allowlist parsing between the allow decision and OAuth scope selection.
- Added regression tests for public and invite-only authorize URL scopes.
- Updated `.env.template` with the public versus org/team scope behavior.

## Live Hotfix
- Backed up `/home/rick/benchmark/bench/server/auth.py` to `/home/rick/benchmark/bench/server/auth.py.issue81-scope-20260423.bak`.
- Rsynced the patched `bench/server/auth.py` to the VPS.
- Restarted `quanttutor`.
- Verified `https://benchmark-liard.vercel.app/auth/login?next=/` now redirects to GitHub with `scope=read%3Auser+user%3Aemail`.

## Verification
- `pytest bench/tests/test_github_oauth_auth.py`
- `git diff --check`
- `codex exec review --uncommitted`

Review note: Codex review found no material issue in this OAuth diff. It reported unrelated untracked `bench/experiments/judge_validation/results/*` artifacts, which remain outside this PR.

Refs #81
