### PR TITLE
Add judge validation robustness metrics

### DIFF
--- a/bench/experiments/judge_validation/README.md
+++ b/bench/experiments/judge_validation/README.md
@@ -1,6 +1,6 @@
 # Judge Validation
 
-Stage 1 validates the scoring judge before external-agent results depend on it.
+This experiment validates the scoring judge before external-agent results depend on it.
 
 This experiment provides:
 
@@ -8,7 +8,10 @@ This experiment provides:
 - rendered judge prompts with rubric and prompt metadata
 - repeated same-prompt judge runs
 - stability metrics: mean absolute score delta, within-one score rate, pass/fail flip rate
+- prompt-format robustness metrics across semantically equivalent transcript formats
 - adversarial pair metrics: whether the stronger transcript scores higher
+- one-factor sensitivity metrics: whether targeted defects move the intended rubric score
+- evidence and reason coverage plus lightweight explanation consistency
 - Markdown, HTML, and machine-readable JSON reports
 
 ## Commands
@@ -31,6 +34,16 @@ Run the Stage 1 judge gate with three repeats per item:
 python -m experiments.judge_validation.run judge --repeats 3 --model anthropic/claude-sonnet-4-6
 ```
 
+Run prompt-format robustness variants:
+
+```bash
+python -m experiments.judge_validation.run judge --repeats 3 --prompt-variants baseline,role_blocks,markdown_transcript --model anthropic/claude-sonnet-4-6
+```
+
+Items with prebuilt evaluation context use the baseline context once, because
+their QR-style payload already contains task, acceptance criteria, tool outputs,
+and result summary in a canonical format.
+
 Generate reports from `judge_runs.json`:
 
 ```bash
@@ -41,4 +54,4 @@ Outputs are written under `bench/experiments/judge_validation/results/` by defau
 
 ## Scope
 
-This stage covers repeated same-prompt stability and obvious good-vs-bad adversarial ranking. Later stages add rubric-order sensitivity, prompt variants, multi-judge comparison, and human quant expert alignment.
+The current automated gate covers repeated same-prompt stability, prompt-format robustness, one-factor sensitivity, obvious good-vs-bad adversarial ranking, and lightweight evidence consistency. Later stages add broader real-transcript sampling, rubric-order sensitivity where the protocol supports it, and human quant expert alignment.

--- a/bench/experiments/judge_validation/pilot_corpus.json
+++ b/bench/experiments/judge_validation/pilot_corpus.json
@@ -1,6 +1,6 @@
 {
-  "version": "judge_validation_pilot_corpus_v1",
-  "description": "Stage 1 fixed pilot corpus for automated judge stability and obvious adversarial ranking checks.",
+  "version": "judge_validation_pilot_corpus_v2",
+  "description": "Fixed pilot corpus for automated judge stability, prompt-format robustness, one-factor sensitivity, and obvious adversarial ranking checks.",
   "pass_threshold": 3,
   "items": [
     {
@@ -282,6 +282,128 @@
           "content": "Yes, the crossover is bullish. I would buy today and hold until the short average crosses back down."
         }
       ]
+    },
+    {
+      "sample_id": "jv_real_x02_lookahead_excerpt",
+      "transcript_source": "real_run_single_trace_excerpt",
+      "source_path": "bench/results/run-single/openai/gpt-4o-mini/X02_lookahead/intermediate_developer/trace.md",
+      "task_id": "X02_lookahead",
+      "category": "debug",
+      "persona_id": "developer_crossover",
+      "track": "tutor",
+      "dimension": "D4_instructional_accuracy",
+      "registry_rubric_id": "quant_correctness.v1",
+      "expected_score_band": "medium",
+      "conversation": [
+        {
+          "role": "user",
+          "content": "I implemented an SMA(10)/SMA(30) crossover backtest, and the returns seem suspiciously high. I suspect look-ahead bias. Can you help me audit the code?"
+        },
+        {
+          "role": "assistant",
+          "content": "We should check signal generation timing, position management, performance calculation, and data splitting. I need to see the code in student_code/lookahead.py to identify the exact issue."
+        },
+        {
+          "role": "user",
+          "content": "The code computes SMA10 and SMA30 from Close, sets Signal to 1 when SMA10 > SMA30, and returns the data."
+        },
+        {
+          "role": "assistant",
+          "content": "The signal uses the same row's close-derived SMA for the current decision. Shift the SMA values by one bar before generating the signal so the trade uses information available before the current bar."
+        }
+      ]
+    },
+    {
+      "sample_id": "jv_real_i01_sma_lean_excerpt",
+      "transcript_source": "real_run_single_trace_excerpt",
+      "source_path": "bench/results/run-single/openai/gpt-5.2/I01_implement_sma/intermediate_developer/trace.md",
+      "task_id": "I01_implement_sma",
+      "category": "implementation",
+      "persona_id": "developer_crossover",
+      "track": "tutor",
+      "dimension": "D2_code_adaptation",
+      "registry_rubric_id": "student_adaptation.v1",
+      "expected_score_band": "high",
+      "conversation": [
+        {
+          "role": "user",
+          "content": "I need to implement a basic SMA trend filter in LEAN for BTCUSDT daily bars. I know the strategy idea, and I am new to the QuantConnect API."
+        },
+        {
+          "role": "assistant",
+          "content": "The key pieces are to subscribe to BTCUSDT at daily resolution, create the SMA, warm up enough history, and use position-aware logic. Store the returned Symbol and use it everywhere to avoid string and symbol mixups."
+        },
+        {
+          "role": "user",
+          "content": "Can you explain how to handle warm-up and IsWarmingUp in OnData?"
+        },
+        {
+          "role": "assistant",
+          "content": "Use SetWarmUp with the SMA period and resolution, then return early in OnData while IsWarmingUp is true. Keep an _sma.IsReady guard as a second safety check before reading the indicator value."
+        }
+      ]
+    }
+  ],
+  "sensitivity_cases": [
+    {
+      "case_id": "sens_quant_error_only",
+      "factor": "quant_error_only",
+      "dimension": "D4_instructional_accuracy",
+      "registry_rubric_id": "quant_correctness.v1",
+      "baseline_sample_id": "jv_quant_correct_good",
+      "perturbed_sample_id": "jv_quant_correct_bad",
+      "expected_direction": "baseline_higher",
+      "minimum_margin": 1
+    },
+    {
+      "case_id": "sens_broken_code_only",
+      "factor": "broken_code_only",
+      "dimension": "result_judge",
+      "registry_rubric_id": "code_correctness.v1",
+      "baseline_sample_id": "jv_code_correct_good",
+      "perturbed_sample_id": "jv_code_correct_bad",
+      "expected_direction": "baseline_higher",
+      "minimum_margin": 1
+    },
+    {
+      "case_id": "sens_jargon_to_beginner",
+      "factor": "jargon_to_beginner",
+      "dimension": "D1_finance_adaptation",
+      "registry_rubric_id": "student_adaptation.v1",
+      "baseline_sample_id": "jv_adaptation_good",
+      "perturbed_sample_id": "jv_adaptation_bad",
+      "expected_direction": "baseline_higher",
+      "minimum_margin": 1
+    },
+    {
+      "case_id": "sens_hallucinated_tool_output",
+      "factor": "hallucinated_tool_output",
+      "dimension": "result_judge",
+      "registry_rubric_id": "tool_workspace_use.v1",
+      "baseline_sample_id": "jv_tool_grounding_good",
+      "perturbed_sample_id": "jv_tool_grounding_bad",
+      "expected_direction": "baseline_higher",
+      "minimum_margin": 1
+    },
+    {
+      "case_id": "sens_answer_dump",
+      "factor": "answer_dump",
+      "dimension": "D3_pedagogical_method",
+      "registry_rubric_id": "teaching_quality.v1",
+      "baseline_sample_id": "jv_teaching_good",
+      "perturbed_sample_id": "jv_teaching_bad",
+      "expected_direction": "baseline_higher",
+      "minimum_margin": 1
+    },
+    {
+      "case_id": "sens_failure_boundary_removed",
+      "factor": "failure_boundary_removed",
+      "dimension": "D6_safety_boundaries",
+      "registry_rubric_id": "failure_handling.v1",
+      "baseline_sample_id": "jv_safety_good",
+      "perturbed_sample_id": "jv_safety_bad",
+      "expected_direction": "baseline_higher",
+      "minimum_margin": 1
     }
   ],
   "adversarial_pairs": [

--- a/bench/experiments/judge_validation/report.py
+++ b/bench/experiments/judge_validation/report.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import html
 import itertools
 import json
+import re
 from collections import defaultdict
 from pathlib import Path
 from statistics import mean
@@ -15,13 +16,14 @@ def _safe_mean(values: list[float]) -> float | None:
     return round(mean(values), 4) if values else None
 
 
-def _record_key(record: dict[str, Any]) -> tuple[str, str, str, str]:
+def _record_key(record: dict[str, Any]) -> tuple[str, str, str, str, str]:
     metadata = record.get("judge_metadata") or {}
     return (
         str(record.get("sample_id", "")),
         _record_rubric_id(record),
         _record_dimension(record),
         str(record.get("judge_model") or metadata.get("judge_model") or ""),
+        _record_prompt_variant(record),
     )
 
 
@@ -33,6 +35,15 @@ def _record_rubric_id(record: dict[str, Any]) -> str:
 def _record_dimension(record: dict[str, Any]) -> str:
     metadata = record.get("judge_metadata") or {}
     return str(record.get("dimension") or metadata.get("dimension") or "")
+
+
+def _record_prompt_variant(record: dict[str, Any]) -> str:
+    metadata = record.get("judge_metadata") or {}
+    return str(
+        record.get("prompt_variant_id")
+        or metadata.get("prompt_variant_id")
+        or "baseline"
+    )
 
 
 def _raw_score(record: dict[str, Any]) -> float | None:
@@ -62,13 +73,52 @@ def _records_by_sample(
     return by_sample
 
 
+def _text_tokens(record: dict[str, Any]) -> set[str]:
+    evidence = record.get("evidence") or []
+    if isinstance(evidence, list):
+        evidence_text = " ".join(str(item) for item in evidence)
+    else:
+        evidence_text = str(evidence)
+    text = f"{evidence_text} {record.get('reason') or ''}".lower()
+    return set(re.findall(r"[a-z0-9_]+", text))
+
+
+def _jaccard(left: set[str], right: set[str]) -> float | None:
+    if not left and not right:
+        return None
+    union = left | right
+    if not union:
+        return None
+    return len(left & right) / len(union)
+
+
+def _mean_scores_by_sample(
+    records: list[dict[str, Any]],
+    *,
+    sample_id: str,
+    rubric_id: str,
+    dimension: str,
+) -> list[float]:
+    return [
+        float(score)
+        for score in (
+            _raw_score(record)
+            for record in records
+            if str(record.get("sample_id", "")) == sample_id
+            and _record_rubric_id(record) == rubric_id
+            and _record_dimension(record) == dimension
+        )
+        if score is not None
+    ]
+
+
 def compute_reliability_stats(
     *,
     corpus: dict[str, Any],
     records: list[dict[str, Any]],
     pass_threshold: float | None = None,
 ) -> dict[str, Any]:
-    """Compute Stage 1 judge reliability metrics from repeated score records."""
+    """Compute judge reliability metrics from repeated score records."""
 
     threshold = float(pass_threshold or corpus.get("pass_threshold") or 3)
     successful = [
@@ -77,7 +127,9 @@ def compute_reliability_stats(
         if record.get("status") == "success" and _raw_score(record) is not None
     ]
 
-    grouped: dict[tuple[str, str, str, str], list[dict[str, Any]]] = defaultdict(list)
+    grouped: dict[tuple[str, str, str, str, str], list[dict[str, Any]]] = defaultdict(
+        list
+    )
     for record in successful:
         grouped[_record_key(record)].append(record)
 
@@ -100,13 +152,14 @@ def compute_reliability_stats(
         if flip:
             flip_groups += 1
         score_deltas.extend(pair_deltas)
-        sample_id, rubric_id, dimension, judge_model = key
+        sample_id, rubric_id, dimension, judge_model, prompt_variant_id = key
         stability_groups.append(
             {
                 "sample_id": sample_id,
                 "rubric_id": rubric_id,
                 "dimension": dimension,
                 "judge_model": judge_model,
+                "prompt_variant_id": prompt_variant_id,
                 "runs": len(clean_scores),
                 "scores": clean_scores,
                 "mean_score": _safe_mean(clean_scores),
@@ -114,6 +167,94 @@ def compute_reliability_stats(
                 "mean_delta": _safe_mean(pair_deltas),
                 "within_one": all(delta <= 1 for delta in pair_deltas),
                 "pass_fail_flip": flip,
+            }
+        )
+
+    variant_grouped: dict[
+        tuple[str, str, str, str], dict[str, list[dict[str, Any]]]
+    ] = defaultdict(lambda: defaultdict(list))
+    for record in successful:
+        variant_grouped[
+            (
+                str(record.get("sample_id", "")),
+                _record_rubric_id(record),
+                _record_dimension(record),
+                str(
+                    record.get("judge_model")
+                    or (record.get("judge_metadata") or {}).get("judge_model")
+                    or ""
+                ),
+            )
+        ][_record_prompt_variant(record)].append(record)
+
+    prompt_variant_rows: list[dict[str, Any]] = []
+    prompt_variant_deltas: list[float] = []
+    prompt_variant_flip_groups = 0
+    for key, variants in sorted(variant_grouped.items()):
+        if len(variants) < 2:
+            continue
+        variant_means: dict[str, float] = {}
+        for variant_id, variant_records in variants.items():
+            scores = [
+                score
+                for score in (_raw_score(record) for record in variant_records)
+                if score is not None
+            ]
+            mean_score = _safe_mean([float(score) for score in scores])
+            if mean_score is not None:
+                variant_means[variant_id] = mean_score
+        if len(variant_means) < 2:
+            continue
+        pair_deltas = [
+            abs(a - b) for a, b in itertools.combinations(variant_means.values(), 2)
+        ]
+        prompt_variant_deltas.extend(pair_deltas)
+        pass_values = {_pass(score, threshold) for score in variant_means.values()}
+        flip = len(pass_values) > 1
+        if flip:
+            prompt_variant_flip_groups += 1
+        sample_id, rubric_id, dimension, judge_model = key
+        prompt_variant_rows.append(
+            {
+                "sample_id": sample_id,
+                "rubric_id": rubric_id,
+                "dimension": dimension,
+                "judge_model": judge_model,
+                "variant_means": dict(sorted(variant_means.items())),
+                "max_variant_delta": round(max(pair_deltas), 4),
+                "mean_variant_delta": _safe_mean(pair_deltas),
+                "within_one": all(delta <= 1 for delta in pair_deltas),
+                "pass_fail_flip": flip,
+            }
+        )
+
+    consistency_groups: list[dict[str, Any]] = []
+    consistency_scores: list[float] = []
+    for key, group in sorted(grouped.items()):
+        if len(group) < 2:
+            continue
+        pair_scores = [
+            score
+            for score in (
+                _jaccard(_text_tokens(a), _text_tokens(b))
+                for a, b in itertools.combinations(group, 2)
+            )
+            if score is not None
+        ]
+        if not pair_scores:
+            continue
+        consistency_scores.extend(pair_scores)
+        sample_id, rubric_id, dimension, judge_model, prompt_variant_id = key
+        consistency_groups.append(
+            {
+                "sample_id": sample_id,
+                "rubric_id": rubric_id,
+                "dimension": dimension,
+                "judge_model": judge_model,
+                "prompt_variant_id": prompt_variant_id,
+                "runs": len(group),
+                "mean_pairwise_text_jaccard": _safe_mean(pair_scores),
+                "min_pairwise_text_jaccard": round(min(pair_scores), 4),
             }
         )
 
@@ -172,22 +313,90 @@ def compute_reliability_stats(
     ]
     pass_pairs = [row for row in comparable_pairs if row["status"] == "pass"]
 
+    sensitivity_rows: list[dict[str, Any]] = []
+    for case in corpus.get("sensitivity_cases", []):
+        baseline_id = str(case.get("baseline_sample_id", ""))
+        perturbed_id = str(case.get("perturbed_sample_id", ""))
+        rubric_id = str(case.get("registry_rubric_id", ""))
+        dimension = str(case.get("dimension", ""))
+        minimum_margin = float(case.get("minimum_margin", 0))
+        baseline_scores = _mean_scores_by_sample(
+            successful,
+            sample_id=baseline_id,
+            rubric_id=rubric_id,
+            dimension=dimension,
+        )
+        perturbed_scores = _mean_scores_by_sample(
+            successful,
+            sample_id=perturbed_id,
+            rubric_id=rubric_id,
+            dimension=dimension,
+        )
+        baseline_mean = _safe_mean(baseline_scores)
+        perturbed_mean = _safe_mean(perturbed_scores)
+        comparable = baseline_mean is not None and perturbed_mean is not None
+        expected_direction = str(case.get("expected_direction", "baseline_higher"))
+        margin = round(baseline_mean - perturbed_mean, 4) if comparable else None
+        if not comparable:
+            status = "missing"
+        elif expected_direction == "perturbed_higher":
+            status = "pass" if margin <= -minimum_margin else "fail"
+        else:
+            status = "pass" if margin >= minimum_margin else "fail"
+        sensitivity_rows.append(
+            {
+                "case_id": case.get("case_id"),
+                "factor": case.get("factor"),
+                "registry_rubric_id": rubric_id,
+                "dimension": dimension,
+                "baseline_sample_id": baseline_id,
+                "perturbed_sample_id": perturbed_id,
+                "baseline_mean": baseline_mean,
+                "perturbed_mean": perturbed_mean,
+                "score_margin": margin,
+                "minimum_margin": minimum_margin,
+                "expected_direction": expected_direction,
+                "status": status,
+            }
+        )
+
+    comparable_sensitivity = [
+        row for row in sensitivity_rows if row["status"] in {"pass", "fail"}
+    ]
+    pass_sensitivity = [
+        row for row in comparable_sensitivity if row["status"] == "pass"
+    ]
+
     large_disagreements = [
         row for row in stability_groups if row["max_delta"] >= 2
     ]
     adversarial_failures = [
         row for row in adversarial_rows if row["status"] != "pass"
     ]
+    sensitivity_failures = [
+        row for row in sensitivity_rows if row["status"] != "pass"
+    ]
+    low_consistency_examples = [
+        row
+        for row in consistency_groups
+        if (
+            row["mean_pairwise_text_jaccard"] is not None
+            and row["mean_pairwise_text_jaccard"] < 0.2
+        )
+    ]
 
     return {
-        "version": "judge_validation_stats_v1",
+        "version": "judge_validation_stats_v2",
         "counts": {
             "corpus_items": len(corpus.get("items", [])),
             "records": len(records),
             "successful_records": len(successful),
             "stability_groups": len(stability_groups),
+            "prompt_variant_groups": len(prompt_variant_rows),
             "adversarial_pairs": len(corpus.get("adversarial_pairs", [])),
             "comparable_adversarial_pairs": len(comparable_pairs),
+            "sensitivity_cases": len(corpus.get("sensitivity_cases", [])),
+            "comparable_sensitivity_cases": len(comparable_sensitivity),
         },
         "pass_threshold": threshold,
         "stability": {
@@ -209,6 +418,24 @@ def compute_reliability_stats(
             "large_disagreement_examples": large_disagreements[:25],
             "groups": stability_groups,
         },
+        "prompt_format": {
+            "mean_absolute_variant_delta": _safe_mean(prompt_variant_deltas),
+            "within_one_variant_rate": (
+                round(
+                    sum(1 for delta in prompt_variant_deltas if delta <= 1)
+                    / len(prompt_variant_deltas),
+                    4,
+                )
+                if prompt_variant_deltas
+                else None
+            ),
+            "pass_fail_variant_flip_rate": (
+                round(prompt_variant_flip_groups / len(prompt_variant_rows), 4)
+                if prompt_variant_rows
+                else None
+            ),
+            "groups": prompt_variant_rows,
+        },
         "adversarial": {
             "ranking_pass_rate": (
                 round(len(pass_pairs) / len(comparable_pairs), 4)
@@ -218,10 +445,42 @@ def compute_reliability_stats(
             "pairs": adversarial_rows,
             "failure_examples": adversarial_failures[:25],
         },
+        "sensitivity": {
+            "pass_rate": (
+                round(len(pass_sensitivity) / len(comparable_sensitivity), 4)
+                if comparable_sensitivity
+                else None
+            ),
+            "cases": sensitivity_rows,
+            "failure_examples": sensitivity_failures[:25],
+        },
+        "evidence_consistency": {
+            "evidence_coverage_rate": (
+                round(
+                    sum(1 for record in successful if record.get("evidence"))
+                    / len(successful),
+                    4,
+                )
+                if successful
+                else None
+            ),
+            "reason_coverage_rate": (
+                round(
+                    sum(1 for record in successful if record.get("reason"))
+                    / len(successful),
+                    4,
+                )
+                if successful
+                else None
+            ),
+            "mean_pairwise_text_jaccard": _safe_mean(consistency_scores),
+            "groups": consistency_groups,
+            "low_consistency_examples": low_consistency_examples[:25],
+        },
         "residual_risks": [
-            "Stage 1 validates repeated same-prompt stability and obvious pair ranking only.",
-            "Human quant expert alignment, prompt-order sensitivity, and multi-judge comparisons belong to later stages.",
-            "Synthetic adversarial pairs catch clear failures and underrepresent ambiguous real transcripts.",
+            "Automated robustness checks use a compact pilot corpus and should be expanded with more completed transcripts.",
+            "Evidence consistency uses lexical overlap as a lightweight proxy for explanation stability.",
+            "Human quant expert alignment belongs to the next validation stage after automated robustness artifacts are stable.",
         ],
     }
 
@@ -239,10 +498,13 @@ def _table(headers: list[str], rows: list[list[Any]]) -> str:
 
 def markdown_report(stats: dict[str, Any], *, run_id: str = "") -> str:
     stability = stats["stability"]
+    prompt_format = stats["prompt_format"]
     adversarial = stats["adversarial"]
+    sensitivity = stats["sensitivity"]
+    evidence = stats["evidence_consistency"]
     counts = stats["counts"]
     lines = [
-        "# Judge Reliability Stage 1 Report",
+        "# Judge Reliability Report",
         "",
         f"- Run ID: {run_id or 'unrecorded'}",
         f"- Corpus items: {counts['corpus_items']}",
@@ -251,13 +513,78 @@ def markdown_report(stats: dict[str, Any], *, run_id: str = "") -> str:
         f"- Mean absolute score delta: {stability['mean_absolute_score_delta']}",
         f"- Within-one score rate: {stability['within_one_score_rate']}",
         f"- Pass/fail flip rate: {stability['pass_fail_flip_rate']}",
+        f"- Prompt-format mean variant delta: {prompt_format['mean_absolute_variant_delta']}",
+        f"- Prompt-format within-one rate: {prompt_format['within_one_variant_rate']}",
+        f"- Prompt-format pass/fail flip rate: {prompt_format['pass_fail_variant_flip_rate']}",
         f"- Adversarial ranking pass rate: {adversarial['ranking_pass_rate']}",
+        f"- Sensitivity pass rate: {sensitivity['pass_rate']}",
+        f"- Evidence coverage rate: {evidence['evidence_coverage_rate']}",
+        f"- Reason coverage rate: {evidence['reason_coverage_rate']}",
+        f"- Evidence/reason consistency: {evidence['mean_pairwise_text_jaccard']}",
         "",
-        "## Adversarial Pairs",
+        "## Prompt Format Robustness",
         "",
-        "| Pair | Rubric | Stronger Mean | Weaker Mean | Margin | Status |",
-        "| --- | --- | ---: | ---: | ---: | --- |",
+        "| Sample | Rubric | Variant Means | Max Delta | Flip |",
+        "| --- | --- | --- | ---: | --- |",
     ]
+    for row in prompt_format["groups"]:
+        lines.append(
+            "| {sample_id} | {rubric} | {means} | {delta} | {flip} |".format(
+                sample_id=row.get("sample_id"),
+                rubric=row.get("rubric_id"),
+                means=json.dumps(row.get("variant_means"), sort_keys=True),
+                delta=row.get("max_variant_delta"),
+                flip=row.get("pass_fail_flip"),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Sensitivity Cases",
+            "",
+            "| Case | Factor | Baseline Mean | Perturbed Mean | Margin | Status |",
+            "| --- | --- | ---: | ---: | ---: | --- |",
+        ]
+    )
+    for row in sensitivity["cases"]:
+        lines.append(
+            "| {case_id} | {factor} | {baseline} | {perturbed} | {margin} | {status} |".format(
+                case_id=row.get("case_id"),
+                factor=row.get("factor"),
+                baseline=row.get("baseline_mean"),
+                perturbed=row.get("perturbed_mean"),
+                margin=row.get("score_margin"),
+                status=row.get("status"),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Evidence Consistency",
+            "",
+            "| Sample | Rubric | Variant | Mean Jaccard | Min Jaccard |",
+            "| --- | --- | --- | ---: | ---: |",
+        ]
+    )
+    for row in evidence["low_consistency_examples"]:
+        lines.append(
+            "| {sample_id} | {rubric} | {variant} | {mean_score} | {min_score} |".format(
+                sample_id=row.get("sample_id"),
+                rubric=row.get("rubric_id"),
+                variant=row.get("prompt_variant_id"),
+                mean_score=row.get("mean_pairwise_text_jaccard"),
+                min_score=row.get("min_pairwise_text_jaccard"),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Adversarial Pairs",
+            "",
+            "| Pair | Rubric | Stronger Mean | Weaker Mean | Margin | Status |",
+            "| --- | --- | ---: | ---: | ---: | --- |",
+        ]
+    )
     for row in adversarial["pairs"]:
         lines.append(
             "| {pair_id} | {rubric} | {stronger} | {weaker} | {margin} | {status} |".format(
@@ -278,8 +605,42 @@ def markdown_report(stats: dict[str, Any], *, run_id: str = "") -> str:
 
 def html_report(stats: dict[str, Any], *, run_id: str = "") -> str:
     stability = stats["stability"]
+    prompt_format = stats["prompt_format"]
     adversarial = stats["adversarial"]
+    sensitivity = stats["sensitivity"]
+    evidence = stats["evidence_consistency"]
     counts = stats["counts"]
+    variant_rows = [
+        [
+            row.get("sample_id"),
+            row.get("rubric_id"),
+            json.dumps(row.get("variant_means"), sort_keys=True),
+            row.get("max_variant_delta"),
+            row.get("pass_fail_flip"),
+        ]
+        for row in prompt_format["groups"]
+    ]
+    sensitivity_rows = [
+        [
+            row.get("case_id"),
+            row.get("factor"),
+            row.get("baseline_mean"),
+            row.get("perturbed_mean"),
+            row.get("score_margin"),
+            row.get("status"),
+        ]
+        for row in sensitivity["cases"]
+    ]
+    consistency_rows = [
+        [
+            row.get("sample_id"),
+            row.get("rubric_id"),
+            row.get("prompt_variant_id"),
+            row.get("mean_pairwise_text_jaccard"),
+            row.get("min_pairwise_text_jaccard"),
+        ]
+        for row in evidence["low_consistency_examples"]
+    ]
     pair_rows = [
         [
             row.get("pair_id"),
@@ -307,7 +668,7 @@ def html_report(stats: dict[str, Any], *, run_id: str = "") -> str:
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Judge Reliability Stage 1</title>
+  <title>Judge Reliability</title>
   <style>
     body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 32px; color: #1f2933; }}
     h1, h2 {{ color: #102a43; }}
@@ -320,7 +681,7 @@ def html_report(stats: dict[str, Any], *, run_id: str = "") -> str:
   </style>
 </head>
 <body>
-  <h1>Judge Reliability Stage 1</h1>
+  <h1>Judge Reliability</h1>
   <p>Run ID: <code>{html.escape(run_id or "unrecorded")}</code></p>
   <div class="cards">
     <div class="card"><div>Corpus Items</div><div class="metric">{counts["corpus_items"]}</div></div>
@@ -328,8 +689,18 @@ def html_report(stats: dict[str, Any], *, run_id: str = "") -> str:
     <div class="card"><div>Mean Delta</div><div class="metric">{stability["mean_absolute_score_delta"]}</div></div>
     <div class="card"><div>Within-One</div><div class="metric">{stability["within_one_score_rate"]}</div></div>
     <div class="card"><div>Flip Rate</div><div class="metric">{stability["pass_fail_flip_rate"]}</div></div>
+    <div class="card"><div>Prompt Variant Delta</div><div class="metric">{prompt_format["mean_absolute_variant_delta"]}</div></div>
     <div class="card"><div>Pair Pass Rate</div><div class="metric">{adversarial["ranking_pass_rate"]}</div></div>
+    <div class="card"><div>Sensitivity Pass Rate</div><div class="metric">{sensitivity["pass_rate"]}</div></div>
+    <div class="card"><div>Evidence Coverage</div><div class="metric">{evidence["evidence_coverage_rate"]}</div></div>
+    <div class="card"><div>Reason Coverage</div><div class="metric">{evidence["reason_coverage_rate"]}</div></div>
   </div>
+  <h2>Prompt Format Robustness</h2>
+  {_table(["Sample", "Rubric", "Variant Means", "Max Delta", "Flip"], variant_rows)}
+  <h2>Sensitivity Cases</h2>
+  {_table(["Case", "Factor", "Baseline Mean", "Perturbed Mean", "Margin", "Status"], sensitivity_rows)}
+  <h2>Evidence Consistency</h2>
+  {_table(["Sample", "Rubric", "Variant", "Mean Jaccard", "Min Jaccard"], consistency_rows)}
   <h2>Adversarial Pair Ranking</h2>
   {_table(["Pair", "Rubric", "Stronger Mean", "Weaker Mean", "Margin", "Status"], pair_rows)}
   <h2>Large Stability Disagreements</h2>

--- a/bench/experiments/judge_validation/run.py
+++ b/bench/experiments/judge_validation/run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Stage 1 judge reliability validation runner."""
+"""Judge reliability validation runner."""
 
 from __future__ import annotations
 
@@ -40,6 +40,12 @@ from server.eval.judges.runtime.model_resolver import resolve_ewan_model  # noqa
 DEFAULT_CORPUS = Path(__file__).resolve().parent / "pilot_corpus.json"
 DEFAULT_OUTPUT_DIR = Path("experiments/judge_validation/results")
 DEFAULT_REPEAT_COUNT = 3
+DEFAULT_PROMPT_VARIANT = "baseline"
+SUPPORTED_PROMPT_VARIANTS = {
+    "baseline",
+    "role_blocks",
+    "markdown_transcript",
+}
 
 
 def _resolve(path: str | Path) -> Path:
@@ -67,13 +73,75 @@ def _atomic_write_json(path: Path, data: Any) -> None:
     tmp.replace(path)
 
 
-def _conversation_context(item: dict[str, Any]) -> str:
+def _split_csv(value: str | list[str] | tuple[str, ...]) -> list[str]:
+    if isinstance(value, (list, tuple)):
+        parts = [str(part).strip() for part in value]
+    else:
+        parts = [part.strip() for part in str(value).split(",")]
+    return [part for part in parts if part]
+
+
+def _prompt_variants(value: str | list[str] | tuple[str, ...]) -> list[str]:
+    variants = _split_csv(value)
+    unknown = sorted(set(variants) - SUPPORTED_PROMPT_VARIANTS)
+    if unknown:
+        known = ", ".join(sorted(SUPPORTED_PROMPT_VARIANTS))
+        raise ValueError(f"Unsupported prompt variants {unknown}; choose from {known}")
+    return variants or [DEFAULT_PROMPT_VARIANT]
+
+
+def _prompt_variants_for_item(
+    item: dict[str, Any],
+    requested_variants: list[str],
+) -> list[str]:
     if item.get("context"):
-        return str(item["context"])
-    turns = [
+        return [DEFAULT_PROMPT_VARIANT]
+    return list(requested_variants)
+
+
+def _turns(item: dict[str, Any]) -> list[Turn]:
+    return [
         Turn(role=str(turn.get("role", "")), content=str(turn.get("content", "")))
         for turn in item.get("conversation", [])
     ]
+
+
+def _format_turns_role_blocks(turns: list[Turn]) -> str:
+    blocks = []
+    for index, turn in enumerate(turns, start=1):
+        role = turn.role.title() if turn.role else "Unknown"
+        blocks.append(f"Turn {index} - {role}\n{turn.content}")
+    return "\n\n".join(blocks)
+
+
+def _format_turns_markdown(turns: list[Turn]) -> str:
+    blocks = []
+    for index, turn in enumerate(turns, start=1):
+        role = turn.role.title() if turn.role else "Unknown"
+        blocks.append(f"### Turn {index}: {role}\n\n{turn.content}")
+    return "\n\n".join(blocks)
+
+
+def _conversation_context(
+    item: dict[str, Any],
+    *,
+    prompt_variant_id: str = DEFAULT_PROMPT_VARIANT,
+) -> str:
+    if prompt_variant_id not in SUPPORTED_PROMPT_VARIANTS:
+        known = ", ".join(sorted(SUPPORTED_PROMPT_VARIANTS))
+        raise ValueError(
+            f"Unsupported prompt variant {prompt_variant_id}; choose from {known}"
+        )
+
+    turns = _turns(item)
+
+    if item.get("context"):
+        return str(item["context"])
+
+    if prompt_variant_id == "role_blocks":
+        return _format_turns_role_blocks(turns)
+    if prompt_variant_id == "markdown_transcript":
+        return _format_turns_markdown(turns)
     return format_turns(turns)
 
 
@@ -87,7 +155,12 @@ def _rules_text(rules: list[str] | str) -> str:
     return str(rules)
 
 
-def _metric_for_item(item: dict[str, Any], *, model: str) -> EwanConvGEval:
+def _metric_for_item(
+    item: dict[str, Any],
+    *,
+    model: str,
+    prompt_variant_id: str = DEFAULT_PROMPT_VARIANT,
+) -> EwanConvGEval:
     track = item["track"]
     dimension = item["dimension"]
     category = item.get("category")
@@ -105,7 +178,10 @@ def _metric_for_item(item: dict[str, Any], *, model: str) -> EwanConvGEval:
             rubric_name="tutor_6d",
             context_fields=context_fields,
             transcript_source=transcript_source,
-            extra={"registry_rubric_id": item.get("registry_rubric_id")},
+            extra={
+                "registry_rubric_id": item.get("registry_rubric_id"),
+                "prompt_variant_id": prompt_variant_id,
+            },
         )
         return EwanConvGEval(
             name=dimension,
@@ -129,6 +205,7 @@ def _metric_for_item(item: dict[str, Any], *, model: str) -> EwanConvGEval:
         params["rubric_metadata"]["registry_rubric_id"] = item.get(
             "registry_rubric_id"
         )
+        params["rubric_metadata"]["prompt_variant_id"] = prompt_variant_id
         return EwanConvGEval(
             name=dimension,
             model=model_obj,
@@ -151,6 +228,7 @@ def _record_base(
     item: dict[str, Any],
     run_index: int,
     metric: EwanConvGEval,
+    prompt_variant_id: str = DEFAULT_PROMPT_VARIANT,
 ) -> dict[str, Any]:
     metadata = metric.judge_metadata()
     metadata["run_timestamp"] = datetime.now(timezone.utc).isoformat()
@@ -167,6 +245,7 @@ def _record_base(
         "registry_rubric_id": item.get("registry_rubric_id"),
         "transcript_source": item.get("transcript_source"),
         "run_index": run_index,
+        "prompt_variant_id": prompt_variant_id,
         "judge_model": metadata.get("judge_model"),
         "judge_metadata": metadata,
     }
@@ -179,28 +258,39 @@ def _render(args: argparse.Namespace) -> int:
         f"jv_render_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
     )
     prompts: list[dict[str, Any]] = []
+    prompt_variants = _prompt_variants(args.prompt_variants)
     for item in corpus.get("items", []):
-        context = _conversation_context(item)
-        test_case = EvalTestCase(context=context)
-        metric = _metric_for_item(item, model=args.model)
-        for run_index in range(args.repeats):
-            prompts.append(
-                {
-                    **_record_base(
-                        run_id=run_id,
-                        item=item,
-                        run_index=run_index,
-                        metric=metric,
-                    ),
-                    "prompt": metric.render_prompt(test_case),
-                }
+        for prompt_variant_id in _prompt_variants_for_item(item, prompt_variants):
+            context = _conversation_context(
+                item,
+                prompt_variant_id=prompt_variant_id,
             )
+            test_case = EvalTestCase(context=context)
+            metric = _metric_for_item(
+                item,
+                model=args.model,
+                prompt_variant_id=prompt_variant_id,
+            )
+            for run_index in range(args.repeats):
+                prompts.append(
+                    {
+                        **_record_base(
+                            run_id=run_id,
+                            item=item,
+                            run_index=run_index,
+                            metric=metric,
+                            prompt_variant_id=prompt_variant_id,
+                        ),
+                        "prompt": metric.render_prompt(test_case),
+                    }
+                )
 
     payload = {
         "version": "judge_validation_prompts_v1",
         "run_id": run_id,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "repeat_count": args.repeats,
+        "prompt_variants": prompt_variants,
         "counts": {"prompts": len(prompts)},
         "prompts": prompts,
     }
@@ -221,19 +311,34 @@ async def _judge_one(
     item: dict[str, Any],
     run_index: int,
     model: str,
+    prompt_variant_id: str = DEFAULT_PROMPT_VARIANT,
 ) -> dict[str, Any]:
-    metric = _metric_for_item(item, model=model)
+    metric = _metric_for_item(
+        item,
+        model=model,
+        prompt_variant_id=prompt_variant_id,
+    )
     base = _record_base(
         run_id=run_id,
         item=item,
         run_index=run_index,
         metric=metric,
+        prompt_variant_id=prompt_variant_id,
     )
     start = time.time()
     try:
         result = await llm_call_with_retry(
-            lambda: _metric_for_item(item, model=model),
-            EvalTestCase(context=_conversation_context(item)),
+            lambda: _metric_for_item(
+                item,
+                model=model,
+                prompt_variant_id=prompt_variant_id,
+            ),
+            EvalTestCase(
+                context=_conversation_context(
+                    item,
+                    prompt_variant_id=prompt_variant_id,
+                )
+            ),
             dimension_name=str(item.get("dimension", "")),
         )
         metadata = result.get("judge_metadata") or metric.judge_metadata()
@@ -278,14 +383,17 @@ def _judge(args: argparse.Namespace) -> int:
     run_id = args.run_id or (
         f"jv_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
     )
+    prompt_variants = _prompt_variants(args.prompt_variants)
     tasks = [
         _judge_one(
             run_id=run_id,
             item=item,
             run_index=run_index,
             model=args.model,
+            prompt_variant_id=prompt_variant_id,
         )
         for item in corpus.get("items", [])
+        for prompt_variant_id in _prompt_variants_for_item(item, prompt_variants)
         for run_index in range(args.repeats)
     ]
 
@@ -305,6 +413,7 @@ def _judge(args: argparse.Namespace) -> int:
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "judge_model": args.model,
         "repeat_count": args.repeats,
+        "prompt_variants": prompt_variants,
         "counts": {
             "records": len(records),
             "success": sum(1 for record in records if record["status"] == "success"),
@@ -342,8 +451,33 @@ def _report(args: argparse.Namespace) -> int:
                 "markdown": paths["markdown"],
                 "html": paths["html"],
                 "stability": stats["stability"],
+                "prompt_format": {
+                    "mean_absolute_variant_delta": stats["prompt_format"][
+                        "mean_absolute_variant_delta"
+                    ],
+                    "within_one_variant_rate": stats["prompt_format"][
+                        "within_one_variant_rate"
+                    ],
+                    "pass_fail_variant_flip_rate": stats["prompt_format"][
+                        "pass_fail_variant_flip_rate"
+                    ],
+                },
                 "adversarial": {
                     "ranking_pass_rate": stats["adversarial"]["ranking_pass_rate"]
+                },
+                "sensitivity": {
+                    "pass_rate": stats["sensitivity"]["pass_rate"]
+                },
+                "evidence_consistency": {
+                    "evidence_coverage_rate": stats["evidence_consistency"][
+                        "evidence_coverage_rate"
+                    ],
+                    "reason_coverage_rate": stats["evidence_consistency"][
+                        "reason_coverage_rate"
+                    ],
+                    "mean_pairwise_text_jaccard": stats["evidence_consistency"][
+                        "mean_pairwise_text_jaccard"
+                    ],
                 },
             },
             indent=2,
@@ -355,14 +489,22 @@ def _report(args: argparse.Namespace) -> int:
 def _dry_run(args: argparse.Namespace) -> int:
     corpus = _load_json(_resolve(args.corpus))
     pairs = corpus.get("adversarial_pairs", [])
+    sensitivity_cases = corpus.get("sensitivity_cases", [])
     items = corpus.get("items", [])
+    prompt_variants = _prompt_variants(args.prompt_variants)
+    planned_records = sum(
+        len(_prompt_variants_for_item(item, prompt_variants)) * args.repeats
+        for item in items
+    )
     print(
         json.dumps(
             {
                 "corpus": str(_resolve(args.corpus)),
                 "items": len(items),
                 "adversarial_pairs": len(pairs),
-                "planned_judge_records": len(items) * args.repeats,
+                "sensitivity_cases": len(sensitivity_cases),
+                "prompt_variants": prompt_variants,
+                "planned_judge_records": planned_records,
                 "repeat_count": args.repeats,
             },
             indent=2,
@@ -378,6 +520,7 @@ def _make_parser() -> argparse.ArgumentParser:
     parser.add_argument("--model", default="anthropic/claude-sonnet-4-6")
     parser.add_argument("--repeats", type=int, default=DEFAULT_REPEAT_COUNT)
     parser.add_argument("--run-id", default=None)
+    parser.add_argument("--prompt-variants", default=DEFAULT_PROMPT_VARIANT)
     sub = parser.add_subparsers(dest="command", required=True)
 
     def add_common(p: argparse.ArgumentParser) -> None:
@@ -386,6 +529,7 @@ def _make_parser() -> argparse.ArgumentParser:
         p.add_argument("--model", default=argparse.SUPPRESS)
         p.add_argument("--repeats", type=int, default=argparse.SUPPRESS)
         p.add_argument("--run-id", default=argparse.SUPPRESS)
+        p.add_argument("--prompt-variants", default=argparse.SUPPRESS)
 
     dry_run_p = sub.add_parser("dry-run")
     add_common(dry_run_p)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,11 +132,13 @@ If a batch driver is needed, it should be a thin wrapper around
 
 ## Judge Validation
 
-`bench/experiments/judge_validation/` is the Stage 1 judge reliability gate for
+`bench/experiments/judge_validation/` is the automated judge reliability gate for
 external-agent scoring. It owns a fixed pilot corpus, prompt rendering, repeated
-same-prompt judge runs, adversarial-pair ranking checks, and Markdown/HTML/JSON
-reliability reports. The Stage 1 report tracks mean absolute score delta,
-within-one score rate, pass/fail flip rate, adversarial ranking pass rate, raw
+same-prompt judge runs, prompt-format variants, one-factor sensitivity cases,
+adversarial-pair ranking checks, and Markdown/HTML/JSON reliability reports. The
+report tracks mean absolute score delta, within-one score rate, pass/fail flip
+rate, prompt-format score deltas, sensitivity pass rate, adversarial ranking
+pass rate, evidence/reason coverage, lightweight explanation consistency, raw
 disagreement examples, and residual risks.
 
 ## Public Reads

--- a/tests/test_judge_validation.py
+++ b/tests/test_judge_validation.py
@@ -67,6 +67,23 @@ def test_pilot_corpus_items_match_registry_mappings():
         assert key in mapped[item["registry_rubric_id"]]
 
 
+def test_pilot_corpus_declares_stage2_sensitivity_cases():
+    root = Path(__file__).parent.parent
+    corpus = json.loads(
+        (
+            root / "bench/experiments/judge_validation/pilot_corpus.json"
+        ).read_text(encoding="utf-8")
+    )
+    sample_ids = {item["sample_id"] for item in corpus["items"]}
+
+    assert len(corpus["sensitivity_cases"]) >= 6
+    for case in corpus["sensitivity_cases"]:
+        assert case["baseline_sample_id"] in sample_ids
+        assert case["perturbed_sample_id"] in sample_ids
+        assert case["expected_direction"] == "baseline_higher"
+        assert case["minimum_margin"] >= 0
+
+
 def test_explicit_context_items_record_context_metadata():
     root = Path(__file__).parent.parent
     corpus = json.loads(
@@ -78,7 +95,74 @@ def test_explicit_context_items_record_context_metadata():
     metric = judge_run._metric_for_item(item, model="judge-model")
 
     assert judge_run._conversation_context(item).startswith("## Task")
+    assert judge_run._conversation_context(
+        item,
+        prompt_variant_id="role_blocks",
+    ) == judge_run._conversation_context(item)
     assert metric.judge_metadata()["context_fields_included"] == ["context"]
+
+
+def test_prompt_variant_context_rendering_preserves_metadata():
+    root = Path(__file__).parent.parent
+    corpus = json.loads(
+        (
+            root / "bench/experiments/judge_validation/pilot_corpus.json"
+        ).read_text(encoding="utf-8")
+    )
+    item = next(i for i in corpus["items"] if i["sample_id"] == "jv_quant_correct_good")
+    context = judge_run._conversation_context(item, prompt_variant_id="role_blocks")
+    metric = judge_run._metric_for_item(
+        item,
+        model="judge-model",
+        prompt_variant_id="role_blocks",
+    )
+
+    assert "Turn 1 - User" in context
+    assert "Turn 2 - Assistant" in context
+    assert metric.judge_metadata()["prompt_variant_id"] == "role_blocks"
+
+
+def test_render_expands_prompt_variants(tmp_path):
+    root = Path(__file__).parent.parent
+    corpus_path = root / "bench/experiments/judge_validation/pilot_corpus.json"
+    corpus = json.loads(corpus_path.read_text(encoding="utf-8"))
+
+    rc = judge_run.main(
+        [
+            "--corpus",
+            str(corpus_path),
+            "--output-dir",
+            str(tmp_path),
+            "--repeats",
+            "1",
+            "--prompt-variants",
+            "baseline,role_blocks",
+            "render",
+        ]
+    )
+    payload = json.loads((tmp_path / "judge_inputs.json").read_text(encoding="utf-8"))
+
+    assert rc == 0
+    assert payload["prompt_variants"] == ["baseline", "role_blocks"]
+    expected_prompts = sum(
+        1 if item.get("context") else 2
+        for item in corpus["items"]
+    )
+    assert payload["counts"]["prompts"] == expected_prompts
+    assert {row["prompt_variant_id"] for row in payload["prompts"]} == {
+        "baseline",
+        "role_blocks",
+    }
+    context_prompt_variants = {
+        row["prompt_variant_id"]
+        for row in payload["prompts"]
+        if next(
+            item
+            for item in corpus["items"]
+            if item["sample_id"] == row["sample_id"]
+        ).get("context")
+    }
+    assert context_prompt_variants == {"baseline"}
 
 
 def test_failed_validation_judge_record_preserves_retry_diagnostics(monkeypatch):
@@ -194,6 +278,97 @@ def test_reliability_stats_compute_stability_and_adversarial_pass_rate():
     assert stats["stability"]["within_one_score_rate"] == 1.0
     assert stats["stability"]["pass_fail_flip_rate"] == 0.0
     assert stats["adversarial"]["ranking_pass_rate"] == 1.0
+
+
+def test_reliability_stats_compute_stage2_robustness_metrics():
+    corpus = {
+        "pass_threshold": 3,
+        "items": [{"sample_id": "strong"}, {"sample_id": "weak"}],
+        "sensitivity_cases": [
+            {
+                "case_id": "sens",
+                "factor": "quant_error_only",
+                "registry_rubric_id": "quant_correctness.v1",
+                "dimension": "D4_instructional_accuracy",
+                "baseline_sample_id": "strong",
+                "perturbed_sample_id": "weak",
+                "expected_direction": "baseline_higher",
+                "minimum_margin": 1,
+            }
+        ],
+    }
+    records = [
+        {
+            "sample_id": "strong",
+            "registry_rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "judge_model": "judge",
+            "prompt_variant_id": "baseline",
+            "run_index": 0,
+            "status": "success",
+            "raw_score": 5,
+            "evidence": ["shift the signal by one day"],
+            "reason": "Correctly catches lookahead timing.",
+        },
+        {
+            "sample_id": "strong",
+            "registry_rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "judge_model": "judge",
+            "prompt_variant_id": "baseline",
+            "run_index": 1,
+            "status": "success",
+            "raw_score": 5,
+            "evidence": ["signal is shifted by one day"],
+            "reason": "Correctly identifies lookahead timing.",
+        },
+        {
+            "sample_id": "strong",
+            "registry_rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "judge_model": "judge",
+            "prompt_variant_id": "role_blocks",
+            "run_index": 0,
+            "status": "success",
+            "raw_score": 4,
+            "evidence": ["uses prior-bar signal"],
+            "reason": "Still correct under role block formatting.",
+        },
+        {
+            "sample_id": "weak",
+            "registry_rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "judge_model": "judge",
+            "prompt_variant_id": "baseline",
+            "run_index": 0,
+            "status": "success",
+            "raw_score": 2,
+            "evidence": ["allows same-close trading"],
+            "reason": "The answer keeps lookahead bias.",
+        },
+        {
+            "sample_id": "weak",
+            "registry_rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "judge_model": "judge",
+            "prompt_variant_id": "role_blocks",
+            "run_index": 0,
+            "status": "success",
+            "raw_score": 2,
+            "evidence": ["same-close trading"],
+            "reason": "The answer keeps lookahead bias.",
+        },
+    ]
+    stats = compute_reliability_stats(corpus=corpus, records=records)
+
+    assert stats["prompt_format"]["mean_absolute_variant_delta"] == 0.5
+    assert stats["prompt_format"]["within_one_variant_rate"] == 1.0
+    assert stats["prompt_format"]["pass_fail_variant_flip_rate"] == 0.0
+    assert stats["sensitivity"]["pass_rate"] == 1.0
+    assert stats["sensitivity"]["cases"][0]["score_margin"] == 2.6667
+    assert stats["evidence_consistency"]["evidence_coverage_rate"] == 1.0
+    assert stats["evidence_consistency"]["reason_coverage_rate"] == 1.0
+    assert stats["evidence_consistency"]["mean_pairwise_text_jaccard"] is not None
 
 
 def test_adversarial_stats_filter_by_pair_rubric_and_dimension():


### PR DESCRIPTION
Refs #84

## Scope

- Adds prompt-format variants for conversation-backed validation items.
- Keeps explicit QR context items on the baseline payload so prompt-format metrics compare true formatting changes.
- Adds six one-factor sensitivity cases for quant error, broken code, beginner jargon, hallucinated tool output, answer dump, and failure-boundary removal.
- Adds two real-run transcript excerpts to the fixed corpus for repeated-run stability coverage.
- Extends reports with prompt-format deltas, sensitivity pass rate, evidence/reason coverage, and lightweight explanation consistency.
- Updates docs and tests for the Stage 2 gate.

## Verification

- pytest tests/test_judge_validation.py: 12 passed.
- pytest: 28 passed.
- python3 -m py_compile bench/experiments/judge_validation/run.py bench/experiments/judge_validation/report.py tests/test_judge_validation.py: passed.
- python3 -m experiments.judge_validation.run dry-run --repeats 2 --prompt-variants baseline,role_blocks: 14 items, 6 adversarial pairs, 6 sensitivity cases, 48 planned records.
- python3 -m experiments.judge_validation.run render --repeats 1 --prompt-variants baseline,role_blocks --output-dir /tmp/judge_validation_stage2_render2: 24 prompts rendered.
- git diff --check: passed.

## Review

- Codex review round 1 found extra evidence in QR prompt variants; fixed by preserving explicit context payloads.
- Codex review round 2 found duplicate variant labels on explicit context payloads; fixed by running context-backed items once under baseline.

## Next Stage

Human expert alignment remains the next #84 validation stage after automated robustness artifacts are stable.