### PR TITLE
Add judge human alignment reporting

### DIFF
--- a/bench/experiments/judge_validation/README.md
+++ b/bench/experiments/judge_validation/README.md
@@ -43,6 +43,17 @@ Render prompt inputs without calling a judge model:
 python -m experiments.judge_validation.run render
 ```
 
+Export the reviewer packet for expert labeling:
+
+```bash
+python -m experiments.judge_validation.run export-review-packet
+```
+
+This writes `human_review_packet.json`, `human_review_packet.md`,
+`google_form_bilingual.md`, `human_label_template.csv`, and the private
+`human_review_sample_map.json` under
+`experiments/judge_validation/results/human_review_packet/`.
+
 Run the Stage 1 judge gate with three repeats per item:
 
 ```bash
@@ -78,7 +89,8 @@ Generate the Stage 3 human-alignment report:
 ```bash
 python -m experiments.judge_validation.run human-alignment \
   --runs experiments/judge_validation/results/judge_runs.json \
-  --labels experiments/judge_validation/human_labels.json
+  --labels experiments/judge_validation/human_labels.json \
+  --sample-map experiments/judge_validation/results/human_review_packet/human_review_sample_map.json
 ```
 
 Outputs are written under `bench/experiments/judge_validation/results/` by default.

--- a/bench/experiments/judge_validation/README.md
+++ b/bench/experiments/judge_validation/README.md
@@ -5,6 +5,7 @@ This experiment validates the scoring judge before external-agent results depend
 This experiment provides:
 
 - a fixed pilot corpus in `pilot_corpus.json`
+- a human label schema and example artifact for expert review
 - rendered judge prompts with rubric and prompt metadata
 - repeated same-prompt judge runs
 - stability metrics: mean absolute score delta, within-one score rate, pass/fail flip rate
@@ -12,7 +13,21 @@ This experiment provides:
 - adversarial pair metrics: whether the stronger transcript scores higher
 - one-factor sensitivity metrics: whether targeted defects move the intended rubric score
 - evidence and reason coverage plus lightweight explanation consistency
+- human-alignment metrics against expert labels
 - Markdown, HTML, and machine-readable JSON reports
+
+## Rubrics and Validation Metrics
+
+Tutor/agent scoring rubrics define the rulebook for the transcript. Examples:
+`quant_correctness.v1`, `code_correctness.v1`, `teaching_quality.v1`,
+`student_adaptation.v1`, `tool_workspace_use.v1`, `failure_handling.v1`,
+`task_completion.v1`, and `final_outcome_quality.v1`.
+
+Judge-validation metrics evaluate the judge as the scorer applying that
+rulebook. They include repeated-run score delta, within-one agreement,
+pass/fail flip rate, adversarial ranking pass rate, prompt-format sensitivity,
+one-factor sensitivity pass rate, evidence consistency, and human expert
+alignment.
 
 ## Commands
 
@@ -50,8 +65,28 @@ Generate reports from `judge_runs.json`:
 python -m experiments.judge_validation.run report
 ```
 
+Convert a Google Form CSV export into the canonical label artifact:
+
+```bash
+python -m experiments.judge_validation.run convert-human-labels \
+  --csv reviewer_export.csv \
+  --labels-output experiments/judge_validation/human_labels.json
+```
+
+Generate the Stage 3 human-alignment report:
+
+```bash
+python -m experiments.judge_validation.run human-alignment \
+  --runs experiments/judge_validation/results/judge_runs.json \
+  --labels experiments/judge_validation/human_labels.json
+```
+
 Outputs are written under `bench/experiments/judge_validation/results/` by default.
 
 ## Scope
 
-The current automated gate covers repeated same-prompt stability, prompt-format robustness, one-factor sensitivity, obvious good-vs-bad adversarial ranking, and lightweight evidence consistency. Later stages add broader real-transcript sampling, rubric-order sensitivity where the protocol supports it, and human quant expert alignment.
+The current automated gate covers repeated same-prompt stability, prompt-format
+robustness, one-factor sensitivity, obvious good-vs-bad adversarial ranking,
+lightweight evidence consistency, and human-alignment reporting. Broader
+real-transcript sampling and rubric-order sensitivity can extend the same report
+shape.

--- a/bench/experiments/judge_validation/human_alignment.py
+++ b/bench/experiments/judge_validation/human_alignment.py
@@ -46,6 +46,18 @@ CSV_HEADER_ALIASES = {
     "notes": ("notes", "reviewer_notes"),
 }
 
+CANONICAL_FAILURE_TAGS = [
+    "quant_error",
+    "code_error",
+    "missing_task_completion",
+    "hallucinated_tool_output",
+    "poor_adaptation",
+    "answer_dump",
+    "unsafe_financial_advice",
+    "unclear_rubric",
+    "other",
+]
+
 
 def _safe_mean(values: list[float]) -> float | None:
     return round(mean(values), 4) if values else None
@@ -86,6 +98,41 @@ def _split_list(value: Any, *, split_commas: bool = False) -> list[str]:
     return [part.strip() for part in re.split(pattern, text) if part.strip()]
 
 
+def _normalize_confidence(value: str) -> str:
+    text = value.strip().lower()
+    tokens = set(re.findall(r"[a-z]+", text))
+    for confidence in ("low", "medium", "high"):
+        if confidence in tokens or text == confidence:
+            return confidence
+    if "低" in text:
+        return "low"
+    if "中" in text:
+        return "medium"
+    if "高" in text:
+        return "high"
+    raise ValueError(f"confidence must be low, medium, or high: {value}")
+
+
+def _normalize_failure_tags(values: list[str]) -> list[str]:
+    normalized_tags: list[str] = []
+    for value in values:
+        normalized = _normalize_header(value)
+        match = next(
+            (
+                tag
+                for tag in CANONICAL_FAILURE_TAGS
+                if normalized == tag
+                or normalized.startswith(f"{tag}_")
+                or normalized.endswith(f"_{tag}")
+                or f"_{tag}_" in normalized
+            ),
+            normalized,
+        )
+        if match and match not in normalized_tags:
+            normalized_tags.append(match)
+    return normalized_tags
+
+
 def _as_int_score(value: Any) -> int:
     if isinstance(value, bool):
         raise ValueError(f"human_score must be an integer from 1 to 5: {value}")
@@ -124,9 +171,7 @@ def normalize_human_label(
         raise ValueError(f"human label is missing required fields: {missing}")
 
     sample_id = _required_text(raw, "sample_id")
-    confidence = _required_text(raw, "confidence").lower()
-    if confidence not in {"low", "medium", "high"}:
-        raise ValueError(f"confidence must be low, medium, or high: {confidence}")
+    confidence = _normalize_confidence(_required_text(raw, "confidence"))
     label = {
         "sample_id": sample_id,
         "transcript_id": str(raw.get("transcript_id") or sample_id).strip(),
@@ -136,7 +181,9 @@ def normalize_human_label(
         "confidence": confidence,
         "human_rationale": _required_text(raw, "human_rationale"),
         "evidence_spans": _split_list(raw.get("evidence_spans")),
-        "failure_tags": _split_list(raw.get("failure_tags"), split_commas=True),
+        "failure_tags": _normalize_failure_tags(
+            _split_list(raw.get("failure_tags"), split_commas=True)
+        ),
         "reviewer_id": _required_text(raw, "reviewer_id"),
         "label_version": str(raw.get("label_version") or "v1").strip(),
         "timestamp": str(
@@ -151,9 +198,33 @@ def normalize_human_label(
 
 def _extract_csv_value(row: dict[str, str], canonical_field: str) -> str:
     aliases = CSV_HEADER_ALIASES[canonical_field]
+    if canonical_field == "reviewer_id":
+        for alias in ("reviewer_id", "reviewer", "reviewer_email"):
+            if alias in row:
+                return row[alias]
+        for alias in ("reviewer_id", "reviewer_email"):
+            for key, value in row.items():
+                if (
+                    key.startswith(f"{alias}_")
+                    or key.endswith(f"_{alias}")
+                    or f"_{alias}_" in key
+                ):
+                    return value
+        return row.get("email_address", "")
+
     for alias in aliases:
         if alias in row:
             return row[alias]
+    for alias in aliases:
+        if alias == "reviewer":
+            continue
+        for key, value in row.items():
+            if (
+                key.startswith(f"{alias}_")
+                or key.endswith(f"_{alias}")
+                or f"_{alias}_" in key
+            ):
+                return value
     return ""
 
 
@@ -203,6 +274,39 @@ def load_human_labels(path: Path) -> list[dict[str, Any]]:
     else:
         raise ValueError("human labels must be a list or an object with labels")
     return [normalize_human_label(label) for label in raw_labels]
+
+
+def load_sample_id_map(path: Path) -> dict[str, str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict):
+        rows = payload.get("mappings", [])
+    elif isinstance(payload, list):
+        rows = payload
+    else:
+        raise ValueError("sample ID map must be a list or an object with mappings")
+    return {
+        str(row.get("review_sample_id")): str(row.get("original_sample_id"))
+        for row in rows
+        if row.get("review_sample_id") and row.get("original_sample_id")
+    }
+
+
+def _apply_sample_id_map(
+    label: dict[str, Any],
+    sample_id_map: dict[str, str],
+) -> dict[str, Any]:
+    if not sample_id_map:
+        return label
+    review_sample_id = str(label.get("sample_id") or "")
+    original_sample_id = sample_id_map.get(review_sample_id)
+    if not original_sample_id:
+        return label
+    mapped = dict(label)
+    mapped["review_sample_id"] = review_sample_id
+    mapped["sample_id"] = original_sample_id
+    if str(mapped.get("transcript_id") or review_sample_id) == review_sample_id:
+        mapped["transcript_id"] = original_sample_id
+    return mapped
 
 
 def _nearest_score(score: float) -> int:
@@ -257,11 +361,15 @@ def compute_human_alignment_stats(
     records: list[dict[str, Any]],
     labels: list[dict[str, Any]],
     pass_threshold: float | None = None,
+    sample_id_map: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Compare successful judge scores against human expert labels."""
 
     threshold = float(pass_threshold or corpus.get("pass_threshold") or 3)
-    normalized_labels = [normalize_human_label(label) for label in labels]
+    normalized_labels = [
+        _apply_sample_id_map(normalize_human_label(label), sample_id_map or {})
+        for label in labels
+    ]
     item_index = {
         str(item.get("sample_id", "")): item
         for item in corpus.get("items", [])
@@ -313,6 +421,7 @@ def compute_human_alignment_stats(
             "persona_id": item.get("persona_id"),
             "transcript_source": item.get("transcript_source"),
             "reviewer_id": label["reviewer_id"],
+            "review_sample_id": label.get("review_sample_id"),
             "confidence": label["confidence"],
             "human_score": human_score,
             "judge_mean_score": judge_mean,

--- a/bench/experiments/judge_validation/human_alignment.py
+++ b/bench/experiments/judge_validation/human_alignment.py
@@ -1,0 +1,602 @@
+"""Human expert alignment metrics for judge validation."""
+
+from __future__ import annotations
+
+import csv
+import html
+import json
+import re
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean
+from typing import Any, Iterable
+
+from .report import _raw_score, _record_dimension, _record_rubric_id
+
+HUMAN_LABELS_VERSION = "judge_validation_human_labels_v1"
+HUMAN_ALIGNMENT_STATS_VERSION = "judge_validation_human_alignment_stats_v1"
+HUMAN_WITHIN_ONE_TARGET = 0.85
+HUMAN_PASS_FAIL_TARGET = 0.9
+LARGE_DISAGREEMENT_DELTA = 2.0
+
+REQUIRED_LABEL_FIELDS = {
+    "sample_id",
+    "rubric_id",
+    "dimension",
+    "human_score",
+    "confidence",
+    "human_rationale",
+    "reviewer_id",
+}
+
+CSV_HEADER_ALIASES = {
+    "timestamp": ("timestamp", "submission_time", "submitted_at"),
+    "reviewer_id": ("reviewer_id", "reviewer", "reviewer_email", "email_address"),
+    "sample_id": ("sample_id", "sample", "validation_sample_id"),
+    "transcript_id": ("transcript_id", "transcript", "conversation_id"),
+    "rubric_id": ("rubric_id", "registry_rubric_id", "rubric"),
+    "dimension": ("dimension", "judge_dimension"),
+    "human_score": ("human_score", "score", "human_rating"),
+    "confidence": ("confidence", "reviewer_confidence"),
+    "human_rationale": ("human_rationale", "rationale", "reviewer_rationale"),
+    "evidence_spans": ("evidence_spans", "evidence", "supporting_evidence"),
+    "failure_tags": ("failure_tags", "tags", "failure_modes"),
+    "label_version": ("label_version", "version"),
+    "notes": ("notes", "reviewer_notes"),
+}
+
+
+def _safe_mean(values: list[float]) -> float | None:
+    return round(mean(values), 4) if values else None
+
+
+def _rate(values: list[bool]) -> float | None:
+    if not values:
+        return None
+    return round(sum(1 for value in values if value) / len(values), 4)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_header(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.strip().lower()).strip("_")
+
+
+def _split_list(value: Any, *, split_commas: bool = False) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    text = str(value).strip()
+    if not text:
+        return []
+    if text.startswith("["):
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, list):
+            return [str(item).strip() for item in parsed if str(item).strip()]
+    pattern = r"[\n;|]+"
+    if split_commas:
+        pattern = r"[\n;|,]+"
+    return [part.strip() for part in re.split(pattern, text) if part.strip()]
+
+
+def _as_int_score(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"human_score must be an integer from 1 to 5: {value}")
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"human_score must be an integer from 1 to 5: {value}") from exc
+    if not numeric.is_integer():
+        raise ValueError(f"human_score must be an integer from 1 to 5: {value}")
+    score = int(numeric)
+    if score < 1 or score > 5:
+        raise ValueError(f"human_score must be an integer from 1 to 5: {value}")
+    return score
+
+
+def _required_text(raw: dict[str, Any], field: str) -> str:
+    value = raw.get(field)
+    if value is None or str(value).strip() == "":
+        raise ValueError(f"human label is missing required field: {field}")
+    return str(value).strip()
+
+
+def normalize_human_label(
+    raw: dict[str, Any],
+    *,
+    default_timestamp: str | None = None,
+) -> dict[str, Any]:
+    """Return a canonical human label record."""
+
+    missing = [
+        field
+        for field in sorted(REQUIRED_LABEL_FIELDS)
+        if raw.get(field) is None or str(raw.get(field)).strip() == ""
+    ]
+    if missing:
+        raise ValueError(f"human label is missing required fields: {missing}")
+
+    sample_id = _required_text(raw, "sample_id")
+    confidence = _required_text(raw, "confidence").lower()
+    if confidence not in {"low", "medium", "high"}:
+        raise ValueError(f"confidence must be low, medium, or high: {confidence}")
+    label = {
+        "sample_id": sample_id,
+        "transcript_id": str(raw.get("transcript_id") or sample_id).strip(),
+        "rubric_id": _required_text(raw, "rubric_id"),
+        "dimension": _required_text(raw, "dimension"),
+        "human_score": _as_int_score(raw.get("human_score")),
+        "confidence": confidence,
+        "human_rationale": _required_text(raw, "human_rationale"),
+        "evidence_spans": _split_list(raw.get("evidence_spans")),
+        "failure_tags": _split_list(raw.get("failure_tags"), split_commas=True),
+        "reviewer_id": _required_text(raw, "reviewer_id"),
+        "label_version": str(raw.get("label_version") or "v1").strip(),
+        "timestamp": str(
+            raw.get("timestamp") or default_timestamp or _utc_now()
+        ).strip(),
+    }
+    notes = str(raw.get("notes") or "").strip()
+    if notes:
+        label["notes"] = notes
+    return label
+
+
+def _extract_csv_value(row: dict[str, str], canonical_field: str) -> str:
+    aliases = CSV_HEADER_ALIASES[canonical_field]
+    for alias in aliases:
+        if alias in row:
+            return row[alias]
+    return ""
+
+
+def labels_from_csv_rows(
+    rows: Iterable[dict[str, str]],
+    *,
+    default_timestamp: str | None = None,
+) -> list[dict[str, Any]]:
+    """Normalize Google Form CSV rows into canonical label records."""
+
+    labels = []
+    for row in rows:
+        normalized_row = {_normalize_header(key): value for key, value in row.items()}
+        raw = {
+            field: _extract_csv_value(normalized_row, field)
+            for field in CSV_HEADER_ALIASES
+        }
+        labels.append(normalize_human_label(raw, default_timestamp=default_timestamp))
+    return labels
+
+
+def convert_csv_to_human_labels(
+    csv_path: Path,
+    *,
+    default_timestamp: str | None = None,
+) -> dict[str, Any]:
+    """Read a reviewer CSV export and return the canonical JSON payload."""
+
+    with csv_path.open(newline="", encoding="utf-8-sig") as fh:
+        labels = labels_from_csv_rows(
+            csv.DictReader(fh),
+            default_timestamp=default_timestamp,
+        )
+    return {
+        "version": HUMAN_LABELS_VERSION,
+        "generated_at": default_timestamp or _utc_now(),
+        "labels": labels,
+    }
+
+
+def load_human_labels(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        raw_labels = payload
+    elif isinstance(payload, dict) and isinstance(payload.get("labels"), list):
+        raw_labels = payload["labels"]
+    else:
+        raise ValueError("human labels must be a list or an object with labels")
+    return [normalize_human_label(label) for label in raw_labels]
+
+
+def _nearest_score(score: float) -> int:
+    return max(1, min(5, int(score + 0.5)))
+
+
+def _aggregate_alignment(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    deltas = [float(row["absolute_delta"]) for row in rows]
+    signed = [float(row["signed_delta"]) for row in rows]
+    return {
+        "labels": len(rows),
+        "exact_agreement": _rate([bool(row["exact_agreement"]) for row in rows]),
+        "within_one_agreement": _rate(
+            [bool(row["within_one_agreement"]) for row in rows]
+        ),
+        "mean_absolute_delta": _safe_mean(deltas),
+        "mean_signed_delta": _safe_mean(signed),
+        "pass_fail_agreement": _rate(
+            [bool(row["pass_fail_agreement"]) for row in rows]
+        ),
+    }
+
+
+def _grouped_alignment(
+    rows: list[dict[str, Any]],
+    field: str,
+) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[str(row.get(field) or "unknown")].append(row)
+    return {
+        key: _aggregate_alignment(value)
+        for key, value in sorted(grouped.items())
+    }
+
+
+def _reviewer_coverage(labels: list[dict[str, Any]]) -> dict[str, Any]:
+    by_reviewer: dict[str, int] = defaultdict(int)
+    by_confidence: dict[str, int] = defaultdict(int)
+    for label in labels:
+        by_reviewer[str(label.get("reviewer_id", "unknown"))] += 1
+        by_confidence[str(label.get("confidence", "unknown"))] += 1
+    return {
+        "reviewers": dict(sorted(by_reviewer.items())),
+        "confidence": dict(sorted(by_confidence.items())),
+    }
+
+
+def compute_human_alignment_stats(
+    *,
+    corpus: dict[str, Any],
+    records: list[dict[str, Any]],
+    labels: list[dict[str, Any]],
+    pass_threshold: float | None = None,
+) -> dict[str, Any]:
+    """Compare successful judge scores against human expert labels."""
+
+    threshold = float(pass_threshold or corpus.get("pass_threshold") or 3)
+    normalized_labels = [normalize_human_label(label) for label in labels]
+    item_index = {
+        str(item.get("sample_id", "")): item
+        for item in corpus.get("items", [])
+    }
+
+    judge_scores: dict[tuple[str, str, str], list[float]] = defaultdict(list)
+    for record in records:
+        if record.get("status") != "success":
+            continue
+        score = _raw_score(record)
+        if score is None:
+            continue
+        key = (
+            str(record.get("sample_id", "")),
+            _record_rubric_id(record),
+            _record_dimension(record),
+        )
+        judge_scores[key].append(float(score))
+
+    comparisons: list[dict[str, Any]] = []
+    missing: list[dict[str, Any]] = []
+    for label in normalized_labels:
+        key = (label["sample_id"], label["rubric_id"], label["dimension"])
+        scores = judge_scores.get(key, [])
+        item = item_index.get(label["sample_id"], {})
+        if not scores:
+            missing.append(
+                {
+                    "sample_id": label["sample_id"],
+                    "rubric_id": label["rubric_id"],
+                    "dimension": label["dimension"],
+                    "reviewer_id": label["reviewer_id"],
+                }
+            )
+            continue
+
+        judge_mean = _safe_mean(scores)
+        assert judge_mean is not None
+        human_score = int(label["human_score"])
+        signed_delta = round(float(judge_mean) - human_score, 4)
+        absolute_delta = round(abs(signed_delta), 4)
+        row = {
+            "sample_id": label["sample_id"],
+            "transcript_id": label["transcript_id"],
+            "rubric_id": label["rubric_id"],
+            "dimension": label["dimension"],
+            "task_id": item.get("task_id"),
+            "category": item.get("category"),
+            "persona_id": item.get("persona_id"),
+            "transcript_source": item.get("transcript_source"),
+            "reviewer_id": label["reviewer_id"],
+            "confidence": label["confidence"],
+            "human_score": human_score,
+            "judge_mean_score": judge_mean,
+            "judge_score_count": len(scores),
+            "nearest_judge_score": _nearest_score(float(judge_mean)),
+            "signed_delta": signed_delta,
+            "absolute_delta": absolute_delta,
+            "exact_agreement": _nearest_score(float(judge_mean)) == human_score,
+            "within_one_agreement": absolute_delta <= 1,
+            "human_pass": human_score >= threshold,
+            "judge_pass": float(judge_mean) >= threshold,
+            "pass_fail_agreement": (human_score >= threshold)
+            == (float(judge_mean) >= threshold),
+            "human_rationale": label["human_rationale"],
+            "evidence_spans": label["evidence_spans"],
+            "failure_tags": label["failure_tags"],
+        }
+        if label.get("notes"):
+            row["notes"] = label["notes"]
+        comparisons.append(row)
+
+    large_disagreements = [
+        row
+        for row in comparisons
+        if float(row["absolute_delta"]) >= LARGE_DISAGREEMENT_DELTA
+    ]
+    large_disagreements_documented = all(
+        row.get("evidence_spans") and row.get("failure_tags")
+        for row in large_disagreements
+    )
+    overall = _aggregate_alignment(comparisons)
+    gate_passed = bool(
+        comparisons
+        and not missing
+        and (overall["within_one_agreement"] or 0) >= HUMAN_WITHIN_ONE_TARGET
+        and (overall["pass_fail_agreement"] or 0) >= HUMAN_PASS_FAIL_TARGET
+        and large_disagreements_documented
+    )
+
+    weak_dimensions = [
+        {
+            "dimension": dimension,
+            **metrics,
+        }
+        for dimension, metrics in _grouped_alignment(
+            comparisons,
+            "dimension",
+        ).items()
+        if (metrics["within_one_agreement"] or 0) < HUMAN_WITHIN_ONE_TARGET
+        or (metrics["pass_fail_agreement"] or 0) < HUMAN_PASS_FAIL_TARGET
+    ]
+
+    return {
+        "version": HUMAN_ALIGNMENT_STATS_VERSION,
+        "pass_threshold": threshold,
+        "targets": {
+            "human_within_one_agreement": HUMAN_WITHIN_ONE_TARGET,
+            "human_pass_fail_agreement": HUMAN_PASS_FAIL_TARGET,
+            "large_disagreement_delta": LARGE_DISAGREEMENT_DELTA,
+        },
+        "counts": {
+            "labels": len(normalized_labels),
+            "comparable_labels": len(comparisons),
+            "missing_judge_comparisons": len(missing),
+            "large_disagreements": len(large_disagreements),
+        },
+        "reviewer_coverage": _reviewer_coverage(normalized_labels),
+        "overall": overall,
+        "slices": {
+            "by_dimension": _grouped_alignment(comparisons, "dimension"),
+            "by_task_category": _grouped_alignment(comparisons, "category"),
+            "by_persona_id": _grouped_alignment(comparisons, "persona_id"),
+            "by_transcript_source": _grouped_alignment(
+                comparisons,
+                "transcript_source",
+            ),
+        },
+        "stage3_gate": {
+            "status": "pass" if gate_passed else "needs_review",
+            "large_disagreements_documented": large_disagreements_documented,
+            "weak_dimensions": weak_dimensions,
+        },
+        "comparisons": comparisons,
+        "missing_judge_comparisons": missing,
+        "large_disagreement_examples": large_disagreements[:25],
+    }
+
+
+def _table(headers: list[str], rows: list[list[Any]]) -> str:
+    head = "".join(f"<th>{html.escape(str(header))}</th>" for header in headers)
+    body = "\n".join(
+        "<tr>"
+        + "".join(f"<td>{html.escape(str(cell))}</td>" for cell in row)
+        + "</tr>"
+        for row in rows
+    )
+    return f"<table><thead><tr>{head}</tr></thead><tbody>{body}</tbody></table>"
+
+
+def markdown_human_alignment_report(
+    stats: dict[str, Any],
+    *,
+    run_id: str = "",
+) -> str:
+    overall = stats["overall"]
+    counts = stats["counts"]
+    lines = [
+        "# Human Alignment Report",
+        "",
+        f"- Judge run ID: {run_id or 'unrecorded'}",
+        f"- Human labels: {counts['labels']}",
+        f"- Comparable labels: {counts['comparable_labels']}",
+        f"- Missing judge comparisons: {counts['missing_judge_comparisons']}",
+        f"- Exact agreement: {overall['exact_agreement']}",
+        f"- Within-one agreement: {overall['within_one_agreement']}",
+        f"- Mean absolute delta: {overall['mean_absolute_delta']}",
+        f"- Pass/fail agreement: {overall['pass_fail_agreement']}",
+        f"- Stage 3 gate: {stats['stage3_gate']['status']}",
+        "",
+        "## Dimension Metrics",
+        "",
+        "| Dimension | Labels | Exact | Within One | Mean Abs Delta | Pass/Fail |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for dimension, metrics in stats["slices"]["by_dimension"].items():
+        lines.append(
+            "| {dimension} | {labels} | {exact} | {within_one} | {delta} | {pf} |".format(
+                dimension=dimension,
+                labels=metrics["labels"],
+                exact=metrics["exact_agreement"],
+                within_one=metrics["within_one_agreement"],
+                delta=metrics["mean_absolute_delta"],
+                pf=metrics["pass_fail_agreement"],
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Large Disagreements",
+            "",
+            "| Sample | Rubric | Human | Judge Mean | Delta | Tags |",
+            "| --- | --- | ---: | ---: | ---: | --- |",
+        ]
+    )
+    for row in stats["large_disagreement_examples"]:
+        lines.append(
+            "| {sample_id} | {rubric} | {human} | {judge} | {delta} | {tags} |".format(
+                sample_id=row.get("sample_id"),
+                rubric=row.get("rubric_id"),
+                human=row.get("human_score"),
+                judge=row.get("judge_mean_score"),
+                delta=row.get("absolute_delta"),
+                tags=", ".join(row.get("failure_tags") or []),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Missing Judge Comparisons",
+            "",
+            "| Sample | Rubric | Dimension | Reviewer |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for row in stats["missing_judge_comparisons"]:
+        lines.append(
+            "| {sample_id} | {rubric} | {dimension} | {reviewer} |".format(
+                sample_id=row.get("sample_id"),
+                rubric=row.get("rubric_id"),
+                dimension=row.get("dimension"),
+                reviewer=row.get("reviewer_id"),
+            )
+        )
+
+    lines.extend(["", "## Reviewer Coverage", ""])
+    for reviewer_id, count in stats["reviewer_coverage"]["reviewers"].items():
+        lines.append(f"- {reviewer_id}: {count}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def html_human_alignment_report(
+    stats: dict[str, Any],
+    *,
+    run_id: str = "",
+) -> str:
+    overall = stats["overall"]
+    counts = stats["counts"]
+    dimension_rows = [
+        [
+            dimension,
+            metrics["labels"],
+            metrics["exact_agreement"],
+            metrics["within_one_agreement"],
+            metrics["mean_absolute_delta"],
+            metrics["pass_fail_agreement"],
+        ]
+        for dimension, metrics in stats["slices"]["by_dimension"].items()
+    ]
+    disagreement_rows = [
+        [
+            row.get("sample_id"),
+            row.get("rubric_id"),
+            row.get("human_score"),
+            row.get("judge_mean_score"),
+            row.get("absolute_delta"),
+            ", ".join(row.get("failure_tags") or []),
+        ]
+        for row in stats["large_disagreement_examples"]
+    ]
+    missing_rows = [
+        [
+            row.get("sample_id"),
+            row.get("rubric_id"),
+            row.get("dimension"),
+            row.get("reviewer_id"),
+        ]
+        for row in stats["missing_judge_comparisons"]
+    ]
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Human Alignment</title>
+  <style>
+    body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 32px; color: #1f2933; }}
+    h1, h2 {{ color: #102a43; }}
+    .cards {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin: 20px 0; }}
+    .card {{ border: 1px solid #d9e2ec; border-radius: 8px; padding: 14px; background: #f8fafc; }}
+    .metric {{ font-size: 26px; font-weight: 700; color: #1864ab; }}
+    table {{ border-collapse: collapse; width: 100%; margin: 12px 0 28px; font-size: 14px; }}
+    th, td {{ border: 1px solid #d9e2ec; padding: 8px; text-align: left; vertical-align: top; }}
+    th {{ background: #e7f5ff; }}
+  </style>
+</head>
+<body>
+  <h1>Human Alignment</h1>
+  <p>Judge run ID: <code>{html.escape(run_id or "unrecorded")}</code></p>
+  <div class="cards">
+    <div class="card"><div>Human Labels</div><div class="metric">{counts["labels"]}</div></div>
+    <div class="card"><div>Comparable Labels</div><div class="metric">{counts["comparable_labels"]}</div></div>
+    <div class="card"><div>Exact Agreement</div><div class="metric">{overall["exact_agreement"]}</div></div>
+    <div class="card"><div>Within-One</div><div class="metric">{overall["within_one_agreement"]}</div></div>
+    <div class="card"><div>Mean Abs Delta</div><div class="metric">{overall["mean_absolute_delta"]}</div></div>
+    <div class="card"><div>Pass/Fail Agreement</div><div class="metric">{overall["pass_fail_agreement"]}</div></div>
+    <div class="card"><div>Stage 3 Gate</div><div class="metric">{stats["stage3_gate"]["status"]}</div></div>
+  </div>
+  <h2>Dimension Metrics</h2>
+  {_table(["Dimension", "Labels", "Exact", "Within One", "Mean Abs Delta", "Pass/Fail"], dimension_rows)}
+  <h2>Large Disagreements</h2>
+  {_table(["Sample", "Rubric", "Human", "Judge Mean", "Delta", "Tags"], disagreement_rows)}
+  <h2>Missing Judge Comparisons</h2>
+  {_table(["Sample", "Rubric", "Dimension", "Reviewer"], missing_rows)}
+</body>
+</html>
+"""
+
+
+def write_human_alignment_reports(
+    *,
+    stats: dict[str, Any],
+    run_id: str,
+    output_dir: Path,
+) -> dict[str, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stats_path = output_dir / "human_alignment_stats.json"
+    md_path = output_dir / "human_alignment_report.md"
+    html_path = output_dir / "human_alignment_report.html"
+    stats_path.write_text(
+        json.dumps(stats, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    md_path.write_text(
+        markdown_human_alignment_report(stats, run_id=run_id),
+        encoding="utf-8",
+    )
+    html_path.write_text(
+        html_human_alignment_report(stats, run_id=run_id),
+        encoding="utf-8",
+    )
+    return {
+        "stats": str(stats_path),
+        "markdown": str(md_path),
+        "html": str(html_path),
+    }

--- a/bench/experiments/judge_validation/human_labels.example.json
+++ b/bench/experiments/judge_validation/human_labels.example.json
@@ -1,0 +1,22 @@
+{
+  "version": "judge_validation_human_labels_v1",
+  "generated_at": "2026-04-23T00:00:00Z",
+  "labels": [
+    {
+      "sample_id": "jv_quant_correct_good",
+      "transcript_id": "jv_quant_correct_good",
+      "rubric_id": "quant_correctness.v1",
+      "dimension": "D4_instructional_accuracy",
+      "human_score": 5,
+      "confidence": "high",
+      "human_rationale": "The response correctly identifies lookahead timing and gives the shift-based fix.",
+      "evidence_spans": [
+        "A signal formed from today's close can only be traded on the next bar"
+      ],
+      "failure_tags": [],
+      "reviewer_id": "expert_anon_1",
+      "label_version": "v1",
+      "timestamp": "2026-04-23T00:00:00Z"
+    }
+  ]
+}

--- a/bench/experiments/judge_validation/human_labels.schema.json
+++ b/bench/experiments/judge_validation/human_labels.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://quanttutorbench.local/schemas/judge_validation_human_labels_v1.json",
+  "title": "Judge Validation Human Labels",
+  "type": "object",
+  "required": ["version", "labels"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "const": "judge_validation_human_labels_v1"
+    },
+    "generated_at": {
+      "type": "string"
+    },
+    "labels": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/human_label"
+      }
+    }
+  },
+  "$defs": {
+    "human_label": {
+      "type": "object",
+      "required": [
+        "sample_id",
+        "transcript_id",
+        "rubric_id",
+        "dimension",
+        "human_score",
+        "confidence",
+        "human_rationale",
+        "evidence_spans",
+        "failure_tags",
+        "reviewer_id",
+        "label_version",
+        "timestamp"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "sample_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "transcript_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rubric_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "dimension": {
+          "type": "string",
+          "minLength": 1
+        },
+        "human_score": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5
+        },
+        "confidence": {
+          "type": "string",
+          "enum": ["low", "medium", "high"]
+        },
+        "human_rationale": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_spans": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "failure_tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "reviewer_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "label_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/bench/experiments/judge_validation/review_packet.py
+++ b/bench/experiments/judge_validation/review_packet.py
@@ -1,0 +1,405 @@
+"""Reviewer packet export for judge-validation human labels."""
+
+from __future__ import annotations
+
+import csv
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REVIEW_PACKET_VERSION = "judge_validation_human_review_packet_v1"
+REVIEW_SAMPLE_MAP_VERSION = "judge_validation_human_review_sample_map_v1"
+
+FORM_FIELDS = [
+    "reviewer_id",
+    "sample_id",
+    "transcript_id",
+    "rubric_id",
+    "dimension",
+    "human_score",
+    "confidence",
+    "human_rationale",
+    "evidence_spans",
+    "failure_tags",
+    "notes",
+]
+
+SUGGESTED_FAILURE_TAGS = [
+    "quant_error",
+    "code_error",
+    "missing_task_completion",
+    "hallucinated_tool_output",
+    "poor_adaptation",
+    "answer_dump",
+    "unsafe_financial_advice",
+    "unclear_rubric",
+    "other",
+]
+
+BILINGUAL_FORM_FIELDS = [
+    {
+        "field": "reviewer_id",
+        "title": "reviewer_id / 专家 ID",
+        "type": "short_answer",
+        "required": True,
+        "help": "Use an anonymized reviewer ID or collected email. / 使用匿名专家 ID 或自动收集的邮箱。",
+    },
+    {
+        "field": "sample_id",
+        "title": "sample_id / 样本 ID",
+        "type": "dropdown",
+        "required": True,
+        "help": "Choose one sample from the review packet. / 从标注包中选择一个样本。",
+    },
+    {
+        "field": "rubric_id",
+        "title": "rubric_id / 评分规则 ID",
+        "type": "dropdown",
+        "required": True,
+        "help": "Copy the rubric ID shown for the sample. / 选择样本对应的评分规则 ID。",
+    },
+    {
+        "field": "dimension",
+        "title": "dimension / 评分维度",
+        "type": "short_answer",
+        "required": True,
+        "help": "Copy the dimension shown for the sample. / 填写样本对应的评分维度。",
+    },
+    {
+        "field": "human_score",
+        "title": "human_score / 人类专家评分",
+        "type": "multiple_choice",
+        "required": True,
+        "options": ["1", "2", "3", "4", "5"],
+        "help": "Integer score from 1 to 5 using the listed anchors. / 按锚点评 1 到 5 的整数分。",
+    },
+    {
+        "field": "confidence",
+        "title": "confidence / 评分信心",
+        "type": "multiple_choice",
+        "required": True,
+        "options": ["high / 高", "medium / 中", "low / 低"],
+        "help": "How confident you are in the label. / 你对这个标注的信心。",
+    },
+    {
+        "field": "human_rationale",
+        "title": "human_rationale / 专家理由",
+        "type": "paragraph",
+        "required": True,
+        "help": "Brief rubric-grounded rationale. / 用评分规则说明理由。",
+    },
+    {
+        "field": "evidence_spans",
+        "title": "evidence_spans / 证据片段",
+        "type": "paragraph",
+        "required": False,
+        "help": "Paste relevant transcript spans, one per line. / 粘贴相关对话证据，每行一个。",
+    },
+    {
+        "field": "failure_tags",
+        "title": "failure_tags / 失败标签",
+        "type": "checkboxes",
+        "required": False,
+        "options": [f"{tag} / {tag.replace('_', ' ')}" for tag in SUGGESTED_FAILURE_TAGS],
+        "help": "Select all applicable tags. / 选择所有适用标签。",
+    },
+    {
+        "field": "notes",
+        "title": "notes / 备注",
+        "type": "paragraph",
+        "required": False,
+        "help": "Optional reviewer notes. / 可选备注。",
+    },
+]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _rubric_index(registry: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        str(entry.get("rubric_id", "")): entry
+        for entry in registry.get("rubrics", [])
+        if entry.get("rubric_id")
+    }
+
+
+def _conversation_context(item: dict[str, Any]) -> str:
+    if item.get("context"):
+        return str(item["context"])
+    blocks = []
+    for index, turn in enumerate(item.get("conversation", []), start=1):
+        role = str(turn.get("role") or "unknown").title()
+        content = str(turn.get("content") or "")
+        blocks.append(f"Turn {index} - {role}\n{content}")
+    return "\n\n".join(blocks)
+
+
+def _selected_items(
+    corpus: dict[str, Any],
+    *,
+    sample_ids: list[str] | None = None,
+    limit: int | None = None,
+) -> list[tuple[int, dict[str, Any]]]:
+    indexed_items = list(enumerate(corpus.get("items", []), start=1))
+    if sample_ids:
+        wanted = set(sample_ids)
+        indexed_items = [
+            (index, item)
+            for index, item in indexed_items
+            if str(item.get("sample_id")) in wanted
+        ]
+    if limit and limit > 0:
+        indexed_items = indexed_items[:limit]
+    return indexed_items
+
+
+def build_review_packet(
+    *,
+    corpus: dict[str, Any],
+    rubric_registry: dict[str, Any],
+    sample_ids: list[str] | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Build a reviewer-facing packet without expected-score hints."""
+
+    rubrics = _rubric_index(rubric_registry)
+    packet_items: list[dict[str, Any]] = []
+    sample_map: list[dict[str, Any]] = []
+    for corpus_index, item in _selected_items(
+        corpus,
+        sample_ids=sample_ids,
+        limit=limit,
+    ):
+        rubric_id = str(item.get("registry_rubric_id") or "")
+        rubric = rubrics.get(rubric_id, {})
+        original_sample_id = str(item.get("sample_id") or "")
+        review_sample_id = f"jv_review_{corpus_index:03d}"
+        sample_map.append(
+            {
+                "review_sample_id": review_sample_id,
+                "original_sample_id": original_sample_id,
+                "rubric_id": rubric_id,
+                "dimension": item.get("dimension"),
+            }
+        )
+        packet_items.append(
+            {
+                "sample_id": review_sample_id,
+                "transcript_id": review_sample_id,
+                "task_id": item.get("task_id"),
+                "category": item.get("category"),
+                "persona_id": item.get("persona_id"),
+                "transcript_source": item.get("transcript_source"),
+                "track": item.get("track"),
+                "dimension": item.get("dimension"),
+                "rubric_id": rubric_id,
+                "rubric_version": rubric.get("version"),
+                "rubric_dimension": rubric.get("dimension"),
+                "score_scale": rubric.get("score_scale"),
+                "score_anchors": rubric.get("score_anchors") or {},
+                "required_evidence": rubric.get("required_evidence") or [],
+                "common_failure_cases": rubric.get("common_failure_cases") or [],
+                "examples": rubric.get("examples") or {},
+                "review_context": _conversation_context(item),
+            }
+        )
+
+    return {
+        "version": REVIEW_PACKET_VERSION,
+        "generated_at": _utc_now(),
+        "description": (
+            "Human expert review packet for judge validation. Reviewers score "
+            "each transcript against the listed rubric only."
+        ),
+        "form_fields": FORM_FIELDS,
+        "bilingual_google_form_fields": BILINGUAL_FORM_FIELDS,
+        "suggested_failure_tags": SUGGESTED_FAILURE_TAGS,
+        "counts": {
+            "items": len(packet_items),
+        },
+        "private_sample_map": sample_map,
+        "items": packet_items,
+    }
+
+
+def _markdown_list(values: list[Any]) -> list[str]:
+    return [f"- {value}" for value in values] or ["-"]
+
+
+def markdown_review_packet(packet: dict[str, Any]) -> str:
+    lines = [
+        "# Judge Validation Human Review Packet",
+        "",
+        f"Generated: {packet.get('generated_at')}",
+        f"Items: {packet.get('counts', {}).get('items')}",
+        "",
+        "## Reviewer Fields",
+        "",
+    ]
+    lines.extend(_markdown_list(packet.get("form_fields") or []))
+    lines.extend(["", "## Suggested Failure Tags", ""])
+    lines.extend(_markdown_list(packet.get("suggested_failure_tags") or []))
+
+    for item in packet.get("items", []):
+        lines.extend(
+            [
+                "",
+                f"## {item.get('sample_id')}",
+                "",
+                f"- Task: {item.get('task_id')}",
+                f"- Category: {item.get('category')}",
+                f"- Persona: {item.get('persona_id')}",
+                f"- Rubric: {item.get('rubric_id')} ({item.get('rubric_version')})",
+                f"- Dimension: {item.get('dimension')}",
+                "",
+                "### Score Anchors",
+                "",
+            ]
+        )
+        for score, anchor in sorted((item.get("score_anchors") or {}).items()):
+            lines.append(f"- {score}: {anchor}")
+        lines.extend(["", "### Required Evidence", ""])
+        lines.extend(_markdown_list(item.get("required_evidence") or []))
+        lines.extend(["", "### Common Failure Cases", ""])
+        lines.extend(_markdown_list(item.get("common_failure_cases") or []))
+        lines.extend(["", "### Transcript Or Evaluation Context", "", "```text"])
+        lines.append(str(item.get("review_context") or ""))
+        lines.append("```")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def markdown_bilingual_google_form(packet: dict[str, Any]) -> str:
+    sample_options = [str(item.get("sample_id")) for item in packet.get("items", [])]
+    rubric_options = sorted(
+        {
+            str(item.get("rubric_id"))
+            for item in packet.get("items", [])
+            if item.get("rubric_id")
+        }
+    )
+    lines = [
+        "# Human Expert Labeling Google Form / 人类专家标注 Google Form",
+        "",
+        "Form title / 表单标题:",
+        "Judge Validation Human Labels / 裁判验证人类专家标注",
+        "",
+        "Form description / 表单说明:",
+        (
+            "Submit one response per sample. Read the matching sample in "
+            "human_review_packet.md, then score the transcript using the listed "
+            "rubric anchors. / 每个样本提交一次。先阅读 human_review_packet.md "
+            "中对应样本，再按评分锚点给该转录打分。"
+        ),
+        "",
+        "Recommended setting / 推荐设置:",
+        "- Collect email addresses / 收集电子邮件地址",
+        "- Keep responses editable / 允许提交后编辑",
+        "",
+        "## Questions / 问题",
+        "",
+    ]
+    for field in packet.get("bilingual_google_form_fields") or []:
+        lines.extend(
+            [
+                f"### {field.get('title')}",
+                "",
+                f"- Type / 类型: {field.get('type')}",
+                f"- Required / 必填: {field.get('required')}",
+                f"- Help / 帮助: {field.get('help')}",
+            ]
+        )
+        options = list(field.get("options") or [])
+        if field.get("field") == "sample_id":
+            options = sample_options
+        if field.get("field") == "rubric_id":
+            options = rubric_options
+        if options:
+            lines.append("- Options / 选项:")
+            lines.extend(f"  - {option}" for option in options)
+        lines.append("")
+
+    lines.extend(["## Sample Index / 样本索引", ""])
+    for item in packet.get("items", []):
+        lines.extend(
+            [
+                f"### {item.get('sample_id')}",
+                "",
+                f"- Task / 任务: {item.get('task_id')}",
+                f"- Category / 类别: {item.get('category')}",
+                f"- Persona / 学生画像: {item.get('persona_id')}",
+                f"- Rubric / 评分规则: {item.get('rubric_id')}",
+                f"- Dimension / 维度: {item.get('dimension')}",
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def write_review_packet(
+    *,
+    packet: dict[str, Any],
+    output_dir: Path,
+) -> dict[str, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "human_review_packet.json"
+    md_path = output_dir / "human_review_packet.md"
+    csv_path = output_dir / "human_label_template.csv"
+    google_form_path = output_dir / "google_form_bilingual.md"
+    sample_map_path = output_dir / "human_review_sample_map.json"
+    public_packet = {
+        key: value for key, value in packet.items() if key != "private_sample_map"
+    }
+
+    json_path.write_text(
+        json.dumps(public_packet, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    md_path.write_text(markdown_review_packet(public_packet), encoding="utf-8")
+    google_form_path.write_text(
+        markdown_bilingual_google_form(public_packet),
+        encoding="utf-8",
+    )
+    sample_map_path.write_text(
+        json.dumps(
+            {
+                "version": REVIEW_SAMPLE_MAP_VERSION,
+                "generated_at": _utc_now(),
+                "mappings": packet.get("private_sample_map", []),
+            },
+            indent=2,
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with csv_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=FORM_FIELDS)
+        writer.writeheader()
+        for item in public_packet.get("items", []):
+            writer.writerow(
+                {
+                    "reviewer_id": "",
+                    "sample_id": item.get("sample_id"),
+                    "transcript_id": item.get("transcript_id"),
+                    "rubric_id": item.get("rubric_id"),
+                    "dimension": item.get("dimension"),
+                    "human_score": "",
+                    "confidence": "",
+                    "human_rationale": "",
+                    "evidence_spans": "",
+                    "failure_tags": "",
+                    "notes": "",
+                }
+            )
+
+    return {
+        "json": str(json_path),
+        "markdown": str(md_path),
+        "csv": str(csv_path),
+        "google_form_bilingual": str(google_form_path),
+        "sample_map": str(sample_map_path),
+    }

--- a/bench/experiments/judge_validation/run.py
+++ b/bench/experiments/judge_validation/run.py
@@ -16,6 +16,12 @@ from typing import Any
 BENCH_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(BENCH_ROOT))
 
+from experiments.judge_validation.human_alignment import (  # noqa: E402
+    convert_csv_to_human_labels,
+    compute_human_alignment_stats,
+    load_human_labels,
+    write_human_alignment_reports,
+)
 from experiments.judge_validation.report import (  # noqa: E402
     compute_reliability_stats,
     write_reports,
@@ -38,6 +44,7 @@ from server.eval.judges.runtime.conv_geval import (  # noqa: E402
 from server.eval.judges.runtime.model_resolver import resolve_ewan_model  # noqa: E402
 
 DEFAULT_CORPUS = Path(__file__).resolve().parent / "pilot_corpus.json"
+DEFAULT_HUMAN_LABELS = Path(__file__).resolve().parent / "human_labels.json"
 DEFAULT_OUTPUT_DIR = Path("experiments/judge_validation/results")
 DEFAULT_REPEAT_COUNT = 3
 DEFAULT_PROMPT_VARIANT = "baseline"
@@ -486,6 +493,56 @@ def _report(args: argparse.Namespace) -> int:
     return 0
 
 
+def _convert_human_labels(args: argparse.Namespace) -> int:
+    csv_path = _resolve(args.csv)
+    output_path = _resolve(args.labels_output)
+    payload = convert_csv_to_human_labels(csv_path)
+    _atomic_write_json(output_path, payload)
+    print(
+        json.dumps(
+            {
+                "human_labels": str(output_path),
+                "labels": len(payload["labels"]),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def _human_alignment(args: argparse.Namespace) -> int:
+    corpus = _load_json(_resolve(args.corpus))
+    runs = _load_json(_resolve(args.runs))
+    labels = load_human_labels(_resolve(args.labels))
+    records = runs.get("records", [])
+    stats = compute_human_alignment_stats(
+        corpus=corpus,
+        records=records,
+        labels=labels,
+    )
+    output_dir = _resolve(args.output_dir)
+    paths = write_human_alignment_reports(
+        stats=stats,
+        run_id=str(runs.get("run_id", "")),
+        output_dir=output_dir,
+    )
+    print(
+        json.dumps(
+            {
+                "run_id": runs.get("run_id"),
+                "labels": len(labels),
+                "stats": paths["stats"],
+                "markdown": paths["markdown"],
+                "html": paths["html"],
+                "overall": stats["overall"],
+                "stage3_gate": stats["stage3_gate"],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
 def _dry_run(args: argparse.Namespace) -> int:
     corpus = _load_json(_resolve(args.corpus))
     pairs = corpus.get("adversarial_pairs", [])
@@ -549,6 +606,31 @@ def _make_parser() -> argparse.ArgumentParser:
         help="Path to judge_runs.json",
     )
 
+    convert_labels_p = sub.add_parser("convert-human-labels")
+    convert_labels_p.add_argument(
+        "--csv",
+        required=True,
+        help="Path to a Google Form CSV export",
+    )
+    convert_labels_p.add_argument(
+        "--labels-output",
+        default=str(DEFAULT_HUMAN_LABELS),
+        help="Path for canonical human_labels.json",
+    )
+
+    human_alignment_p = sub.add_parser("human-alignment")
+    add_common(human_alignment_p)
+    human_alignment_p.add_argument(
+        "--runs",
+        default=str(DEFAULT_OUTPUT_DIR / "judge_runs.json"),
+        help="Path to judge_runs.json",
+    )
+    human_alignment_p.add_argument(
+        "--labels",
+        default=str(DEFAULT_HUMAN_LABELS),
+        help="Path to human_labels.json",
+    )
+
     return parser
 
 
@@ -563,6 +645,10 @@ def main(argv: list[str] | None = None) -> int:
         return _judge(args)
     if args.command == "report":
         return _report(args)
+    if args.command == "convert-human-labels":
+        return _convert_human_labels(args)
+    if args.command == "human-alignment":
+        return _human_alignment(args)
     parser.error(f"Unknown command: {args.command}")
     return 2
 

--- a/bench/experiments/judge_validation/run.py
+++ b/bench/experiments/judge_validation/run.py
@@ -20,11 +20,16 @@ from experiments.judge_validation.human_alignment import (  # noqa: E402
     convert_csv_to_human_labels,
     compute_human_alignment_stats,
     load_human_labels,
+    load_sample_id_map,
     write_human_alignment_reports,
 )
 from experiments.judge_validation.report import (  # noqa: E402
     compute_reliability_stats,
     write_reports,
+)
+from experiments.judge_validation.review_packet import (  # noqa: E402
+    build_review_packet,
+    write_review_packet,
 )
 from server.eval.inputs.rubric_builder import (  # noqa: E402
     build_eval_params,
@@ -45,7 +50,9 @@ from server.eval.judges.runtime.model_resolver import resolve_ewan_model  # noqa
 
 DEFAULT_CORPUS = Path(__file__).resolve().parent / "pilot_corpus.json"
 DEFAULT_HUMAN_LABELS = Path(__file__).resolve().parent / "human_labels.json"
+DEFAULT_RUBRIC_REGISTRY = BENCH_ROOT / "server/eval/rubrics/rubric_registry.json"
 DEFAULT_OUTPUT_DIR = Path("experiments/judge_validation/results")
+DEFAULT_REVIEW_PACKET_DIR = DEFAULT_OUTPUT_DIR / "human_review_packet"
 DEFAULT_REPEAT_COUNT = 3
 DEFAULT_PROMPT_VARIANT = "baseline"
 SUPPORTED_PROMPT_VARIANTS = {
@@ -510,15 +517,51 @@ def _convert_human_labels(args: argparse.Namespace) -> int:
     return 0
 
 
+def _export_review_packet(args: argparse.Namespace) -> int:
+    corpus = _load_json(_resolve(args.corpus))
+    rubric_registry = _load_json(_resolve(args.rubric_registry))
+    sample_ids = _split_csv(args.sample_ids) if args.sample_ids else None
+    limit = args.limit if args.limit and args.limit > 0 else None
+    packet_output_dir = (
+        _resolve(args.packet_output_dir)
+        if args.packet_output_dir
+        else _resolve(args.output_dir) / "human_review_packet"
+    )
+    packet = build_review_packet(
+        corpus=corpus,
+        rubric_registry=rubric_registry,
+        sample_ids=sample_ids,
+        limit=limit,
+    )
+    paths = write_review_packet(
+        packet=packet,
+        output_dir=packet_output_dir,
+    )
+    print(
+        json.dumps(
+            {
+                "review_packet": paths,
+                "items": packet["counts"]["items"],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
 def _human_alignment(args: argparse.Namespace) -> int:
     corpus = _load_json(_resolve(args.corpus))
     runs = _load_json(_resolve(args.runs))
     labels = load_human_labels(_resolve(args.labels))
+    sample_id_map = (
+        load_sample_id_map(_resolve(args.sample_map)) if args.sample_map else None
+    )
     records = runs.get("records", [])
     stats = compute_human_alignment_stats(
         corpus=corpus,
         records=records,
         labels=labels,
+        sample_id_map=sample_id_map,
     )
     output_dir = _resolve(args.output_dir)
     paths = write_human_alignment_reports(
@@ -618,6 +661,30 @@ def _make_parser() -> argparse.ArgumentParser:
         help="Path for canonical human_labels.json",
     )
 
+    review_packet_p = sub.add_parser("export-review-packet")
+    add_common(review_packet_p)
+    review_packet_p.add_argument(
+        "--rubric-registry",
+        default=str(DEFAULT_RUBRIC_REGISTRY),
+        help="Path to rubric_registry.json",
+    )
+    review_packet_p.add_argument(
+        "--packet-output-dir",
+        default=None,
+        help="Directory for reviewer packet JSON, Markdown, and CSV files",
+    )
+    review_packet_p.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum number of corpus items to export; 0 exports all selected items",
+    )
+    review_packet_p.add_argument(
+        "--sample-ids",
+        default="",
+        help="Optional comma-separated sample IDs for a targeted packet",
+    )
+
     human_alignment_p = sub.add_parser("human-alignment")
     add_common(human_alignment_p)
     human_alignment_p.add_argument(
@@ -629,6 +696,11 @@ def _make_parser() -> argparse.ArgumentParser:
         "--labels",
         default=str(DEFAULT_HUMAN_LABELS),
         help="Path to human_labels.json",
+    )
+    human_alignment_p.add_argument(
+        "--sample-map",
+        default="",
+        help="Optional blind review_sample_id to original_sample_id mapping",
     )
 
     return parser
@@ -647,6 +719,8 @@ def main(argv: list[str] | None = None) -> int:
         return _report(args)
     if args.command == "convert-human-labels":
         return _convert_human_labels(args)
+    if args.command == "export-review-packet":
+        return _export_review_packet(args)
     if args.command == "human-alignment":
         return _human_alignment(args)
     parser.error(f"Unknown command: {args.command}")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,11 +135,16 @@ If a batch driver is needed, it should be a thin wrapper around
 `bench/experiments/judge_validation/` is the automated judge reliability gate for
 external-agent scoring. It owns a fixed pilot corpus, prompt rendering, repeated
 same-prompt judge runs, prompt-format variants, one-factor sensitivity cases,
-adversarial-pair ranking checks, and Markdown/HTML/JSON reliability reports. The
-report tracks mean absolute score delta, within-one score rate, pass/fail flip
-rate, prompt-format score deltas, sensitivity pass rate, adversarial ranking
-pass rate, evidence/reason coverage, lightweight explanation consistency, raw
-disagreement examples, and residual risks.
+adversarial-pair ranking checks, human label artifacts, Google Form CSV
+conversion, and Markdown/HTML/JSON reliability reports. The automated report
+tracks mean absolute score delta, within-one score rate, pass/fail flip rate,
+prompt-format score deltas, sensitivity pass rate, adversarial ranking pass
+rate, evidence/reason coverage, lightweight explanation consistency, raw
+disagreement examples, and residual risks. The human-alignment report joins
+`judge_runs.json` with `human_labels.json` and reports exact agreement,
+within-one agreement, mean absolute delta versus human labels, pass/fail
+agreement, large disagreement examples, and bias slices by dimension, category,
+persona, and transcript source.
 
 ## Public Reads
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,15 +136,16 @@ If a batch driver is needed, it should be a thin wrapper around
 external-agent scoring. It owns a fixed pilot corpus, prompt rendering, repeated
 same-prompt judge runs, prompt-format variants, one-factor sensitivity cases,
 adversarial-pair ranking checks, human label artifacts, Google Form CSV
-conversion, and Markdown/HTML/JSON reliability reports. The automated report
-tracks mean absolute score delta, within-one score rate, pass/fail flip rate,
-prompt-format score deltas, sensitivity pass rate, adversarial ranking pass
-rate, evidence/reason coverage, lightweight explanation consistency, raw
-disagreement examples, and residual risks. The human-alignment report joins
-`judge_runs.json` with `human_labels.json` and reports exact agreement,
-within-one agreement, mean absolute delta versus human labels, pass/fail
-agreement, large disagreement examples, and bias slices by dimension, category,
-persona, and transcript source.
+conversion, bilingual Google Form blueprint export, blind reviewer packet
+export, private sample-ID mapping, and Markdown/HTML/JSON reliability reports.
+The automated report tracks mean absolute score delta, within-one score rate,
+pass/fail flip rate, prompt-format score deltas, sensitivity pass rate,
+adversarial ranking pass rate, evidence/reason coverage, lightweight
+explanation consistency, raw disagreement examples, and residual risks. The
+human-alignment report joins `judge_runs.json` with `human_labels.json` and
+reports exact agreement, within-one agreement, mean absolute delta versus human
+labels, pass/fail agreement, large disagreement examples, and bias slices by
+dimension, category, persona, and transcript source.
 
 ## Public Reads
 

--- a/tests/test_judge_human_alignment.py
+++ b/tests/test_judge_human_alignment.py
@@ -1,0 +1,366 @@
+import csv
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "bench"))
+
+from experiments.judge_validation import run as judge_run
+from experiments.judge_validation.human_alignment import (
+    compute_human_alignment_stats,
+    convert_csv_to_human_labels,
+    labels_from_csv_rows,
+    normalize_human_label,
+)
+
+
+def test_human_alignment_stats_compute_agreement_metrics():
+    corpus = {
+        "pass_threshold": 3,
+        "items": [
+            {
+                "sample_id": "strong",
+                "task_id": "B03_lookahead_prevention",
+                "category": "backtest",
+                "persona_id": "finance_veteran",
+                "transcript_source": "synthetic_adversarial",
+            },
+            {
+                "sample_id": "weak",
+                "task_id": "B03_lookahead_prevention",
+                "category": "backtest",
+                "persona_id": "finance_veteran",
+                "transcript_source": "synthetic_adversarial",
+            },
+        ],
+    }
+    records = [
+        {
+            "sample_id": "strong",
+            "registry_rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "status": "success",
+            "raw_score": 5,
+        },
+        {
+            "sample_id": "strong",
+            "registry_rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "status": "success",
+            "raw_score": 4,
+        },
+        {
+            "sample_id": "weak",
+            "registry_rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "status": "success",
+            "raw_score": 2,
+        },
+    ]
+    labels = [
+        {
+            "sample_id": "strong",
+            "rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "human_score": 5,
+            "confidence": "high",
+            "human_rationale": "The timing correction is accurate.",
+            "evidence_spans": ["shift by one day"],
+            "failure_tags": [],
+            "reviewer_id": "expert_anon_1",
+            "timestamp": "2026-04-23T00:00:00Z",
+        },
+        {
+            "sample_id": "weak",
+            "rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "human_score": 1,
+            "confidence": "high",
+            "human_rationale": "The answer permits same-close trading.",
+            "evidence_spans": ["trade happened at that close"],
+            "failure_tags": ["quant_error"],
+            "reviewer_id": "expert_anon_1",
+            "timestamp": "2026-04-23T00:00:00Z",
+        },
+    ]
+
+    stats = compute_human_alignment_stats(
+        corpus=corpus,
+        records=records,
+        labels=labels,
+    )
+
+    assert stats["counts"]["labels"] == 2
+    assert stats["counts"]["comparable_labels"] == 2
+    assert stats["overall"]["exact_agreement"] == 0.5
+    assert stats["overall"]["within_one_agreement"] == 1.0
+    assert stats["overall"]["mean_absolute_delta"] == 0.75
+    assert stats["overall"]["pass_fail_agreement"] == 1.0
+    assert stats["slices"]["by_dimension"]["D4_instructional_accuracy"]["labels"] == 2
+    assert stats["stage3_gate"]["status"] == "pass"
+
+
+def test_human_alignment_reports_large_disagreements_and_missing_scores():
+    corpus = {
+        "pass_threshold": 3,
+        "items": [
+            {
+                "sample_id": "sample",
+                "category": "debug",
+                "persona_id": "developer_crossover",
+                "transcript_source": "real_run_excerpt",
+            }
+        ],
+    }
+    records = [
+        {
+            "sample_id": "sample",
+            "registry_rubric_id": "code_correctness.v1",
+            "dimension": "result_judge",
+            "status": "success",
+            "raw_score": 2,
+        }
+    ]
+    labels = [
+        {
+            "sample_id": "sample",
+            "rubric_id": "code_correctness.v1",
+            "dimension": "result_judge",
+            "human_score": 5,
+            "confidence": "medium",
+            "human_rationale": "The human reviewer credited the regression test.",
+            "evidence_spans": ["test passed"],
+            "failure_tags": ["unclear_rubric"],
+            "reviewer_id": "expert_anon_2",
+            "timestamp": "2026-04-23T00:00:00Z",
+        },
+        {
+            "sample_id": "missing",
+            "rubric_id": "code_correctness.v1",
+            "dimension": "result_judge",
+            "human_score": 4,
+            "confidence": "low",
+            "human_rationale": "This label has no matching judge score.",
+            "evidence_spans": ["artifact exists"],
+            "failure_tags": [],
+            "reviewer_id": "expert_anon_2",
+            "timestamp": "2026-04-23T00:00:00Z",
+        },
+    ]
+
+    stats = compute_human_alignment_stats(
+        corpus=corpus,
+        records=records,
+        labels=labels,
+    )
+
+    assert stats["counts"]["missing_judge_comparisons"] == 1
+    assert stats["counts"]["large_disagreements"] == 1
+    assert stats["large_disagreement_examples"][0]["absolute_delta"] == 3.0
+    assert stats["large_disagreement_examples"][0]["failure_tags"] == [
+        "unclear_rubric"
+    ]
+    assert stats["stage3_gate"]["large_disagreements_documented"] is True
+    assert stats["stage3_gate"]["status"] == "needs_review"
+
+
+def test_human_alignment_gate_requires_full_label_coverage():
+    corpus = {"pass_threshold": 3, "items": [{"sample_id": "sample"}]}
+    records = [
+        {
+            "sample_id": "sample",
+            "registry_rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "status": "success",
+            "raw_score": 5,
+        }
+    ]
+    labels = [
+        {
+            "sample_id": "sample",
+            "rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "human_score": 5,
+            "confidence": "high",
+            "human_rationale": "Correct.",
+            "reviewer_id": "expert_anon_1",
+        },
+        {
+            "sample_id": "missing",
+            "rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "human_score": 5,
+            "confidence": "high",
+            "human_rationale": "Correct.",
+            "reviewer_id": "expert_anon_1",
+        },
+    ]
+
+    stats = compute_human_alignment_stats(
+        corpus=corpus,
+        records=records,
+        labels=labels,
+    )
+
+    assert stats["overall"]["within_one_agreement"] == 1.0
+    assert stats["counts"]["missing_judge_comparisons"] == 1
+    assert stats["stage3_gate"]["status"] == "needs_review"
+
+
+def test_human_label_score_must_be_integral():
+    base = {
+        "sample_id": "sample",
+        "rubric_id": "quant_correctness.v1",
+        "dimension": "D4_instructional_accuracy",
+        "confidence": "high",
+        "human_rationale": "Correct.",
+        "reviewer_id": "expert_anon_1",
+    }
+
+    assert normalize_human_label({**base, "human_score": "5.0"})["human_score"] == 5
+
+    try:
+        normalize_human_label({**base, "human_score": "4.9"})
+    except ValueError as exc:
+        assert "human_score must be an integer" in str(exc)
+    else:
+        raise AssertionError("fractional human score should fail validation")
+
+
+def test_google_form_csv_rows_convert_to_human_labels():
+    rows = [
+        {
+            "Reviewer ID": "expert_anon_1",
+            "Sample ID": "jv_quant_correct_good",
+            "Rubric ID": "quant_correctness.v1",
+            "Dimension": "D4_instructional_accuracy",
+            "Human Score": "5",
+            "Confidence": "High",
+            "Human Rationale": "Correct lookahead explanation.",
+            "Evidence Spans": "shift by one day\nnext bar",
+            "Failure Tags": "quant_error, other",
+            "Timestamp": "2026-04-23T00:00:00Z",
+        }
+    ]
+
+    labels = labels_from_csv_rows(rows)
+
+    assert labels[0]["human_score"] == 5
+    assert labels[0]["confidence"] == "high"
+    assert labels[0]["evidence_spans"] == ["shift by one day", "next bar"]
+    assert labels[0]["failure_tags"] == ["quant_error", "other"]
+    assert labels[0]["transcript_id"] == "jv_quant_correct_good"
+
+
+def test_google_form_email_address_can_supply_reviewer_id():
+    rows = [
+        {
+            "Email Address": "expert@example.com",
+            "Sample ID": "sample",
+            "Rubric ID": "quant_correctness.v1",
+            "Dimension": "D4_instructional_accuracy",
+            "Human Score": "5",
+            "Confidence": "High",
+            "Human Rationale": "Correct lookahead explanation.",
+        }
+    ]
+
+    labels = labels_from_csv_rows(rows)
+
+    assert labels[0]["reviewer_id"] == "expert@example.com"
+
+
+def test_convert_human_labels_and_human_alignment_cli(tmp_path):
+    csv_path = tmp_path / "labels.csv"
+    with csv_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(
+            fh,
+            fieldnames=[
+                "reviewer_id",
+                "sample_id",
+                "rubric_id",
+                "dimension",
+                "human_score",
+                "confidence",
+                "human_rationale",
+                "evidence_spans",
+                "failure_tags",
+                "timestamp",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "reviewer_id": "expert_anon_1",
+                "sample_id": "sample",
+                "rubric_id": "quant_correctness.v1",
+                "dimension": "D4_instructional_accuracy",
+                "human_score": "4",
+                "confidence": "high",
+                "human_rationale": "Correct with a small omission.",
+                "evidence_spans": "shift by one day",
+                "failure_tags": "",
+                "timestamp": "2026-04-23T00:00:00Z",
+            }
+        )
+    payload = convert_csv_to_human_labels(csv_path)
+    assert payload["labels"][0]["sample_id"] == "sample"
+
+    corpus_path = tmp_path / "corpus.json"
+    runs_path = tmp_path / "judge_runs.json"
+    labels_path = tmp_path / "human_labels.json"
+    output_dir = tmp_path / "reports"
+    corpus_path.write_text(
+        json.dumps(
+            {
+                "pass_threshold": 3,
+                "items": [
+                    {
+                        "sample_id": "sample",
+                        "category": "backtest",
+                        "persona_id": "finance_veteran",
+                        "transcript_source": "synthetic_adversarial",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    runs_path.write_text(
+        json.dumps(
+            {
+                "run_id": "jv_test",
+                "records": [
+                    {
+                        "sample_id": "sample",
+                        "registry_rubric_id": "quant_correctness.v1",
+                        "dimension": "D4_instructional_accuracy",
+                        "status": "success",
+                        "raw_score": 4,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    labels_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    rc = judge_run.main(
+        [
+            "--corpus",
+            str(corpus_path),
+            "--output-dir",
+            str(output_dir),
+            "human-alignment",
+            "--runs",
+            str(runs_path),
+            "--labels",
+            str(labels_path),
+        ]
+    )
+
+    assert rc == 0
+    stats = json.loads((output_dir / "human_alignment_stats.json").read_text())
+    assert stats["overall"]["exact_agreement"] == 1.0
+    assert (output_dir / "human_alignment_report.md").exists()
+    assert (output_dir / "human_alignment_report.html").exists()

--- a/tests/test_judge_human_alignment.py
+++ b/tests/test_judge_human_alignment.py
@@ -10,7 +10,12 @@ from experiments.judge_validation.human_alignment import (
     compute_human_alignment_stats,
     convert_csv_to_human_labels,
     labels_from_csv_rows,
+    load_sample_id_map,
     normalize_human_label,
+)
+from experiments.judge_validation.review_packet import (
+    build_review_packet,
+    write_review_packet,
 )
 
 
@@ -261,13 +266,36 @@ def test_google_form_email_address_can_supply_reviewer_id():
             "Dimension": "D4_instructional_accuracy",
             "Human Score": "5",
             "Confidence": "High",
-            "Human Rationale": "Correct lookahead explanation.",
+            "Reviewer Rationale": "Correct lookahead explanation.",
         }
     ]
 
     labels = labels_from_csv_rows(rows)
 
     assert labels[0]["reviewer_id"] == "expert@example.com"
+    assert labels[0]["human_rationale"] == "Correct lookahead explanation."
+
+
+def test_bilingual_google_form_headers_and_options_convert_to_labels():
+    rows = [
+        {
+            "Email Address": "expert@example.com",
+            "reviewer_id / 专家 ID": "expert_anon_1",
+            "sample_id / 样本 ID": "sample",
+            "rubric_id / 评分规则 ID": "quant_correctness.v1",
+            "dimension / 评分维度": "D4_instructional_accuracy",
+            "human_score / 人类专家评分": "5",
+            "confidence / 评分信心": "high / 高",
+            "human_rationale / 专家理由": "Correct timing explanation.",
+            "failure_tags / 失败标签": "quant_error / quant error, other / other",
+        }
+    ]
+
+    labels = labels_from_csv_rows(rows)
+
+    assert labels[0]["confidence"] == "high"
+    assert labels[0]["failure_tags"] == ["quant_error", "other"]
+    assert labels[0]["reviewer_id"] == "expert_anon_1"
 
 
 def test_convert_human_labels_and_human_alignment_cli(tmp_path):
@@ -364,3 +392,267 @@ def test_convert_human_labels_and_human_alignment_cli(tmp_path):
     assert stats["overall"]["exact_agreement"] == 1.0
     assert (output_dir / "human_alignment_report.md").exists()
     assert (output_dir / "human_alignment_report.html").exists()
+
+
+def test_human_alignment_uses_blind_sample_map():
+    corpus = {"pass_threshold": 3, "items": [{"sample_id": "original"}]}
+    records = [
+        {
+            "sample_id": "original",
+            "registry_rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "status": "success",
+            "raw_score": 5,
+        }
+    ]
+    labels = [
+        {
+            "sample_id": "jv_review_001",
+            "rubric_id": "quant_correctness.v1",
+            "dimension": "D4_instructional_accuracy",
+            "human_score": 5,
+            "confidence": "high",
+            "human_rationale": "Correct.",
+            "reviewer_id": "expert_anon_1",
+        }
+    ]
+
+    stats = compute_human_alignment_stats(
+        corpus=corpus,
+        records=records,
+        labels=labels,
+        sample_id_map={"jv_review_001": "original"},
+    )
+
+    assert stats["counts"]["comparable_labels"] == 1
+    assert stats["comparisons"][0]["sample_id"] == "original"
+    assert stats["comparisons"][0]["review_sample_id"] == "jv_review_001"
+    assert stats["stage3_gate"]["status"] == "pass"
+
+
+def test_review_packet_exports_reviewer_materials_without_expected_scores(tmp_path):
+    corpus = {
+        "items": [
+            {
+                "sample_id": "sample",
+                "pair_id": "pair",
+                "pair_role": "stronger",
+                "task_id": "B03_lookahead_prevention",
+                "category": "backtest",
+                "persona_id": "finance_veteran",
+                "transcript_source": "synthetic_adversarial",
+                "track": "tutor",
+                "dimension": "D4_instructional_accuracy",
+                "registry_rubric_id": "quant_correctness.v1",
+                "expected_score_band": "high",
+                "conversation": [
+                    {"role": "user", "content": "Is same-close trading valid?"},
+                    {"role": "assistant", "content": "Shift the signal one bar."},
+                ],
+            }
+        ]
+    }
+    registry = {
+        "rubrics": [
+            {
+                "rubric_id": "quant_correctness.v1",
+                "version": "v1",
+                "dimension": "quant_correctness",
+                "score_scale": {"min": 1, "max": 5},
+                "score_anchors": {"1": "wrong", "5": "excellent"},
+                "required_evidence": ["formula"],
+                "common_failure_cases": ["lookahead"],
+                "examples": {"high": "accurate"},
+            }
+        ]
+    }
+
+    packet = build_review_packet(corpus=corpus, rubric_registry=registry)
+    item = packet["items"][0]
+    paths = write_review_packet(packet=packet, output_dir=tmp_path)
+
+    assert packet["counts"]["items"] == 1
+    assert packet["private_sample_map"][0]["review_sample_id"] == "jv_review_001"
+    assert packet["private_sample_map"][0]["original_sample_id"] == "sample"
+    assert item["sample_id"] == "jv_review_001"
+    assert item["rubric_id"] == "quant_correctness.v1"
+    assert "Shift the signal one bar" in item["review_context"]
+    assert "sample" not in item["sample_id"]
+    assert "expected_score_band" not in item
+    assert "pair_role" not in item
+    assert Path(paths["json"]).exists()
+    assert Path(paths["markdown"]).exists()
+    assert Path(paths["google_form_bilingual"]).exists()
+    sample_map = load_sample_id_map(Path(paths["sample_map"]))
+    assert sample_map == {"jv_review_001": "sample"}
+    public_json = json.loads(Path(paths["json"]).read_text(encoding="utf-8"))
+    assert "private_sample_map" not in public_json
+    csv_text = Path(paths["csv"]).read_text(encoding="utf-8")
+    assert "human_score" in csv_text
+    assert "jv_review_001" in csv_text
+    form_text = Path(paths["google_form_bilingual"]).read_text(encoding="utf-8")
+    assert "Judge Validation Human Labels" in form_text
+    assert "裁判验证人类专家标注" in form_text
+
+
+def test_review_packet_blind_ids_use_corpus_position_for_targeted_exports():
+    corpus = {
+        "items": [
+            {
+                "sample_id": "first",
+                "dimension": "result_judge",
+                "registry_rubric_id": "code_correctness.v1",
+                "context": "first context",
+            },
+            {
+                "sample_id": "second",
+                "dimension": "result_judge",
+                "registry_rubric_id": "code_correctness.v1",
+                "context": "second context",
+            },
+        ]
+    }
+    registry = {
+        "rubrics": [
+            {
+                "rubric_id": "code_correctness.v1",
+                "version": "v1",
+                "dimension": "code_correctness",
+                "score_scale": {"min": 1, "max": 5},
+                "score_anchors": {"1": "broken", "5": "robust"},
+            }
+        ]
+    }
+
+    packet = build_review_packet(
+        corpus=corpus,
+        rubric_registry=registry,
+        sample_ids=["second"],
+    )
+
+    assert packet["items"][0]["sample_id"] == "jv_review_002"
+    assert packet["private_sample_map"][0]["original_sample_id"] == "second"
+
+
+def test_export_review_packet_cli(tmp_path):
+    corpus_path = tmp_path / "corpus.json"
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "packet"
+    corpus_path.write_text(
+        json.dumps(
+            {
+                "items": [
+                    {
+                        "sample_id": "sample",
+                        "task_id": "task",
+                        "category": "debug",
+                        "persona_id": "developer_crossover",
+                        "transcript_source": "synthetic_adversarial",
+                        "track": "qr",
+                        "dimension": "result_judge",
+                        "registry_rubric_id": "code_correctness.v1",
+                        "context": "## Task\nFix the bug.",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry_path.write_text(
+        json.dumps(
+            {
+                "rubrics": [
+                    {
+                        "rubric_id": "code_correctness.v1",
+                        "version": "v1",
+                        "dimension": "code_correctness",
+                        "score_scale": {"min": 1, "max": 5},
+                        "score_anchors": {"1": "broken", "5": "robust"},
+                        "required_evidence": ["test output"],
+                        "common_failure_cases": ["runtime error"],
+                        "examples": {"high": "tested fix"},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rc = judge_run.main(
+        [
+            "--corpus",
+            str(corpus_path),
+            "export-review-packet",
+            "--rubric-registry",
+            str(registry_path),
+            "--packet-output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert rc == 0
+    assert (output_dir / "human_review_packet.json").exists()
+    assert (output_dir / "human_review_packet.md").exists()
+    assert (output_dir / "human_label_template.csv").exists()
+    assert (output_dir / "google_form_bilingual.md").exists()
+    assert (output_dir / "human_review_sample_map.json").exists()
+
+
+def test_export_review_packet_cli_honors_output_dir(tmp_path):
+    corpus_path = tmp_path / "corpus.json"
+    registry_path = tmp_path / "registry.json"
+    output_dir = tmp_path / "results"
+    corpus_path.write_text(
+        json.dumps(
+            {
+                "items": [
+                    {
+                        "sample_id": "sample",
+                        "task_id": "task",
+                        "category": "debug",
+                        "persona_id": "developer_crossover",
+                        "transcript_source": "synthetic_adversarial",
+                        "track": "qr",
+                        "dimension": "result_judge",
+                        "registry_rubric_id": "code_correctness.v1",
+                        "context": "## Task\nFix the bug.",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry_path.write_text(
+        json.dumps(
+            {
+                "rubrics": [
+                    {
+                        "rubric_id": "code_correctness.v1",
+                        "version": "v1",
+                        "dimension": "code_correctness",
+                        "score_scale": {"min": 1, "max": 5},
+                        "score_anchors": {"1": "broken", "5": "robust"},
+                        "required_evidence": ["test output"],
+                        "common_failure_cases": ["runtime error"],
+                        "examples": {"high": "tested fix"},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rc = judge_run.main(
+        [
+            "--corpus",
+            str(corpus_path),
+            "--output-dir",
+            str(output_dir),
+            "export-review-packet",
+            "--rubric-registry",
+            str(registry_path),
+        ]
+    )
+
+    assert rc == 0
+    assert (output_dir / "human_review_packet" / "google_form_bilingual.md").exists()


### PR DESCRIPTION
Refs #84

## Scope
- Add human label schema and example artifact for Stage 3 expert review.
- Add Google Form CSV conversion for canonical human label JSON.
- Add human alignment stats and Markdown/HTML/JSON reports joining human labels with judge runs.
- Wire convert-human-labels and human-alignment into the judge validation CLI.
- Document the tutor rubric vs judge validation metric distinction.

## Verification
- pytest: 35 passed.
- python3 -m py_compile bench/experiments/judge_validation/human_alignment.py bench/experiments/judge_validation/run.py tests/test_judge_human_alignment.py: passed.
- git diff --check: passed.
- codex exec review --uncommitted: two rounds; fixed full-label coverage gating, integral score validation, and Google Forms Email Address reviewer alias.