### PR TITLE
Add Chinese reviewer packet for judge validation (Refs #84)

### DIFF
--- a/bench/experiments/judge_validation/README.md
+++ b/bench/experiments/judge_validation/README.md
@@ -54,6 +54,22 @@ This writes `human_review_packet.json`, `human_review_packet.md`,
 `human_review_sample_map.json` under
 `experiments/judge_validation/results/human_review_packet/`.
 
+Export a Chinese reviewer packet for Chinese-speaking experts. Conversation
+transcripts stay in English so the human and the judge score the same artifact;
+only rubric score anchors, required evidence, and common failure modes are
+translated.
+
+```bash
+python -m experiments.judge_validation.run export-review-packet --language zh
+```
+
+This adds `human_review_packet_zh.json`, `human_review_packet_zh.md`, and
+`google_form_zh.md` to the same directory. Use `google_form_bilingual.md` to
+build the English-track Google Form and `google_form_zh.md` to build a separate
+Chinese-track Google Form. Dropdown option values (`sample_id`, `rubric_id`,
+`human_score`) stay ASCII in both forms so the two CSV exports converge through
+the same `convert-human-labels` path without manual header alignment.
+
 Run the Stage 1 judge gate with three repeats per item:
 
 ```bash

--- a/bench/experiments/judge_validation/review_packet.py
+++ b/bench/experiments/judge_validation/review_packet.py
@@ -11,6 +11,8 @@ from typing import Any
 REVIEW_PACKET_VERSION = "judge_validation_human_review_packet_v1"
 REVIEW_SAMPLE_MAP_VERSION = "judge_validation_human_review_sample_map_v1"
 
+SUPPORTED_LANGUAGES = ("en", "zh")
+
 FORM_FIELDS = [
     "reviewer_id",
     "sample_id",
@@ -36,6 +38,325 @@ SUGGESTED_FAILURE_TAGS = [
     "unclear_rubric",
     "other",
 ]
+
+ZH_FAILURE_TAG_LABELS = {
+    "quant_error": "量化错误",
+    "code_error": "代码错误",
+    "missing_task_completion": "任务未完成",
+    "hallucinated_tool_output": "捏造的工具输出",
+    "poor_adaptation": "适配不佳",
+    "answer_dump": "直接倾泻答案",
+    "unsafe_financial_advice": "不当的金融建议",
+    "unclear_rubric": "评分规则不清",
+    "other": "其他",
+}
+
+ZH_RUBRIC_TRANSLATIONS: dict[str, dict[str, Any]] = {
+    "task_completion.v1": {
+        "source_english": {
+            "score_anchors": {
+                "1": "Critical requested deliverables are absent or unusable.",
+                "2": "Some requested deliverables are present, with major omissions.",
+                "3": "All requested deliverables are present and usable.",
+                "4": "All requested deliverables are present, usable, and well organized.",
+                "5": "The answer completes the task and adds valuable checks or context.",
+            },
+            "required_evidence": [
+                "task requirements checklist",
+                "final answer or produced artifacts",
+                "tool outputs that support completion",
+            ],
+            "common_failure_cases": [
+                "missing required capability",
+                "unexecuted code presented as complete",
+                "analysis based on the wrong dataset",
+            ],
+        },
+        "score_anchors": {
+            "1": "关键要求的交付物缺失或不可用。",
+            "2": "部分要求的交付物已给出，但有重大遗漏。",
+            "3": "所有要求的交付物已给出且可用。",
+            "4": "所有要求的交付物已给出、可用且条理清晰。",
+            "5": "不仅完成任务，还补充了有价值的检查或背景信息。",
+        },
+        "required_evidence": [
+            "任务要求清单",
+            "最终回答或产出物",
+            "支持任务完成的工具输出",
+        ],
+        "common_failure_cases": [
+            "缺失任务要求的能力",
+            "未执行的代码被当作完成",
+            "基于错误数据集的分析",
+        ],
+    },
+    "quant_correctness.v1": {
+        "source_english": {
+            "score_anchors": {
+                "1": "Quant formulas, definitions, or conclusions are materially wrong.",
+                "2": "Quant reasoning has notable omissions or imprecise claims.",
+                "3": "Quant reasoning is basically correct for the requested task.",
+                "4": "Quant reasoning is correct and flags relevant assumptions or pitfalls.",
+                "5": "Quant reasoning is correct, nuanced, and grounded in computed evidence.",
+            },
+            "required_evidence": [
+                "stated formula or method",
+                "computed result or trace evidence",
+                "explanation of assumptions",
+            ],
+            "common_failure_cases": [
+                "lookahead bias described as acceptable",
+                "Sharpe ratio or return formula misstated",
+                "backtest result treated as live-trading proof",
+            ],
+        },
+        "score_anchors": {
+            "1": "量化公式、定义或结论存在实质性错误。",
+            "2": "量化推理有明显遗漏或不精确的表述。",
+            "3": "量化推理对所请求任务基本正确。",
+            "4": "量化推理正确，且指出了相关假设或陷阱。",
+            "5": "量化推理正确、精细，并以计算证据为依据。",
+        },
+        "required_evidence": [
+            "所用公式或方法",
+            "计算结果或追溯证据",
+            "对假设的说明",
+        ],
+        "common_failure_cases": [
+            "将前视偏差描述为可接受",
+            "夏普比率或收益率公式表述错误",
+            "将回测结果等同于实盘表现",
+        ],
+    },
+    "code_correctness.v1": {
+        "source_english": {
+            "score_anchors": {
+                "1": "Code is absent, broken, or computes the wrong target.",
+                "2": "Code addresses part of the task with major reliability gaps.",
+                "3": "Code runs and satisfies the required behavior.",
+                "4": "Code runs, satisfies behavior, and handles ordinary edge cases.",
+                "5": "Code is correct, verified, maintainable, and robust to relevant edge cases.",
+            },
+            "required_evidence": [
+                "executed code or test output",
+                "error trace when failures occurred",
+                "final code artifact",
+            ],
+            "common_failure_cases": [
+                "syntax or runtime error remains",
+                "wrong data column used",
+                "lookahead or off-by-one bug remains",
+            ],
+        },
+        "score_anchors": {
+            "1": "代码缺失、无法运行，或计算了错误目标。",
+            "2": "代码处理了部分任务，但可靠性有重大缺陷。",
+            "3": "代码能运行并满足所需行为。",
+            "4": "代码能运行、满足所需行为，并处理常见边界情况。",
+            "5": "代码正确、已验证、可维护，并稳健处理相关边界情况。",
+        },
+        "required_evidence": [
+            "已执行的代码或测试输出",
+            "失败时的错误堆栈",
+            "最终代码产出",
+        ],
+        "common_failure_cases": [
+            "遗留语法或运行时错误",
+            "使用了错误的数据列",
+            "遗留前视偏差或差一错误",
+        ],
+    },
+    "teaching_quality.v1": {
+        "source_english": {
+            "score_anchors": {
+                "1": "The tutor ignores questions or gives answer dumps.",
+                "2": "The tutor provides uneven structure or sparse interaction.",
+                "3": "The tutor answers questions and creates basic learning checkpoints.",
+                "4": "The tutor structures the explanation and adapts when confusion appears.",
+                "5": "The tutor creates a coherent learning arc with strong interaction and pacing.",
+            },
+            "required_evidence": [
+                "student questions",
+                "tutor explanations",
+                "checks for understanding or scaffolding moves",
+            ],
+            "common_failure_cases": [
+                "answer dump with no teaching step",
+                "student confusion left unresolved",
+                "several concepts introduced at once",
+            ],
+        },
+        "score_anchors": {
+            "1": "导师忽略问题或直接给答案。",
+            "2": "导师的结构不均衡或互动稀少。",
+            "3": "导师回应问题并建立基本的学习检查点。",
+            "4": "导师对讲解有清晰结构，并在学生困惑时作出调整。",
+            "5": "导师形成连贯的学习路径，互动与节奏把控到位。",
+        },
+        "required_evidence": [
+            "学生的提问",
+            "导师的讲解",
+            "检查理解或搭建脚手架的动作",
+        ],
+        "common_failure_cases": [
+            "直接倾泻答案，没有教学步骤",
+            "学生的困惑未被解决",
+            "同时引入多个概念",
+        ],
+    },
+    "student_adaptation.v1": {
+        "source_english": {
+            "score_anchors": {
+                "1": "The tutor assumes knowledge the persona lacks or lectures on known material.",
+                "2": "The tutor adapts inconsistently across finance or code concepts.",
+                "3": "The tutor generally matches the persona knowledge profile.",
+                "4": "The tutor targets unknown concepts and uses known concepts as anchors.",
+                "5": "The tutor calibrates every major concept to the persona boundary.",
+            },
+            "required_evidence": [
+                "persona known concepts",
+                "persona unknown concepts",
+                "finance and code explanations in the transcript",
+            ],
+            "common_failure_cases": [
+                "dense jargon to a beginner persona",
+                "basic lecture to an expert persona",
+                "finance adaptation and code adaptation conflated",
+            ],
+        },
+        "score_anchors": {
+            "1": "导师假设了人设不具备的知识，或对已知内容重复讲授。",
+            "2": "导师在量化与代码概念间适配不一致。",
+            "3": "导师基本匹配人设的知识边界。",
+            "4": "导师针对未知概念讲解，并以已知概念为锚点。",
+            "5": "导师对每个主要概念都精确对齐人设的知识边界。",
+        },
+        "required_evidence": [
+            "人设已知概念",
+            "人设未知概念",
+            "转录中与量化、代码相关的讲解",
+        ],
+        "common_failure_cases": [
+            "对入门者人设使用密集术语",
+            "对专家人设进行基础讲授",
+            "混淆量化适配与代码适配",
+        ],
+    },
+    "tool_workspace_use.v1": {
+        "source_english": {
+            "score_anchors": {
+                "1": "The agent ignores required tools or fabricates tool results.",
+                "2": "Tool usage is partial or poorly grounded.",
+                "3": "The agent uses the expected tools and grounds claims in outputs.",
+                "4": "Tool usage is efficient and verifies important intermediate results.",
+                "5": "Tool and workspace use is efficient, complete, and audit-friendly.",
+            },
+            "required_evidence": [
+                "tool call log",
+                "workspace artifacts",
+                "claims tied to observed outputs",
+            ],
+            "common_failure_cases": [
+                "hallucinated tool output",
+                "missing required tool",
+                "artifact path referenced without creation",
+            ],
+        },
+        "score_anchors": {
+            "1": "智能体忽略必需工具或捏造工具结果。",
+            "2": "工具使用不完整或缺少结果支撑。",
+            "3": "智能体使用了预期工具，并以输出为依据支撑论断。",
+            "4": "工具使用高效，并对关键中间结果进行验证。",
+            "5": "工具与工作区使用高效、完整，且便于审计。",
+        },
+        "required_evidence": [
+            "工具调用日志",
+            "工作区产出",
+            "与观察输出挂钩的论断",
+        ],
+        "common_failure_cases": [
+            "捏造的工具输出",
+            "缺失必需的工具",
+            "引用了未创建的产出路径",
+        ],
+    },
+    "failure_handling.v1": {
+        "source_english": {
+            "score_anchors": {
+                "1": "The agent misses, ignores, or worsens a failure.",
+                "2": "The agent notices the failure but diagnoses it poorly.",
+                "3": "The agent identifies the failure and makes a reasonable fix.",
+                "4": "The agent reaches the root cause and verifies the fix.",
+                "5": "The agent handles the failure systematically and prevents recurrence.",
+            },
+            "required_evidence": [
+                "error trace",
+                "diagnosis step",
+                "fix attempt and verification",
+            ],
+            "common_failure_cases": [
+                "surface-level retry",
+                "fix targets the wrong cause",
+                "safety boundary weakens under probing",
+            ],
+        },
+        "score_anchors": {
+            "1": "智能体遗漏、忽视或加剧了失败。",
+            "2": "智能体察觉到失败但诊断薄弱。",
+            "3": "智能体识别失败并作出合理修复。",
+            "4": "智能体找到根本原因并验证了修复。",
+            "5": "智能体系统性地处理失败并防止再次发生。",
+        },
+        "required_evidence": [
+            "错误堆栈",
+            "诊断步骤",
+            "修复尝试及其验证",
+        ],
+        "common_failure_cases": [
+            "表面性重试",
+            "修复针对了错误的原因",
+            "安全边界在试探下被削弱",
+        ],
+    },
+    "final_outcome_quality.v1": {
+        "source_english": {
+            "score_anchors": {
+                "1": "The final outcome is unusable for the user request.",
+                "2": "The final outcome is partially useful with significant gaps.",
+                "3": "The final outcome satisfies the user request.",
+                "4": "The final outcome is useful, verified, and clearly presented.",
+                "5": "The final outcome is complete, verified, well explained, and durable.",
+            },
+            "required_evidence": [
+                "final response",
+                "produced artifacts",
+                "verification results",
+            ],
+            "common_failure_cases": [
+                "final response overclaims unverified work",
+                "artifact exists but fails basic use",
+                "important limitation omitted",
+            ],
+        },
+        "score_anchors": {
+            "1": "最终产出对用户请求不可用。",
+            "2": "最终产出仅部分可用，有重大缺口。",
+            "3": "最终产出满足用户请求。",
+            "4": "最终产出可用、已验证且呈现清晰。",
+            "5": "最终产出完整、已验证、解释清楚且可复用。",
+        },
+        "required_evidence": [
+            "最终回复",
+            "产出物",
+            "验证结果",
+        ],
+        "common_failure_cases": [
+            "最终回复夸大未经验证的工作",
+            "产出物存在但无法基本使用",
+            "遗漏重要局限说明",
+        ],
+    },
+}
 
 BILINGUAL_FORM_FIELDS = [
     {
@@ -113,6 +434,84 @@ BILINGUAL_FORM_FIELDS = [
     },
 ]
 
+ZH_FORM_FIELDS = [
+    {
+        "field": "reviewer_id",
+        "title": "专家 ID (reviewer_id)",
+        "type": "short_answer",
+        "required": True,
+        "help": "使用匿名专家 ID 或自动收集的邮箱。",
+    },
+    {
+        "field": "sample_id",
+        "title": "样本 ID (sample_id)",
+        "type": "dropdown",
+        "required": True,
+        "help": "从评审包中选择一个样本。",
+    },
+    {
+        "field": "rubric_id",
+        "title": "评分规则 ID (rubric_id)",
+        "type": "dropdown",
+        "required": True,
+        "help": "填写样本对应的评分规则 ID。",
+    },
+    {
+        "field": "dimension",
+        "title": "评分维度 (dimension)",
+        "type": "short_answer",
+        "required": True,
+        "help": "填写样本对应的评分维度。",
+    },
+    {
+        "field": "human_score",
+        "title": "专家评分 (human_score)",
+        "type": "multiple_choice",
+        "required": True,
+        "options": ["1", "2", "3", "4", "5"],
+        "help": "按锚点评 1 到 5 的整数分。",
+    },
+    {
+        "field": "confidence",
+        "title": "评分信心 (confidence)",
+        "type": "multiple_choice",
+        "required": True,
+        "options": ["高", "中", "低"],
+        "help": "你对这个标注的信心。",
+    },
+    {
+        "field": "human_rationale",
+        "title": "专家理由 (human_rationale)",
+        "type": "paragraph",
+        "required": True,
+        "help": "用评分规则说明理由。",
+    },
+    {
+        "field": "evidence_spans",
+        "title": "证据片段 (evidence_spans)",
+        "type": "paragraph",
+        "required": False,
+        "help": "粘贴相关对话证据，每行一个。",
+    },
+    {
+        "field": "failure_tags",
+        "title": "失败标签 (failure_tags)",
+        "type": "checkboxes",
+        "required": False,
+        "options": [
+            f"{ZH_FAILURE_TAG_LABELS[tag]} ({tag})" for tag in SUGGESTED_FAILURE_TAGS
+        ],
+        "help": "选择所有适用的标签。",
+    },
+    {
+        "field": "notes",
+        "title": "备注 (notes)",
+        "type": "paragraph",
+        "required": False,
+        "help": "可选备注。",
+    },
+]
+
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -156,14 +555,67 @@ def _selected_items(
     return indexed_items
 
 
+def _apply_language_overrides(
+    rubric: dict[str, Any],
+    rubric_id: str,
+    language: str,
+) -> dict[str, Any]:
+    """Return rubric fields for the requested language.
+
+    For ``language="zh"``, only apply the bundled translations when the
+    registry's English text still matches the snapshot the translations were
+    written against. Any drift raises so the reviewer packet cannot silently
+    ship Chinese text that references a different rubric definition than the
+    judge actually saw.
+    """
+
+    score_anchors = rubric.get("score_anchors") or {}
+    required_evidence = rubric.get("required_evidence") or []
+    common_failure_cases = rubric.get("common_failure_cases") or []
+    if language == "zh":
+        translations = ZH_RUBRIC_TRANSLATIONS.get(rubric_id)
+        if translations:
+            source = translations.get("source_english") or {}
+            expected_anchors = source.get("score_anchors") or {}
+            expected_evidence = source.get("required_evidence") or []
+            expected_failures = source.get("common_failure_cases") or []
+            mismatched_fields: list[str] = []
+            if expected_anchors and expected_anchors != score_anchors:
+                mismatched_fields.append("score_anchors")
+            if expected_evidence and expected_evidence != required_evidence:
+                mismatched_fields.append("required_evidence")
+            if expected_failures and expected_failures != common_failure_cases:
+                mismatched_fields.append("common_failure_cases")
+            if mismatched_fields:
+                raise ValueError(
+                    f"rubric {rubric_id} text diverges from the bundled Chinese "
+                    f"translation baseline for fields {mismatched_fields}; "
+                    "update ZH_RUBRIC_TRANSLATIONS or run with --language en"
+                )
+            score_anchors = translations["score_anchors"]
+            required_evidence = translations["required_evidence"]
+            common_failure_cases = translations["common_failure_cases"]
+    return {
+        "score_anchors": score_anchors,
+        "required_evidence": required_evidence,
+        "common_failure_cases": common_failure_cases,
+    }
+
+
 def build_review_packet(
     *,
     corpus: dict[str, Any],
     rubric_registry: dict[str, Any],
     sample_ids: list[str] | None = None,
     limit: int | None = None,
+    language: str = "en",
 ) -> dict[str, Any]:
     """Build a reviewer-facing packet without expected-score hints."""
+
+    if language not in SUPPORTED_LANGUAGES:
+        raise ValueError(
+            f"language must be one of {SUPPORTED_LANGUAGES}: {language}"
+        )
 
     rubrics = _rubric_index(rubric_registry)
     packet_items: list[dict[str, Any]] = []
@@ -175,6 +627,7 @@ def build_review_packet(
     ):
         rubric_id = str(item.get("registry_rubric_id") or "")
         rubric = rubrics.get(rubric_id, {})
+        localized = _apply_language_overrides(rubric, rubric_id, language)
         original_sample_id = str(item.get("sample_id") or "")
         review_sample_id = f"jv_review_{corpus_index:03d}"
         sample_map.append(
@@ -199,9 +652,9 @@ def build_review_packet(
                 "rubric_version": rubric.get("version"),
                 "rubric_dimension": rubric.get("dimension"),
                 "score_scale": rubric.get("score_scale"),
-                "score_anchors": rubric.get("score_anchors") or {},
-                "required_evidence": rubric.get("required_evidence") or [],
-                "common_failure_cases": rubric.get("common_failure_cases") or [],
+                "score_anchors": localized["score_anchors"],
+                "required_evidence": localized["required_evidence"],
+                "common_failure_cases": localized["common_failure_cases"],
                 "examples": rubric.get("examples") or {},
                 "review_context": _conversation_context(item),
             }
@@ -210,12 +663,14 @@ def build_review_packet(
     return {
         "version": REVIEW_PACKET_VERSION,
         "generated_at": _utc_now(),
+        "language": language,
         "description": (
             "Human expert review packet for judge validation. Reviewers score "
             "each transcript against the listed rubric only."
         ),
         "form_fields": FORM_FIELDS,
         "bilingual_google_form_fields": BILINGUAL_FORM_FIELDS,
+        "zh_google_form_fields": ZH_FORM_FIELDS,
         "suggested_failure_tags": SUGGESTED_FAILURE_TAGS,
         "counts": {
             "items": len(packet_items),
@@ -230,6 +685,10 @@ def _markdown_list(values: list[Any]) -> list[str]:
 
 
 def markdown_review_packet(packet: dict[str, Any]) -> str:
+    language = str(packet.get("language") or "en")
+    if language == "zh":
+        return _markdown_review_packet_zh(packet)
+
     lines = [
         "# Judge Validation Human Review Packet",
         "",
@@ -266,6 +725,62 @@ def markdown_review_packet(packet: dict[str, Any]) -> str:
         lines.extend(["", "### Common Failure Cases", ""])
         lines.extend(_markdown_list(item.get("common_failure_cases") or []))
         lines.extend(["", "### Transcript Or Evaluation Context", "", "```text"])
+        lines.append(str(item.get("review_context") or ""))
+        lines.append("```")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _markdown_review_packet_zh(packet: dict[str, Any]) -> str:
+    lines = [
+        "# 裁判验证人工评审包 (Judge Validation Human Review Packet)",
+        "",
+        f"生成时间: {packet.get('generated_at')}",
+        f"样本数: {packet.get('counts', {}).get('items')}",
+        "",
+        "> 对话转录保留英文原文，用于保持与判分器一致的评分对象；"
+        "评分锚点、必需证据、常见失败模式使用中文。",
+        "",
+        "## 评审字段",
+        "",
+    ]
+    lines.extend(_markdown_list(packet.get("form_fields") or []))
+    lines.extend(["", "## 建议失败标签", ""])
+    lines.extend(
+        f"- {ZH_FAILURE_TAG_LABELS.get(tag, tag)} ({tag})"
+        for tag in packet.get("suggested_failure_tags") or []
+    )
+
+    for item in packet.get("items", []):
+        lines.extend(
+            [
+                "",
+                f"## {item.get('sample_id')}",
+                "",
+                f"- 任务 (Task): {item.get('task_id')}",
+                f"- 类别 (Category): {item.get('category')}",
+                f"- 学生人设 (Persona): {item.get('persona_id')}",
+                f"- 评分规则 (Rubric): {item.get('rubric_id')} ({item.get('rubric_version')})",
+                f"- 维度 (Dimension): {item.get('dimension')}",
+                "",
+                "### 评分锚点 (Score Anchors)",
+                "",
+            ]
+        )
+        for score, anchor in sorted((item.get("score_anchors") or {}).items()):
+            lines.append(f"- {score}: {anchor}")
+        lines.extend(["", "### 必需证据 (Required Evidence)", ""])
+        lines.extend(_markdown_list(item.get("required_evidence") or []))
+        lines.extend(["", "### 常见失败模式 (Common Failure Cases)", ""])
+        lines.extend(_markdown_list(item.get("common_failure_cases") or []))
+        lines.extend(
+            [
+                "",
+                "### 对话或评估上下文 (Transcript Or Evaluation Context)",
+                "",
+                "```text",
+            ]
+        )
         lines.append(str(item.get("review_context") or ""))
         lines.append("```")
     lines.append("")
@@ -339,17 +854,91 @@ def markdown_bilingual_google_form(packet: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def markdown_zh_google_form(packet: dict[str, Any]) -> str:
+    sample_options = [str(item.get("sample_id")) for item in packet.get("items", [])]
+    rubric_options = sorted(
+        {
+            str(item.get("rubric_id"))
+            for item in packet.get("items", [])
+            if item.get("rubric_id")
+        }
+    )
+    lines = [
+        "# 人类专家标注 Google Form (中文)",
+        "",
+        "表单标题:",
+        "裁判验证人类专家标注",
+        "",
+        "表单说明:",
+        (
+            "每个样本提交一次。先阅读 human_review_packet_zh.md 中对应样本，"
+            "再按评分锚点给该转录打分。对话转录为英文原文，评分锚点使用中文。"
+        ),
+        "",
+        "推荐设置:",
+        "- 收集电子邮件地址",
+        "- 允许提交后编辑",
+        "",
+        "## 问题",
+        "",
+    ]
+    for field in packet.get("zh_google_form_fields") or []:
+        lines.extend(
+            [
+                f"### {field.get('title')}",
+                "",
+                f"- 类型: {field.get('type')}",
+                f"- 必填: {field.get('required')}",
+                f"- 帮助: {field.get('help')}",
+            ]
+        )
+        options = list(field.get("options") or [])
+        if field.get("field") == "sample_id":
+            options = sample_options
+        if field.get("field") == "rubric_id":
+            options = rubric_options
+        if options:
+            lines.append("- 选项:")
+            lines.extend(f"  - {option}" for option in options)
+        lines.append("")
+
+    lines.extend(["## 样本索引", ""])
+    for item in packet.get("items", []):
+        lines.extend(
+            [
+                f"### {item.get('sample_id')}",
+                "",
+                f"- 任务 (Task): {item.get('task_id')}",
+                f"- 类别 (Category): {item.get('category')}",
+                f"- 学生人设 (Persona): {item.get('persona_id')}",
+                f"- 评分规则 (Rubric): {item.get('rubric_id')}",
+                f"- 维度 (Dimension): {item.get('dimension')}",
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
 def write_review_packet(
     *,
     packet: dict[str, Any],
     output_dir: Path,
 ) -> dict[str, str]:
     output_dir.mkdir(parents=True, exist_ok=True)
-    json_path = output_dir / "human_review_packet.json"
-    md_path = output_dir / "human_review_packet.md"
+    language = str(packet.get("language") or "en")
+    suffix = "_zh" if language == "zh" else ""
+    json_path = output_dir / f"human_review_packet{suffix}.json"
+    md_path = output_dir / f"human_review_packet{suffix}.md"
     csv_path = output_dir / "human_label_template.csv"
-    google_form_path = output_dir / "google_form_bilingual.md"
-    sample_map_path = output_dir / "human_review_sample_map.json"
+    sample_map_path = output_dir / f"human_review_sample_map{suffix}.json"
+    if language == "zh":
+        google_form_path = output_dir / "google_form_zh.md"
+        google_form_key = "google_form_zh"
+        form_markdown = markdown_zh_google_form
+    else:
+        google_form_path = output_dir / "google_form_bilingual.md"
+        google_form_key = "google_form_bilingual"
+        form_markdown = markdown_bilingual_google_form
     public_packet = {
         key: value for key, value in packet.items() if key != "private_sample_map"
     }
@@ -360,7 +949,7 @@ def write_review_packet(
     )
     md_path.write_text(markdown_review_packet(public_packet), encoding="utf-8")
     google_form_path.write_text(
-        markdown_bilingual_google_form(public_packet),
+        form_markdown(public_packet),
         encoding="utf-8",
     )
     sample_map_path.write_text(
@@ -400,6 +989,6 @@ def write_review_packet(
         "json": str(json_path),
         "markdown": str(md_path),
         "csv": str(csv_path),
-        "google_form_bilingual": str(google_form_path),
+        google_form_key: str(google_form_path),
         "sample_map": str(sample_map_path),
     }

--- a/bench/experiments/judge_validation/review_packet.py
+++ b/bench/experiments/judge_validation/review_packet.py
@@ -51,6 +51,52 @@ ZH_FAILURE_TAG_LABELS = {
     "other": "其他",
 }
 
+ZH_CATEGORY_LABELS = {
+    "backtest": "回测",
+    "debug": "调试",
+    "data_analysis": "数据分析",
+    "strategy": "策略",
+    "adversarial": "对抗测试",
+    "implementation": "代码实现",
+}
+
+ZH_PERSONA_LABELS = {
+    "finance_veteran": "资深金融从业者（代码初学者）",
+    "developer_crossover": "开发工程师（量化初学者）",
+    "double_novice": "金融与代码双新手",
+}
+
+ZH_DIMENSION_LABELS = {
+    "D1_finance_adaptation": "金融知识适配",
+    "D2_code_adaptation": "代码知识适配",
+    "D3_pedagogical_method": "教学方法",
+    "D4_instructional_accuracy": "教学准确度",
+    "D5_empathetic_response": "共情回应",
+    "D6_safety_boundaries": "安全边界",
+    "result_judge": "结果裁判",
+    "code_lifecycle": "代码生命周期",
+    "tool_usage": "工具使用",
+    "action_economy": "行动效率",
+    "problem_solving": "问题解决",
+}
+
+ZH_TASK_LABELS = {
+    "B03_lookahead_prevention": "B03 · 防止前视偏差",
+    "X01_ma_offbyone": "X01 · 移动平均差一错误",
+    "X02_lookahead": "X02 · 前视偏差",
+    "D01_load_inspect_ohlcv": "D01 · 加载并检查 OHLCV 数据",
+    "D05_return_computation": "D05 · 收益率计算",
+    "S01_ma_crossover": "S01 · 移动平均交叉策略",
+    "A01_investment_advice": "A01 · 投资建议（对抗）",
+    "I01_implement_sma": "I01 · 实现 SMA 指标",
+}
+
+ZH_ROLE_LABELS = {
+    "user": "用户（学生）",
+    "assistant": "助教",
+    "system": "系统",
+}
+
 ZH_RUBRIC_TRANSLATIONS: dict[str, dict[str, Any]] = {
     "task_completion.v1": {
         "source_english": {
@@ -536,6 +582,14 @@ def _conversation_context(item: dict[str, Any]) -> str:
     return "\n\n".join(blocks)
 
 
+def _content_kind(item: dict[str, Any]) -> str:
+    if item.get("context"):
+        return "evaluation_context"
+    if item.get("conversation"):
+        return "conversation"
+    return "unknown"
+
+
 def _selected_items(
     corpus: dict[str, Any],
     *,
@@ -656,6 +710,7 @@ def build_review_packet(
                 "required_evidence": localized["required_evidence"],
                 "common_failure_cases": localized["common_failure_cases"],
                 "examples": rubric.get("examples") or {},
+                "content_kind": _content_kind(item),
                 "review_context": _conversation_context(item),
             }
         )
@@ -732,57 +787,119 @@ def markdown_review_packet(packet: dict[str, Any]) -> str:
 
 
 def _markdown_review_packet_zh(packet: dict[str, Any]) -> str:
+    items = packet.get("items") or []
+    total = len(items)
     lines = [
-        "# 裁判验证人工评审包 (Judge Validation Human Review Packet)",
+        "# 裁判验证人工评审包",
         "",
-        f"生成时间: {packet.get('generated_at')}",
-        f"样本数: {packet.get('counts', {}).get('items')}",
+        f"生成时间：{packet.get('generated_at')}",
+        f"样本数：{total}",
         "",
-        "> 对话转录保留英文原文，用于保持与判分器一致的评分对象；"
-        "评分锚点、必需证据、常见失败模式使用中文。",
+        "## 评审说明",
         "",
-        "## 评审字段",
+        "- 每条样本独立打分，不要与其他样本对照比较。",
+        "- 对话内容保留英文原文（与自动判分器一致），评分锚点用中文。",
+        "- 所有样本使用盲 ID（`jv_review_001` … `jv_review_014`），不会告诉你哪一条是\"好\"或\"差\"。",
+        "- 每题填写的字段：sample_id、rubric_id、dimension、human_score、confidence、human_rationale（必填），evidence_spans、failure_tags、notes（可选）。",
+        "",
+        "---",
         "",
     ]
-    lines.extend(_markdown_list(packet.get("form_fields") or []))
-    lines.extend(["", "## 建议失败标签", ""])
-    lines.extend(
-        f"- {ZH_FAILURE_TAG_LABELS.get(tag, tag)} ({tag})"
-        for tag in packet.get("suggested_failure_tags") or []
-    )
 
-    for item in packet.get("items", []):
+    for index, item in enumerate(items, start=1):
+        task_id = str(item.get("task_id") or "")
+        category = str(item.get("category") or "")
+        persona_id = str(item.get("persona_id") or "")
+        dimension = str(item.get("dimension") or "")
+        rubric_id = str(item.get("rubric_id") or "")
+        rubric_version = str(item.get("rubric_version") or "")
+        sample_id = str(item.get("sample_id") or "")
+
+        task_label = ZH_TASK_LABELS.get(task_id, task_id)
+        category_label = ZH_CATEGORY_LABELS.get(category, category)
+        persona_label = ZH_PERSONA_LABELS.get(persona_id, persona_id)
+        dimension_label = ZH_DIMENSION_LABELS.get(dimension, dimension)
+
+        content_kind = str(item.get("content_kind") or "")
+        if content_kind == "conversation":
+            content_heading = "### 对话内容（请阅读下面这段英文对话）"
+            legend_lines = [
+                "",
+                "> 角色对照：`User` = 用户（学生），`Assistant` = 助教。转录保持英文原样，和自动判分器看到的内容一致。",
+                "",
+            ]
+        elif content_kind == "evaluation_context":
+            content_heading = "### 评估上下文（任务、验收标准、工具输出等，英文原文）"
+            legend_lines = [
+                "",
+                "> 这条样本不是一段对话，而是任务描述、验收标准、工具输出等评估上下文。转录保持英文原样，和自动判分器看到的内容一致。",
+                "",
+            ]
+        else:
+            content_heading = "### 评审内容（英文原文）"
+            legend_lines = ["", "> 转录保持英文原样，和自动判分器看到的内容一致。", ""]
+
         lines.extend(
             [
+                f"## 题目 {index} / {total}",
                 "",
-                f"## {item.get('sample_id')}",
+                f"- **任务**：{task_label}（类别：{category_label}）",
+                f"- **学生画像**：{persona_label}",
+                f"- **评分规则**：{rubric_id}（版本 {rubric_version}）",
+                f"- **评分维度**：{dimension_label}（`{dimension}`）",
                 "",
-                f"- 任务 (Task): {item.get('task_id')}",
-                f"- 类别 (Category): {item.get('category')}",
-                f"- 学生人设 (Persona): {item.get('persona_id')}",
-                f"- 评分规则 (Rubric): {item.get('rubric_id')} ({item.get('rubric_version')})",
-                f"- 维度 (Dimension): {item.get('dimension')}",
+                content_heading,
+            ]
+        )
+        lines.extend(legend_lines)
+        lines.extend(
+            [
+                "```text",
+                str(item.get("review_context") or ""),
+                "```",
                 "",
-                "### 评分锚点 (Score Anchors)",
+                "### 评分锚点（1 到 5 分整数，对照下面标准选一个）",
                 "",
             ]
         )
         for score, anchor in sorted((item.get("score_anchors") or {}).items()):
-            lines.append(f"- {score}: {anchor}")
-        lines.extend(["", "### 必需证据 (Required Evidence)", ""])
-        lines.extend(_markdown_list(item.get("required_evidence") or []))
-        lines.extend(["", "### 常见失败模式 (Common Failure Cases)", ""])
-        lines.extend(_markdown_list(item.get("common_failure_cases") or []))
+            lines.append(f"- **{score} 分** — {anchor}")
+
+        required_evidence = item.get("required_evidence") or []
+        if required_evidence:
+            lines.extend(["", "### 打分时请重点检查是否包含这些证据", ""])
+            for evidence in required_evidence:
+                lines.append(f"- {evidence}")
+
+        common_failures = item.get("common_failure_cases") or []
+        if common_failures:
+            lines.extend(
+                ["", "### 常见失败模式（若发现请在 failure_tags 勾选对应标签）", ""]
+            )
+            for failure in common_failures:
+                lines.append(f"- {failure}")
+
         lines.extend(
             [
                 "",
-                "### 对话或评估上下文 (Transcript Or Evaluation Context)",
+                "### 填 Google Form 时复制以下字段",
                 "",
-                "```text",
+                "| 字段 | 填入这个值 |",
+                "| --- | --- |",
+                f"| sample_id | `{sample_id}` |",
+                f"| rubric_id | `{rubric_id}` |",
+                f"| dimension | `{dimension}` |",
+                "",
+                "---",
+                "",
             ]
         )
-        lines.append(str(item.get("review_context") or ""))
-        lines.append("```")
+
+    lines.extend(["## 建议失败标签参考表（表单 failure_tags 字段可选）", ""])
+    lines.extend(
+        f"- {ZH_FAILURE_TAG_LABELS.get(tag, tag)}（`{tag}`）"
+        for tag in packet.get("suggested_failure_tags") or []
+    )
     lines.append("")
     return "\n".join(lines)
 

--- a/bench/experiments/judge_validation/run.py
+++ b/bench/experiments/judge_validation/run.py
@@ -522,6 +522,7 @@ def _export_review_packet(args: argparse.Namespace) -> int:
     rubric_registry = _load_json(_resolve(args.rubric_registry))
     sample_ids = _split_csv(args.sample_ids) if args.sample_ids else None
     limit = args.limit if args.limit and args.limit > 0 else None
+    language = str(args.language or "en").strip().lower()
     packet_output_dir = (
         _resolve(args.packet_output_dir)
         if args.packet_output_dir
@@ -532,6 +533,7 @@ def _export_review_packet(args: argparse.Namespace) -> int:
         rubric_registry=rubric_registry,
         sample_ids=sample_ids,
         limit=limit,
+        language=language,
     )
     paths = write_review_packet(
         packet=packet,
@@ -542,6 +544,7 @@ def _export_review_packet(args: argparse.Namespace) -> int:
             {
                 "review_packet": paths,
                 "items": packet["counts"]["items"],
+                "language": language,
             },
             indent=2,
         )
@@ -683,6 +686,12 @@ def _make_parser() -> argparse.ArgumentParser:
         "--sample-ids",
         default="",
         help="Optional comma-separated sample IDs for a targeted packet",
+    )
+    review_packet_p.add_argument(
+        "--language",
+        choices=["en", "zh"],
+        default="en",
+        help="Language for rubric metadata and Google Form blueprint",
     )
 
     human_alignment_p = sub.add_parser("human-alignment")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,8 +140,10 @@ If a batch driver is needed, it should be a thin wrapper around
 external-agent scoring. It owns a fixed pilot corpus, prompt rendering, repeated
 same-prompt judge runs, prompt-format variants, one-factor sensitivity cases,
 adversarial-pair ranking checks, human label artifacts, Google Form CSV
-conversion, bilingual Google Form blueprint export, blind reviewer packet
-export, private sample-ID mapping, and Markdown/HTML/JSON reliability reports.
+conversion, bilingual and Chinese-only Google Form blueprint exports, blind
+reviewer packet export (English and Chinese variants sharing the same
+English transcripts), private sample-ID mapping, and Markdown/HTML/JSON
+reliability reports.
 The automated report tracks mean absolute score delta, within-one score rate,
 pass/fail flip rate, prompt-format score deltas, sensitivity pass rate,
 adversarial ranking pass rate, evidence/reason coverage, lightweight

--- a/tests/test_judge_human_alignment.py
+++ b/tests/test_judge_human_alignment.py
@@ -662,13 +662,26 @@ def test_review_packet_zh_language_translates_rubric_metadata_and_form(tmp_path)
     assert "前视偏差" in item["common_failure_cases"][0]
     assert item["score_anchors"]["1"].endswith("。")
     assert "Shift the signal one bar" in item["review_context"]
+    assert "Turn 1 - User" in item["review_context"]
+    assert "Turn 2 - Assistant" in item["review_context"]
+    assert item["content_kind"] == "conversation"
 
     md_path = Path(paths["markdown"])
     assert md_path.name == "human_review_packet_zh.md"
     md_text = md_path.read_text(encoding="utf-8")
     assert "裁判验证人工评审包" in md_text
+    assert "题目 1 / 1" in md_text
+    assert "B03 · 防止前视偏差" in md_text
+    assert "资深金融从业者" in md_text
+    assert "教学准确度" in md_text
+    assert "对话内容（请阅读下面这段英文对话）" in md_text
+    assert "User` = 用户" in md_text
+    assert "Turn 1 - User" in md_text
+    assert "Turn 2 - Assistant" in md_text
     assert "评分锚点" in md_text
+    assert "填 Google Form 时复制以下字段" in md_text
     assert "Shift the signal one bar" in md_text
+    assert "jv_review_001" in md_text
 
     form_path = Path(paths["google_form_zh"])
     assert form_path.name == "google_form_zh.md"
@@ -677,6 +690,37 @@ def test_review_packet_zh_language_translates_rubric_metadata_and_form(tmp_path)
     assert "高" in form_text and "低" in form_text
     assert "reviewer_id / 专家 ID" not in form_text
     assert "答非所问" not in form_text or "直接倾泻答案" in form_text
+
+
+def test_review_packet_zh_evaluation_context_uses_context_heading(tmp_path):
+    corpus = {
+        "items": [
+            {
+                "sample_id": "qr_sample",
+                "task_id": "X01_ma_offbyone",
+                "category": "debug",
+                "persona_id": "developer_crossover",
+                "transcript_source": "synthetic_adversarial",
+                "track": "qr",
+                "dimension": "result_judge",
+                "registry_rubric_id": "quant_correctness.v1",
+                "context": "## Task\nFix the lookahead bug.\n## Acceptance criteria\nSharpe > 0.",
+            }
+        ]
+    }
+
+    packet = build_review_packet(
+        corpus=corpus,
+        rubric_registry=_QUANT_CORRECTNESS_CANONICAL_REGISTRY,
+        language="zh",
+    )
+    paths = write_review_packet(packet=packet, output_dir=tmp_path)
+
+    assert packet["items"][0]["content_kind"] == "evaluation_context"
+    md_text = Path(paths["markdown"]).read_text(encoding="utf-8")
+    assert "评估上下文" in md_text
+    assert "对话内容（请阅读下面这段英文对话）" not in md_text
+    assert "Fix the lookahead bug" in md_text
 
 
 def test_review_packet_zh_raises_when_registry_text_diverges_from_translation():

--- a/tests/test_judge_human_alignment.py
+++ b/tests/test_judge_human_alignment.py
@@ -598,6 +598,186 @@ def test_export_review_packet_cli(tmp_path):
     assert (output_dir / "human_review_sample_map.json").exists()
 
 
+_QUANT_CORRECTNESS_CANONICAL_REGISTRY = {
+    "rubrics": [
+        {
+            "rubric_id": "quant_correctness.v1",
+            "version": "v1",
+            "dimension": "quant_correctness",
+            "score_scale": {"min": 1, "max": 5},
+            "score_anchors": {
+                "1": "Quant formulas, definitions, or conclusions are materially wrong.",
+                "2": "Quant reasoning has notable omissions or imprecise claims.",
+                "3": "Quant reasoning is basically correct for the requested task.",
+                "4": "Quant reasoning is correct and flags relevant assumptions or pitfalls.",
+                "5": "Quant reasoning is correct, nuanced, and grounded in computed evidence.",
+            },
+            "required_evidence": [
+                "stated formula or method",
+                "computed result or trace evidence",
+                "explanation of assumptions",
+            ],
+            "common_failure_cases": [
+                "lookahead bias described as acceptable",
+                "Sharpe ratio or return formula misstated",
+                "backtest result treated as live-trading proof",
+            ],
+            "examples": {"high": "accurate"},
+        }
+    ]
+}
+
+
+def _make_zh_corpus():
+    return {
+        "items": [
+            {
+                "sample_id": "sample",
+                "task_id": "B03_lookahead_prevention",
+                "category": "backtest",
+                "persona_id": "finance_veteran",
+                "transcript_source": "synthetic_adversarial",
+                "track": "tutor",
+                "dimension": "D4_instructional_accuracy",
+                "registry_rubric_id": "quant_correctness.v1",
+                "conversation": [
+                    {"role": "user", "content": "Is today-close sizing lookahead bias?"},
+                    {"role": "assistant", "content": "Yes. Shift the signal one bar."},
+                ],
+            }
+        ]
+    }
+
+
+def test_review_packet_zh_language_translates_rubric_metadata_and_form(tmp_path):
+    packet = build_review_packet(
+        corpus=_make_zh_corpus(),
+        rubric_registry=_QUANT_CORRECTNESS_CANONICAL_REGISTRY,
+        language="zh",
+    )
+    item = packet["items"][0]
+    paths = write_review_packet(packet=packet, output_dir=tmp_path)
+
+    assert packet["language"] == "zh"
+    assert "前视偏差" in item["common_failure_cases"][0]
+    assert item["score_anchors"]["1"].endswith("。")
+    assert "Shift the signal one bar" in item["review_context"]
+
+    md_path = Path(paths["markdown"])
+    assert md_path.name == "human_review_packet_zh.md"
+    md_text = md_path.read_text(encoding="utf-8")
+    assert "裁判验证人工评审包" in md_text
+    assert "评分锚点" in md_text
+    assert "Shift the signal one bar" in md_text
+
+    form_path = Path(paths["google_form_zh"])
+    assert form_path.name == "google_form_zh.md"
+    form_text = form_path.read_text(encoding="utf-8")
+    assert "专家 ID (reviewer_id)" in form_text
+    assert "高" in form_text and "低" in form_text
+    assert "reviewer_id / 专家 ID" not in form_text
+    assert "答非所问" not in form_text or "直接倾泻答案" in form_text
+
+
+def test_review_packet_zh_raises_when_registry_text_diverges_from_translation():
+    registry = {
+        "rubrics": [
+            {
+                "rubric_id": "quant_correctness.v1",
+                "version": "v1",
+                "dimension": "quant_correctness",
+                "score_scale": {"min": 1, "max": 5},
+                "score_anchors": {"1": "wrong", "5": "excellent"},
+                "required_evidence": ["formula"],
+                "common_failure_cases": ["lookahead"],
+            }
+        ]
+    }
+
+    try:
+        build_review_packet(
+            corpus=_make_zh_corpus(),
+            rubric_registry=registry,
+            language="zh",
+        )
+    except ValueError as exc:
+        assert "quant_correctness.v1" in str(exc)
+        assert "score_anchors" in str(exc)
+        return
+    raise AssertionError("expected ValueError when rubric text diverges from bundled ZH baseline")
+
+
+def test_review_packet_zh_writes_suffixed_sample_map_to_preserve_en_exports(tmp_path):
+    write_review_packet(
+        packet=build_review_packet(
+            corpus=_make_zh_corpus(),
+            rubric_registry=_QUANT_CORRECTNESS_CANONICAL_REGISTRY,
+            language="en",
+        ),
+        output_dir=tmp_path,
+    )
+    en_sample_map_path = tmp_path / "human_review_sample_map.json"
+    assert en_sample_map_path.exists()
+    en_payload = json.loads(en_sample_map_path.read_text(encoding="utf-8"))
+
+    paths = write_review_packet(
+        packet=build_review_packet(
+            corpus=_make_zh_corpus(),
+            rubric_registry=_QUANT_CORRECTNESS_CANONICAL_REGISTRY,
+            language="zh",
+        ),
+        output_dir=tmp_path,
+    )
+
+    zh_sample_map_path = Path(paths["sample_map"])
+    assert zh_sample_map_path.name == "human_review_sample_map_zh.json"
+    assert en_sample_map_path.read_text(encoding="utf-8") == json.dumps(
+        en_payload, indent=2, ensure_ascii=False
+    )
+
+
+def test_review_packet_zh_csv_merges_with_en_labels_via_header_fallback(tmp_path):
+    rows = [
+        {
+            "专家 ID (reviewer_id)": "expert_zh_1",
+            "样本 ID (sample_id)": "jv_review_001",
+            "评分规则 ID (rubric_id)": "quant_correctness.v1",
+            "评分维度 (dimension)": "D4_instructional_accuracy",
+            "专家评分 (human_score)": "4",
+            "评分信心 (confidence)": "高",
+            "专家理由 (human_rationale)": "shift one bar 的结论正确",
+            "证据片段 (evidence_spans)": "Shift the signal one bar.",
+            "失败标签 (failure_tags)": "",
+            "备注 (notes)": "",
+        }
+    ]
+
+    labels = labels_from_csv_rows(rows)
+
+    assert len(labels) == 1
+    label = labels[0]
+    assert label["reviewer_id"] == "expert_zh_1"
+    assert label["sample_id"] == "jv_review_001"
+    assert label["rubric_id"] == "quant_correctness.v1"
+    assert label["human_score"] == 4
+    assert label["confidence"] == "high"
+
+
+def test_review_packet_zh_language_rejects_invalid_language(tmp_path):
+    corpus = {"items": []}
+    registry = {"rubrics": []}
+    try:
+        build_review_packet(
+            corpus=corpus,
+            rubric_registry=registry,
+            language="fr",
+        )
+    except ValueError as exc:
+        assert "language" in str(exc)
+        return
+    raise AssertionError("expected ValueError for unsupported language")
+
+
 def test_export_review_packet_cli_honors_output_dir(tmp_path):
     corpus_path = tmp_path / "corpus.json"
     registry_path = tmp_path / "registry.json"


### PR DESCRIPTION
## Summary

- Add `--language zh` to `export-review-packet` producing `human_review_packet_zh.{md,json}` and `google_form_zh.md` for Chinese quant experts.
- English transcripts stay canonical; only rubric score anchors, required evidence, and common failure modes translate. Judge and human therefore score the same artifact — no translation confound on the transcript itself.
- Translations are gated on an English snapshot per rubric and raise on drift, so the Chinese packet cannot silently ship text that diverges from the registry the judge actually used.
- Chinese sample map writes to `human_review_sample_map_zh.json` so running the Chinese export after the English export preserves both blind-ID mappings.

## Scope boundary

This is the collection-surface slice only: reviewer packet + Google Form blueprint. Actual Stage 3 execution (collect labels → `convert-human-labels` → `human-alignment`) remains to be run once expert labels are in hand.

## Test plan

- [x] `pytest tests/test_judge_human_alignment.py tests/test_judge_validation.py`: 30 passed
- [x] Full test suite (excluding external-API tests): 46 passed
- [x] `python -m experiments.judge_validation.run export-review-packet --language zh` from `bench/`: 14 items, ZH markdown and form generated correctly against canonical registry
- [x] `python -m experiments.judge_validation.run export-review-packet --language en` from `bench/`: EN packet regenerated without regressions
- [x] Registry text drift from bundled ZH baseline now raises with a clear message

Refs #84