### PR TITLE
Add human review console

### DIFF
--- a/bench/experiments/human_review/README.md
+++ b/bench/experiments/human_review/README.md
@@ -1,0 +1,26 @@
+# Human Review
+
+`bench/experiments/human_review/` stores structured reviewer opinion cards for
+archived session bundles. The console reads completed bundles from
+`bench/results/server/` and writes one JSON file per bundle and GitHub reviewer:
+
+```text
+human_review/{bundle_id}/{github_user_id}.json
+```
+
+Each file is append-only from the UI perspective and uses
+`human_review_opinions_v1`. The fields `sample_id`, `reviewer_id`,
+`label_version`, and `timestamp` are kept so downstream tools can join this
+artifact shape with the earlier `judge_validation/human_labels*.json` exports.
+
+Opinion cards use one primary `section`:
+
+- `task_spec`
+- `conversation`
+- `tool_log`
+- `workspace`
+- `judge_eval`
+- `overall`
+
+The optional `target` object points at the reviewed row:
+`turn_index`, `tool_call_index`, `file_path`, or `criterion_id`.

--- a/bench/experiments/human_review/human_review.schema.json
+++ b/bench/experiments/human_review/human_review.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://quanttutorbench.local/schemas/human_review_opinions_v1.json",
+  "title": "Human Review Opinion Cards",
+  "type": "object",
+  "required": [
+    "version",
+    "bundle_id",
+    "sample_id",
+    "github_username",
+    "github_user_id",
+    "reviewer_id",
+    "opinions"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "version": {
+      "const": "human_review_opinions_v1"
+    },
+    "bundle_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sample_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "github_username": {
+      "type": "string"
+    },
+    "github_user_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "reviewer_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string"
+    },
+    "opinions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/opinion"
+      }
+    }
+  },
+  "$defs": {
+    "opinion": {
+      "type": "object",
+      "required": [
+        "opinion_id",
+        "bundle_id",
+        "sample_id",
+        "section",
+        "severity",
+        "comment",
+        "tags",
+        "github_username",
+        "github_user_id",
+        "reviewer_id",
+        "created_at",
+        "timestamp",
+        "label_version"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "opinion_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "bundle_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sample_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "section": {
+          "enum": [
+            "task_spec",
+            "conversation",
+            "tool_log",
+            "workspace",
+            "judge_eval",
+            "overall"
+          ]
+        },
+        "target": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "turn_index": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "tool_call_index": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "file_path": {
+              "type": "string"
+            },
+            "criterion_id": {
+              "type": "string"
+            }
+          }
+        },
+        "severity": {
+          "enum": ["info", "concern", "blocker"]
+        },
+        "comment": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "judge_disagreement": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "judge_score": {
+              "type": "number"
+            },
+            "human_score": {
+              "type": "number"
+            }
+          }
+        },
+        "github_username": {
+          "type": "string"
+        },
+        "github_user_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reviewer_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string"
+        },
+        "label_version": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -1897,6 +1897,8 @@ def create_app(
 
     all_routes = [
         Route("/", serve_index, methods=["GET"]),
+        Route("/review", serve_index, methods=["GET"]),
+        Route("/review/{path:path}", serve_index, methods=["GET"]),
         Route("/health", rest_health, methods=["GET"]),
         *ui_routes(manager),
         *rest_routes,

--- a/bench/server/auth.py
+++ b/bench/server/auth.py
@@ -34,6 +34,7 @@ class UserContext:
     email: str
     display_name: str
     avatar_url: str
+    github_user_id: str = ""
     role: Literal["admin", "user"] = "user"
 
     @property
@@ -48,6 +49,7 @@ class UserContext:
         return cls(
             user_id=str(data.get("user_id") or ""),
             github_login=str(data.get("github_login") or ""),
+            github_user_id=str(data.get("github_user_id") or ""),
             email=str(data.get("email") or ""),
             display_name=str(data.get("display_name") or ""),
             avatar_url=str(data.get("avatar_url") or ""),
@@ -508,6 +510,7 @@ class AuthService:
         return UserContext(
             user_id=f"github:{login.lower()}",
             github_login=login,
+            github_user_id=str(profile.get("id") or ""),
             email=email,
             display_name=str(profile.get("name") or login),
             avatar_url=str(profile.get("avatar_url") or ""),
@@ -572,6 +575,7 @@ def _client_api_keys() -> dict[str, UserContext]:
         users[key] = UserContext(
             user_id=user_id,
             github_login=github_login,
+            github_user_id=user_id,
             email=email,
             display_name=github_login or user_id,
             avatar_url="",
@@ -620,6 +624,7 @@ def _local_dev_user() -> UserContext:
     return UserContext(
         user_id="local-dev",
         github_login="local-dev",
+        github_user_id="local-dev",
         email="",
         display_name="Local Dev",
         avatar_url="",

--- a/bench/server/web/README.md
+++ b/bench/server/web/README.md
@@ -20,8 +20,9 @@ Main pieces:
 
 Current routes:
 - `GET /`
-- `#/run` SPA route for the REST session run harness
-- `#/results` SPA route for archived result browsing
+- `#/flow-demo` SPA route for run flow monitoring
+- `#/run` SPA route for agent connection and run creation
+- `#/review` SPA route for archived session review
 - `#/tasks` SPA route for task browsing
 - `GET /ui/tasks`
 - `GET /ui/results`
@@ -31,11 +32,11 @@ Current routes:
 - `GET /ui/results/{session_id}/files/{path:path}`
 
 Run route scope:
-- `#/run` first asks for `Agent Test` or `Human Test`.
-- `Human Test` is a browser-side REST harness: register/start a server session, display the client-visible background and student opening, send tutor messages through `/session/{sid}/send`, refresh status/tools, cancel active sessions, and jump to Results after completion.
-- `Agent Test` mirrors the real automated flow in `bench/client/runner.py` (`register_session` → `start_session` → `list_tools` → `adapter.generate_response` → `save_client_trace`) but its start button is intentionally disabled until a backend job launcher exists.
-- The Run surface only displays public task labels such as `D01`/`X09`; hidden task metadata belongs in the server/client execution context, not the tester-facing Run panels.
-- The frontend does not start local agent subprocesses or manage automated client jobs yet.
+- `#/run` opens the agent connection surface directly.
+- The agent connection surface creates a task-specific run through `/ui/runs`, exposes run token connection details, opens the REST API key modal, and links to the QuantTutorBench REST agent skill.
+- `Agent Test` mirrors the real automated flow in `bench/client/runner.py` (`register_session` → `start_session` → `list_tools` → `adapter.generate_response` → `save_client_trace`) when the dedicated `run-agent.js` module is loaded.
+- The Run surface only displays public task labels such as `D01`/`X09`; hidden task metadata stays in the server/client execution context.
+- Session Flow owns run lifecycle browsing. Human Review owns archived session inspection.
 
 Result detail read model:
 - `tool_logs`: domain tool calls only; excludes `send_message`

--- a/bench/server/web/README.md
+++ b/bench/server/web/README.md
@@ -21,7 +21,7 @@ Main pieces:
 Current routes:
 - `GET /`
 - `#/flow-demo` SPA route for run flow monitoring
-- `#/run` SPA route for agent connection and run creation
+- `#/run` SPA route for REST agent prompt generation
 - `#/review` SPA route for archived session review
 - `#/tasks` SPA route for task browsing
 - `GET /ui/tasks`
@@ -30,12 +30,13 @@ Current routes:
 - `GET /ui/results/{session_id}/workspace`
 - `GET /ui/results/{session_id}/workspace/preview/{path:path}`
 - `GET /ui/results/{session_id}/files/{path:path}`
+- `GET /skills/quanttutorbench-rest-agent`
+- `GET /skills/quanttutorbench-rest-agent/raw`
 
 Run route scope:
-- `#/run` opens the agent connection surface directly.
-- The agent connection surface creates a task-specific run through `/ui/runs`, exposes run token connection details, opens the REST API key modal, and links to the QuantTutorBench REST agent skill.
-- `Agent Test` mirrors the real automated flow in `bench/client/runner.py` (`register_session` → `start_session` → `list_tools` → `adapter.generate_response` → `save_client_trace`) when the dedicated `run-agent.js` module is loaded.
-- The Run surface only displays public task labels such as `D01`/`X09`; hidden task metadata stays in the server/client execution context.
+- `#/run` opens a copyable REST agent prompt directly.
+- The prompt surface generates a fresh REST API key through `/ui/api-key`, embeds the key in a textarea, includes a public task label field, and includes both the browser skill URL and the raw Markdown skill URL for `curl`.
+- External agents create or claim runs through the REST skill workflow; hidden task metadata stays in the server/client execution context.
 - Session Flow owns run lifecycle browsing. Human Review owns archived session inspection.
 
 Result detail read model:

--- a/bench/server/web/README.md
+++ b/bench/server/web/README.md
@@ -40,6 +40,9 @@ Run route scope:
 - External agents create or claim runs through the REST skill workflow; hidden task metadata stays in the server/client execution context.
 - Session Flow owns run lifecycle browsing. Human Review owns archived session inspection.
 
+Task route scope:
+- `#/tasks` renders a task-class selector first, then shows tasks only for the selected class.
+
 Result detail read model:
 - `tool_logs`: domain tool calls only; excludes `send_message`
 - `all_tool_logs`: raw server `run_state.tool_logs`

--- a/bench/server/web/README.md
+++ b/bench/server/web/README.md
@@ -42,6 +42,7 @@ Run route scope:
 
 Task route scope:
 - `#/tasks` renders a task-class selector first, then shows tasks only for the selected class.
+- The task-class selector can collapse so the selected class task list gets the full width.
 
 Result detail read model:
 - `tool_logs`: domain tool calls only; excludes `send_message`

--- a/bench/server/web/README.md
+++ b/bench/server/web/README.md
@@ -30,12 +30,13 @@ Current routes:
 - `GET /ui/results/{session_id}/workspace`
 - `GET /ui/results/{session_id}/workspace/preview/{path:path}`
 - `GET /ui/results/{session_id}/files/{path:path}`
+- `GET /skill.md`
 - `GET /skills/quanttutorbench-rest-agent`
 - `GET /skills/quanttutorbench-rest-agent/raw`
 
 Run route scope:
 - `#/run` opens a copyable REST agent prompt directly.
-- The prompt surface generates a fresh REST API key through `/ui/api-key`, embeds the key in a textarea, includes a public task label field, and includes both the browser skill URL and the raw Markdown skill URL for `curl`.
+- The prompt surface generates a fresh REST API key through `/ui/api-key` and embeds a short Moltbook-style instruction, `/skill.md`, base URL, and key in a textarea.
 - External agents create or claim runs through the REST skill workflow; hidden task metadata stays in the server/client execution context.
 - Session Flow owns run lifecycle browsing. Human Review owns archived session inspection.
 

--- a/bench/server/web/review_store.py
+++ b/bench/server/web/review_store.py
@@ -1,0 +1,512 @@
+"""Human review storage and read model for archived session bundles."""
+
+from __future__ import annotations
+
+import json
+import re
+import secrets
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from server.auth import UserContext
+
+
+REVIEW_SCHEMA_VERSION = "human_review_opinions_v1"
+SECTION_IDS = {
+    "task_spec",
+    "conversation",
+    "tool_log",
+    "workspace",
+    "judge_eval",
+    "overall",
+}
+SEVERITY_IDS = {"info", "concern", "blocker"}
+TARGET_KEYS = {"turn_index", "tool_call_index", "file_path", "criterion_id"}
+
+
+class ReviewStore:
+    """JSON-on-disk opinion cards keyed by bundle and GitHub reviewer."""
+
+    def __init__(self, bench_root: str | Path, indexer):
+        self.bench_root = Path(bench_root)
+        self.indexer = indexer
+        self.review_root = self.bench_root / "experiments" / "human_review"
+        self._lock = threading.Lock()
+
+    def list_bundles(
+        self,
+        user: UserContext | None = None,
+        *,
+        include_all: bool = False,
+        include_org: bool = False,
+    ) -> list[dict[str, Any]]:
+        bundles: list[dict[str, Any]] = []
+        owner_user_id = None if include_all or user is None else user.user_id
+        for item in self.indexer.list_results(
+            owner_user_id=owner_user_id,
+            user=user,
+            include_all=include_all,
+            include_org=include_org,
+        ):
+            bundle_id = str(item.get("session_id") or "")
+            if not bundle_id:
+                continue
+            review_dir = self._bundle_dir(bundle_id)
+            review_count = (
+                len(list(review_dir.glob("*.json"))) if review_dir.is_dir() else 0
+            )
+            row = dict(item)
+            row["bundle_id"] = bundle_id
+            row["review_count"] = review_count
+            row["reviewed_by_current_user"] = (
+                self._review_file(bundle_id, user).exists() if user else False
+            )
+            bundles.append(row)
+        return bundles
+
+    def get_bundle(
+        self,
+        bundle_id: str,
+        user: UserContext | None = None,
+        *,
+        include_all: bool = False,
+        include_org: bool = False,
+    ) -> dict[str, Any] | None:
+        detail = self.indexer.get_detail(
+            bundle_id,
+            user=user,
+            include_all=include_all,
+            include_org=include_org,
+        )
+        if detail is None:
+            return None
+
+        canonical_id = str(detail.get("session_id") or bundle_id)
+        workspace = self.indexer.get_workspace_index(
+            canonical_id,
+            user=user,
+            include_all=include_all,
+            include_org=include_org,
+        )
+        if workspace is None:
+            workspace = {"session_id": canonical_id, "file_count": 0, "files": []}
+
+        score_json = detail.get("score_json") if isinstance(detail, dict) else None
+        return {
+            "bundle_id": canonical_id,
+            "detail": detail,
+            "layers": {
+                "task_spec": self._build_task_spec_layer(detail, score_json),
+                "conversation": self._build_conversation_layer(detail),
+                "tool_log": self._build_tool_log_layer(detail),
+                "workspace": self._build_workspace_layer(detail, workspace),
+                "judge_eval": self._build_judge_eval_layer(detail, score_json),
+            },
+            "review": self.load_review(canonical_id, user),
+        }
+
+    def load_review(
+        self, bundle_id: str, user: UserContext | None = None
+    ) -> dict[str, Any]:
+        if user is None:
+            return self._empty_review(bundle_id, user)
+
+        path = self._review_file(bundle_id, user)
+        if not path.exists():
+            return self._empty_review(bundle_id, user)
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return self._empty_review(bundle_id, user)
+        if not isinstance(payload, dict):
+            return self._empty_review(bundle_id, user)
+
+        base = self._empty_review(bundle_id, user)
+        base.update(payload)
+        base["opinions"] = [
+            item for item in payload.get("opinions", []) if isinstance(item, dict)
+        ]
+        return base
+
+    def append_opinion(
+        self,
+        bundle_id: str,
+        user: UserContext,
+        raw_card: dict[str, Any],
+        *,
+        include_all: bool = False,
+        include_org: bool = False,
+    ) -> dict[str, Any]:
+        canonical_id = self._canonical_bundle_id(
+            bundle_id,
+            user=user,
+            include_all=include_all,
+            include_org=include_org,
+        )
+        card = self._normalize_card(canonical_id, user, raw_card)
+        with self._lock:
+            review = self.load_review(canonical_id, user)
+            now = _utc_now()
+            if not review.get("created_at"):
+                review["created_at"] = now
+            review["updated_at"] = now
+            review["github_username"] = user.github_login
+            review["github_user_id"] = _stable_github_user_id(user)
+            review["reviewer_id"] = _stable_github_user_id(user)
+            review.setdefault("opinions", []).append(card)
+            self._write_review(canonical_id, user, review)
+            return review
+
+    def replace_opinions(
+        self,
+        bundle_id: str,
+        user: UserContext,
+        raw_cards: list[Any],
+        *,
+        include_all: bool = False,
+        include_org: bool = False,
+    ) -> dict[str, Any]:
+        canonical_id = self._canonical_bundle_id(
+            bundle_id,
+            user=user,
+            include_all=include_all,
+            include_org=include_org,
+        )
+        cards = [
+            self._normalize_card(canonical_id, user, card)
+            for card in raw_cards
+            if isinstance(card, dict)
+        ]
+        with self._lock:
+            review = self.load_review(canonical_id, user)
+            now = _utc_now()
+            review["updated_at"] = now
+            review["github_username"] = user.github_login
+            review["github_user_id"] = _stable_github_user_id(user)
+            review["reviewer_id"] = _stable_github_user_id(user)
+            review["opinions"] = cards
+            self._write_review(canonical_id, user, review)
+            return review
+
+    def _empty_review(
+        self, bundle_id: str, user: UserContext | None = None
+    ) -> dict[str, Any]:
+        github_user_id = _stable_github_user_id(user) if user else ""
+        github_username = user.github_login if user else ""
+        return {
+            "version": REVIEW_SCHEMA_VERSION,
+            "bundle_id": bundle_id,
+            "sample_id": bundle_id,
+            "github_username": github_username,
+            "github_user_id": github_user_id,
+            "reviewer_id": github_user_id,
+            "created_at": "",
+            "updated_at": "",
+            "opinions": [],
+        }
+
+    def _normalize_card(
+        self,
+        bundle_id: str,
+        user: UserContext,
+        raw_card: dict[str, Any],
+    ) -> dict[str, Any]:
+        section = str(raw_card.get("section") or "").strip()
+        if section not in SECTION_IDS:
+            raise ValueError("Invalid section")
+
+        severity = str(raw_card.get("severity") or "info").strip().lower()
+        if severity not in SEVERITY_IDS:
+            raise ValueError("Invalid severity")
+
+        comment = str(raw_card.get("comment") or "").strip()
+        if not comment:
+            raise ValueError("Comment is required")
+
+        now = _utc_now()
+        card = {
+            "opinion_id": str(
+                raw_card.get("opinion_id") or f"op_{secrets.token_hex(8)}"
+            ),
+            "sample_id": bundle_id,
+            "bundle_id": bundle_id,
+            "section": section,
+            "target": self._normalize_target(raw_card.get("target")),
+            "severity": severity,
+            "comment": comment,
+            "tags": _normalize_tags(raw_card.get("tags")),
+            "github_username": user.github_login,
+            "github_user_id": _stable_github_user_id(user),
+            "reviewer_id": _stable_github_user_id(user),
+            "created_at": now,
+            "timestamp": now,
+            "label_version": "v1",
+        }
+
+        if section == "judge_eval":
+            disagreement = self._normalize_judge_disagreement(
+                raw_card.get("judge_disagreement")
+            )
+            if disagreement:
+                card["judge_disagreement"] = disagreement
+
+        return card
+
+    def _normalize_target(self, value: Any) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            return {}
+
+        target: dict[str, Any] = {}
+        for key in TARGET_KEYS:
+            if key not in value:
+                continue
+            raw = value.get(key)
+            if key in {"turn_index", "tool_call_index"}:
+                try:
+                    index = int(raw)
+                except (TypeError, ValueError):
+                    continue
+                if index >= 0:
+                    target[key] = index
+                continue
+            text = str(raw or "").strip()
+            if text:
+                target[key] = text
+        return target
+
+    def _normalize_judge_disagreement(self, value: Any) -> dict[str, float]:
+        if not isinstance(value, dict):
+            return {}
+        normalized: dict[str, float] = {}
+        for key in ("judge_score", "human_score"):
+            raw = value.get(key)
+            if raw in (None, ""):
+                continue
+            try:
+                normalized[key] = float(raw)
+            except (TypeError, ValueError):
+                continue
+        return normalized
+
+    def _write_review(
+        self, bundle_id: str, user: UserContext, payload: dict[str, Any]
+    ) -> None:
+        path = self._review_file(bundle_id, user)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        tmp.replace(path)
+
+    def _review_file(self, bundle_id: str, user: UserContext | None) -> Path:
+        reviewer = _safe_path_part(
+            _stable_github_user_id(user) if user else "anonymous"
+        )
+        return self._bundle_dir(bundle_id) / f"{reviewer}.json"
+
+    def _bundle_dir(self, bundle_id: str) -> Path:
+        return self.review_root / _safe_path_part(bundle_id)
+
+    def _canonical_bundle_id(
+        self,
+        bundle_id: str,
+        *,
+        user: UserContext | None = None,
+        include_all: bool = False,
+        include_org: bool = False,
+    ) -> str:
+        detail = self.indexer.get_detail(
+            bundle_id,
+            user=user,
+            include_all=include_all,
+            include_org=include_org,
+        )
+        if isinstance(detail, dict):
+            canonical_id = str(detail.get("session_id") or "").strip()
+            if canonical_id:
+                return canonical_id
+        return str(bundle_id or "")
+
+    def _build_task_spec_layer(
+        self, detail: dict[str, Any], score_json: Any
+    ) -> dict[str, Any]:
+        return {
+            "task": {
+                "task_id": str(detail.get("task_id") or ""),
+                "description": str(detail.get("description") or ""),
+                "category": str(detail.get("category") or ""),
+                "difficulty": str(detail.get("difficulty") or ""),
+                "requires_code": bool(detail.get("requires_code")),
+                "max_turns": detail.get("max_turns"),
+            },
+            "persona": {
+                "persona_id": str(detail.get("persona_id") or ""),
+                "description": str(detail.get("persona_description") or ""),
+                "knowledge_level": str(detail.get("persona_knowledge_level") or ""),
+            },
+            "judge_rubric": self._extract_judge_rubric(score_json),
+        }
+
+    def _build_conversation_layer(self, detail: dict[str, Any]) -> dict[str, Any]:
+        turns = detail.get("conversation")
+        return {"turns": turns if isinstance(turns, list) else []}
+
+    def _build_tool_log_layer(self, detail: dict[str, Any]) -> dict[str, Any]:
+        logs = detail.get("all_tool_logs") or detail.get("tool_logs")
+        return {"tool_calls": logs if isinstance(logs, list) else []}
+
+    def _build_workspace_layer(
+        self, detail: dict[str, Any], workspace: dict[str, Any]
+    ) -> dict[str, Any]:
+        return {
+            "tree": workspace.get("files", []),
+            "file_count": workspace.get("file_count", 0),
+            "top_extensions": workspace.get("top_extensions", []),
+            "diffs": detail.get("workspace_diffs") or [],
+            "stdout": str(detail.get("stdout") or ""),
+            "stderr": str(detail.get("stderr") or ""),
+        }
+
+    def _build_judge_eval_layer(
+        self, detail: dict[str, Any], score_json: Any
+    ) -> dict[str, Any]:
+        return {
+            "status": str(detail.get("evaluation_status") or "pending"),
+            "overall_score": detail.get("overall_score"),
+            "rows": self._extract_judge_rows(score_json),
+            "score_json": score_json if isinstance(score_json, dict) else None,
+        }
+
+    def _extract_judge_rubric(self, score_json: Any) -> dict[str, Any]:
+        if not isinstance(score_json, dict):
+            return {}
+        reliability = score_json.get("judge_reliability")
+        if not isinstance(reliability, dict):
+            reliability = {}
+        return {
+            "score_id": str(score_json.get("score_id") or ""),
+            "eval_model": str(score_json.get("eval_model") or ""),
+            "eval_mode": str(score_json.get("eval_mode") or ""),
+            "judge_validation_run": str(reliability.get("validation_run_id") or ""),
+            "tracks": [
+                {
+                    "track": track,
+                    "status": str((score_json.get(track) or {}).get("status") or ""),
+                    "score": (score_json.get(track) or {}).get("score"),
+                }
+                for track in ("qr", "qp", "tutor")
+                if isinstance(score_json.get(track), dict)
+            ],
+        }
+
+    def _extract_judge_rows(self, score_json: Any) -> list[dict[str, Any]]:
+        if not isinstance(score_json, dict):
+            return []
+
+        rows: list[dict[str, Any]] = []
+        for track in ("qr", "qp", "tutor"):
+            payload = score_json.get(track)
+            if not isinstance(payload, dict):
+                continue
+            rows.append(
+                {
+                    "criterion_id": track,
+                    "track": track,
+                    "criterion": track,
+                    "score": payload.get("score"),
+                    "verdict": str(payload.get("status") or ""),
+                    "reasoning": str(payload.get("error") or ""),
+                    "evidence": [],
+                }
+            )
+            detail = payload.get("detail")
+            if isinstance(detail, dict):
+                rows.extend(self._extract_detail_rows(track, detail))
+        return rows
+
+    def _extract_detail_rows(
+        self, track: str, detail: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for key, value in detail.items():
+            if isinstance(value, dict):
+                row = self._detail_value_to_row(track, str(key), value)
+                if row:
+                    rows.append(row)
+                continue
+            if isinstance(value, list):
+                for index, item in enumerate(value):
+                    if isinstance(item, dict):
+                        row = self._detail_value_to_row(
+                            track, f"{key}_{index}", item
+                        )
+                        if row:
+                            rows.append(row)
+        return rows
+
+    def _detail_value_to_row(
+        self, track: str, key: str, value: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        has_score = any(
+            name in value for name in ("score", "human_score", "judge_score")
+        )
+        has_text = any(
+            name in value for name in ("reason", "reasoning", "rationale", "error")
+        )
+        has_status = "status" in value or "verdict" in value
+        if not (has_score or has_text or has_status):
+            return None
+        evidence = value.get("evidence")
+        if not isinstance(evidence, list):
+            evidence = value.get("evidence_spans")
+        return {
+            "criterion_id": f"{track}.{key}",
+            "track": track,
+            "criterion": key,
+            "score": value.get("score"),
+            "verdict": str(value.get("status") or value.get("verdict") or ""),
+            "reasoning": str(
+                value.get("reason")
+                or value.get("reasoning")
+                or value.get("rationale")
+                or value.get("error")
+                or ""
+            ),
+            "evidence": evidence if isinstance(evidence, list) else [],
+        }
+
+
+def _stable_github_user_id(user: UserContext | None) -> str:
+    if user is None:
+        return ""
+    return str(user.github_user_id or user.user_id or user.github_login or "").strip()
+
+
+def _safe_path_part(value: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return "unknown"
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "_", text)
+    return cleaned.strip("._") or "unknown"
+
+
+def _normalize_tags(value: Any) -> list[str]:
+    if isinstance(value, str):
+        raw_tags = value.split(",")
+    elif isinstance(value, list):
+        raw_tags = value
+    else:
+        raw_tags = []
+    tags: list[str] = []
+    for item in raw_tags:
+        text = str(item or "").strip()
+        if text and text not in tags:
+            tags.append(text)
+    return tags[:20]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/bench/server/web/static/css/styles.css
+++ b/bench/server/web/static/css/styles.css
@@ -476,6 +476,14 @@ h1 {
   align-items: start;
 }
 
+.task-catalog-layout.is-task-class-hidden {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.task-catalog-layout.is-task-class-hidden .task-class-panel {
+  display: none;
+}
+
 .task-class-panel {
   display: grid;
   gap: 14px;
@@ -493,6 +501,20 @@ h1 {
 .task-class-panel-head h2 {
   margin: 0;
   font-size: 16px;
+}
+
+.task-class-panel-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.task-class-toggle {
+  min-height: 34px;
+  padding: 7px 11px;
+  font-size: 12px;
 }
 
 .task-class-list {

--- a/bench/server/web/static/css/styles.css
+++ b/bench/server/web/static/css/styles.css
@@ -2972,3 +2972,233 @@ h1 {
     margin-bottom: 4px;
   }
 }
+
+/* Human review console */
+.review-refresh-wrap {
+  display: flex;
+  align-items: end;
+}
+
+.review-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  gap: 18px;
+  align-items: start;
+}
+
+.review-layer-stack {
+  display: grid;
+  gap: 18px;
+  min-width: 0;
+}
+
+.review-layer,
+.review-opinion-panel {
+  padding: 18px;
+}
+
+.review-opinion-panel {
+  position: sticky;
+  top: calc(var(--nav-height) + 18px);
+}
+
+.review-layer-head,
+.review-row-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.review-layer-head h2 {
+  margin: 0;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.review-layer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.review-spec-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.review-spec-block {
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 250, 243, 0.64);
+}
+
+.review-spec-block h3 {
+  margin: 0 0 12px;
+  font-size: 15px;
+}
+
+.review-markdown {
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.review-markdown pre,
+.review-markdown code {
+  white-space: pre-wrap;
+}
+
+.review-turn-list,
+.review-tool-list,
+.review-judge-table,
+.review-opinion-list {
+  display: grid;
+  gap: 12px;
+}
+
+.review-turn,
+.review-tool-call,
+.review-judge-row,
+.review-opinion-card,
+.review-file-row {
+  padding: 14px;
+  border: 1px solid var(--border-light);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 250, 243, 0.76);
+}
+
+.review-row-head > div,
+.review-file-row > div {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.review-row-head strong,
+.review-file-row strong {
+  overflow-wrap: anywhere;
+}
+
+.review-tool-call details,
+.review-layer details {
+  margin-top: 10px;
+}
+
+.review-tool-call summary,
+.review-layer summary {
+  cursor: pointer;
+  color: var(--accent-strong);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.review-rubric-track-list,
+.review-file-list {
+  display: grid;
+  gap: 8px;
+}
+
+.review-file-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-left-color: var(--success);
+}
+
+.review-slot-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.review-slot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: rgba(141, 67, 16, 0.05);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.review-slot strong {
+  color: var(--accent-strong);
+  font-variant-numeric: tabular-nums;
+}
+
+.review-opinion-card {
+  border-left-color: var(--success);
+}
+
+.review-opinion-card.severity-concern {
+  border-left-color: var(--warning);
+}
+
+.review-opinion-card.severity-blocker {
+  border-left-color: var(--error-text);
+}
+
+.review-opinion-card p {
+  margin: 8px 0;
+  line-height: 1.55;
+}
+
+.review-card-time {
+  color: var(--text-muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.review-opinion-form,
+.review-form-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.review-form-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 1080px) {
+  .review-layout,
+  .review-spec-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .review-opinion-panel {
+    position: static;
+  }
+}
+
+@media (max-width: 720px) {
+  .review-layer-head,
+  .review-row-head,
+  .review-file-row {
+    display: grid;
+  }
+
+  .review-layer-actions {
+    justify-content: flex-start;
+  }
+
+  .review-slot-grid,
+  .review-form-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/bench/server/web/static/css/styles.css
+++ b/bench/server/web/static/css/styles.css
@@ -512,9 +512,28 @@ h1 {
 }
 
 .task-class-toggle {
-  min-height: 34px;
-  padding: 7px 11px;
-  font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--accent-strong);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 850;
+  line-height: 1;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease), border-color var(--duration-fast) var(--ease), box-shadow var(--duration-fast) var(--ease);
+}
+
+.task-class-toggle:hover {
+  border-color: rgba(179, 92, 30, 0.42);
+  background: rgba(246, 222, 196, 0.42);
+  box-shadow: 0 6px 14px rgba(179, 92, 30, 0.1);
 }
 
 .task-class-list {

--- a/bench/server/web/static/css/styles.css
+++ b/bench/server/web/static/css/styles.css
@@ -631,38 +631,28 @@ h1 {
   align-items: start;
 }
 
-.run-agent-create-panel {
-  display: grid;
-  grid-template-columns: minmax(340px, 540px) minmax(320px, 1fr);
-  gap: 18px;
-  align-items: start;
+.run-agent-prompt-panel {
+  max-width: 1040px;
 }
 
-.run-agent-create-card,
-.run-agent-api-card {
+.run-agent-prompt-card {
   display: grid;
   gap: 18px;
-  padding: 24px;
+  padding: 26px;
 }
 
-.run-agent-create-card {
-  min-height: 300px;
-}
-
-.run-agent-card-head {
+.run-agent-prompt-head {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
 }
 
-.run-agent-card-head h2,
-.run-agent-api-card h2 {
+.run-agent-prompt-head h2 {
   margin: 0;
 }
 
-.run-agent-card-head .detail-empty-note,
-.run-agent-api-card .detail-empty-note {
+.run-agent-prompt-head .detail-empty-note {
   margin: 8px 0 0;
 }
 
@@ -681,49 +671,91 @@ h1 {
   white-space: nowrap;
 }
 
-.run-agent-create-card .filter-select {
-  min-height: 46px;
-  border-color: var(--border-strong);
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(255, 250, 243, 0.92));
-  cursor: pointer;
+.run-agent-prompt-head .run-selected-badge {
+  max-width: 240px;
 }
 
-.run-task-reflection {
+.run-agent-prompt-controls {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-wrap: wrap;
   gap: 12px;
-  padding: 12px 14px;
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.66);
-  color: var(--text-muted);
-  transition: border-color var(--duration-fast) var(--ease), box-shadow var(--duration-fast) var(--ease), background var(--duration-fast) var(--ease), transform var(--duration-fast) var(--ease);
 }
 
-.run-task-reflection span {
+.run-agent-prompt-field {
+  display: grid;
+  gap: 7px;
+  min-width: min(100%, 280px);
+}
+
+.run-agent-prompt-field span {
+  color: var(--text-muted);
   font-size: 12px;
   font-weight: 800;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
-.run-task-reflection strong {
+.run-agent-prompt-input {
+  min-height: 42px;
+  padding: 0 13px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text);
+  font: inherit;
+}
+
+.run-agent-prompt-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(179, 92, 30, 0.12);
+}
+
+.run-agent-prompt-text {
+  width: 100%;
+  min-height: 390px;
+  resize: vertical;
+  padding: 16px 18px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.82);
   color: var(--text);
   font-family: var(--font-mono);
-  font-size: 14px;
+  font-size: 13px;
+  line-height: 1.62;
 }
 
-.run-task-reflection.is-active,
-.run-task-reflection.is-updated {
-  border-color: rgba(179, 92, 30, 0.42);
-  background: rgba(246, 222, 196, 0.42);
-  box-shadow: 0 8px 18px rgba(179, 92, 30, 0.1);
+.run-agent-prompt-text:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(179, 92, 30, 0.12);
 }
 
-.run-task-reflection.is-updated {
-  transform: translateY(-1px);
+.api-key-agent-prompt {
+  min-height: 240px;
+  margin-bottom: 10px;
+}
+
+.run-agent-skill-url {
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.66);
+}
+
+.run-agent-skill-url span {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.run-agent-skill-url code {
+  color: var(--code-text);
+  font-size: 12.5px;
 }
 
 .run-agent-api-actions {
@@ -2826,17 +2858,15 @@ h1 {
 
   .run-mode-grid,
   .run-grid,
-  .run-agent-grid,
-  .run-agent-create-panel {
+  .run-agent-grid {
     grid-template-columns: 1fr;
   }
 
-  .run-agent-create-card,
-  .run-agent-api-card {
+  .run-agent-prompt-card {
     padding: 18px;
   }
 
-  .run-agent-card-head {
+  .run-agent-prompt-head {
     flex-direction: column;
   }
 

--- a/bench/server/web/static/css/styles.css
+++ b/bench/server/web/static/css/styles.css
@@ -2981,9 +2981,13 @@ h1 {
 
 .review-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 360px;
-  gap: 18px;
+  grid-template-columns: minmax(220px, 280px) minmax(420px, 1fr) minmax(320px, 360px);
+  gap: 16px;
   align-items: start;
+}
+
+.review-layout.is-context-hidden {
+  grid-template-columns: 48px minmax(420px, 1fr) minmax(320px, 360px);
 }
 
 .review-layer-stack {
@@ -2993,13 +2997,156 @@ h1 {
 }
 
 .review-layer,
+.review-context-panel,
+.review-chat-panel,
 .review-opinion-panel {
   padding: 18px;
+  min-width: 0;
 }
 
+.review-context-panel,
 .review-opinion-panel {
   position: sticky;
   top: calc(var(--nav-height) + 18px);
+  max-height: calc(100vh - var(--nav-height) - 36px);
+  overflow-y: auto;
+}
+
+.review-context-rail {
+  position: sticky;
+  top: calc(var(--nav-height) + 18px);
+  display: flex;
+  justify-content: center;
+  min-height: 180px;
+  padding: 10px 6px;
+}
+
+.review-context-rail .review-context-toggle {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  white-space: nowrap;
+}
+
+.review-chat-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - var(--nav-height) - 190px);
+  overflow: hidden;
+  padding: 0;
+}
+
+.review-chat-panel .review-layer-head {
+  padding: 18px 18px 0;
+}
+
+.review-chat-area {
+  min-height: 540px;
+  max-height: calc(100vh - var(--nav-height) - 220px);
+  border-top: 1px solid var(--border-light);
+}
+
+.review-chat-area .msg {
+  max-width: min(82%, 820px);
+}
+
+.review-context-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.review-context-section,
+.review-context-details {
+  padding-top: 14px;
+  border-top: 1px solid var(--border-light);
+}
+
+.review-context-section:first-child {
+  padding-top: 0;
+  border-top: none;
+}
+
+.review-context-section h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.review-context-markdown {
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.review-context-panel .detail-meta-grid {
+  grid-template-columns: 1fr;
+}
+
+.review-context-panel .detail-meta-item {
+  padding: 7px 0;
+}
+
+.review-context-panel summary {
+  cursor: pointer;
+  color: var(--accent-strong);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.review-context-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.review-context-evidence {
+  min-width: 0;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.review-context-evidence:last-child {
+  border-bottom: none;
+}
+
+.review-context-evidence summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.review-context-evidence-body {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.review-context-evidence-body h4 {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.review-context-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.review-context-row:last-child {
+  border-bottom: none;
+}
+
+.review-context-row span,
+.review-context-row code {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.review-context-judge-row {
+  min-width: 0;
 }
 
 .review-layer-head,
@@ -3115,31 +3262,44 @@ h1 {
   border-left-color: var(--success);
 }
 
-.review-slot-grid {
+.review-opinion-editor {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-  margin-bottom: 14px;
-}
-
-.review-slot {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 10px;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 14px;
   border: 1px solid var(--border-light);
   border-radius: var(--radius-sm);
-  background: rgba(141, 67, 16, 0.05);
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 700;
-  text-transform: uppercase;
+  background: rgba(255, 250, 243, 0.72);
 }
 
-.review-slot strong {
+.review-editor-title h3 {
+  margin: 2px 0 0;
+  font-size: 15px;
+  line-height: 1.25;
+}
+
+.review-inline-form .run-actions {
+  justify-content: flex-start;
+}
+
+.review-advanced-fields {
+  display: grid;
+  gap: 12px;
+}
+
+.review-advanced-fields summary {
+  cursor: pointer;
   color: var(--accent-strong);
-  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.review-advanced-fields[open] {
+  padding-top: 4px;
+}
+
+.review-advanced-fields[open] > *:not(summary) {
+  margin-top: 12px;
 }
 
 .review-opinion-card {
@@ -3175,14 +3335,45 @@ h1 {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+@media (max-width: 1280px) {
+  .review-layout {
+    grid-template-columns: minmax(210px, 250px) minmax(360px, 1fr) minmax(300px, 330px);
+  }
+
+  .review-layout.is-context-hidden {
+    grid-template-columns: 48px minmax(360px, 1fr) minmax(300px, 330px);
+  }
+}
+
 @media (max-width: 1080px) {
   .review-layout,
+  .review-layout.is-context-hidden,
   .review-spec-grid {
     grid-template-columns: 1fr;
   }
 
+  .review-context-panel,
+  .review-context-rail,
   .review-opinion-panel {
     position: static;
+    max-height: none;
+  }
+
+  .review-context-rail {
+    min-height: auto;
+    justify-content: flex-start;
+  }
+
+  .review-context-rail .review-context-toggle {
+    writing-mode: horizontal-tb;
+  }
+
+  .review-chat-panel {
+    min-height: auto;
+  }
+
+  .review-chat-area {
+    max-height: none;
   }
 }
 
@@ -3197,7 +3388,6 @@ h1 {
     justify-content: flex-start;
   }
 
-  .review-slot-grid,
   .review-form-grid {
     grid-template-columns: 1fr;
   }

--- a/bench/server/web/static/css/styles.css
+++ b/bench/server/web/static/css/styles.css
@@ -469,15 +469,84 @@ h1 {
   background: rgba(116, 107, 99, 0.1);
 }
 
-.tasks-group {
-  margin-bottom: 30px;
+.task-catalog-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
 }
 
+.task-class-panel {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+}
+
+.task-class-panel-head,
 .tasks-group-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+}
+
+.task-class-panel-head h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.task-class-list {
+  display: grid;
+  gap: 8px;
+}
+
+.task-class-btn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.62);
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 750;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease), border-color var(--duration-fast) var(--ease), box-shadow var(--duration-fast) var(--ease);
+}
+
+.task-class-btn strong {
+  flex: 0 0 auto;
+  min-width: 28px;
+  padding: 4px 7px;
+  border-radius: var(--radius-pill);
+  background: rgba(141, 67, 16, 0.08);
+  color: var(--accent-strong);
+  font-size: 12px;
+  text-align: center;
+}
+
+.task-class-btn:hover,
+.task-class-btn.is-active {
+  border-color: rgba(179, 92, 30, 0.38);
+  background: rgba(246, 222, 196, 0.38);
+}
+
+.task-class-btn.is-active {
+  box-shadow: 0 8px 18px rgba(179, 92, 30, 0.1);
+}
+
+.tasks-group {
+  min-width: 0;
+  margin-bottom: 30px;
+}
+
+.tasks-group-header {
   margin-bottom: 14px;
 }
 
@@ -2822,8 +2891,13 @@ h1 {
 
   .run-mode-grid,
   .run-grid,
-  .run-agent-grid {
+  .run-agent-grid,
+  .task-catalog-layout {
     grid-template-columns: 1fr;
+  }
+
+  .task-class-panel {
+    padding: 16px;
   }
 
   .run-agent-prompt-card {

--- a/bench/server/web/static/css/styles.css
+++ b/bench/server/web/static/css/styles.css
@@ -368,11 +368,18 @@ h1 {
   background: #fff;
   color: var(--text);
   font: inherit;
-  transition: border-color var(--duration-fast) var(--ease), box-shadow var(--duration-fast) var(--ease);
+  transition: border-color var(--duration-fast) var(--ease), box-shadow var(--duration-fast) var(--ease), background var(--duration-fast) var(--ease);
+}
+
+.filter-input:hover,
+.filter-select:hover {
+  border-color: var(--border-strong);
+  background: rgba(255, 255, 255, 0.92);
 }
 
 .filter-input:focus,
-.filter-select:focus {
+.filter-select:focus,
+.filter-select.is-active {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 3px rgba(179, 92, 30, 0.12);
@@ -578,12 +585,11 @@ h1 {
 }
 
 .run-sticky-header {
-  position: sticky;
-  top: 0;
+  position: static;
   z-index: 8;
   margin-bottom: 18px;
-  background: rgba(255, 250, 243, 0.96);
-  backdrop-filter: blur(10px);
+  background: transparent;
+  backdrop-filter: none;
 }
 
 .run-mode-grid {
@@ -623,6 +629,107 @@ h1 {
   grid-template-columns: minmax(240px, 300px) minmax(560px, 1.4fr) minmax(260px, 320px);
   gap: 18px;
   align-items: start;
+}
+
+.run-agent-create-panel {
+  display: grid;
+  grid-template-columns: minmax(340px, 540px) minmax(320px, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.run-agent-create-card,
+.run-agent-api-card {
+  display: grid;
+  gap: 18px;
+  padding: 24px;
+}
+
+.run-agent-create-card {
+  min-height: 300px;
+}
+
+.run-agent-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.run-agent-card-head h2,
+.run-agent-api-card h2 {
+  margin: 0;
+}
+
+.run-agent-card-head .detail-empty-note,
+.run-agent-api-card .detail-empty-note {
+  margin: 8px 0 0;
+}
+
+.run-selected-badge {
+  flex: 0 0 auto;
+  max-width: 120px;
+  overflow: hidden;
+  padding: 7px 10px;
+  border: 1px solid rgba(179, 92, 30, 0.18);
+  border-radius: var(--radius-pill);
+  background: var(--accent-subtle);
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.run-agent-create-card .filter-select {
+  min-height: 46px;
+  border-color: var(--border-strong);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(255, 250, 243, 0.92));
+  cursor: pointer;
+}
+
+.run-task-reflection {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.66);
+  color: var(--text-muted);
+  transition: border-color var(--duration-fast) var(--ease), box-shadow var(--duration-fast) var(--ease), background var(--duration-fast) var(--ease), transform var(--duration-fast) var(--ease);
+}
+
+.run-task-reflection span {
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.run-task-reflection strong {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 14px;
+}
+
+.run-task-reflection.is-active,
+.run-task-reflection.is-updated {
+  border-color: rgba(179, 92, 30, 0.42);
+  background: rgba(246, 222, 196, 0.42);
+  box-shadow: 0 8px 18px rgba(179, 92, 30, 0.1);
+}
+
+.run-task-reflection.is-updated {
+  transform: translateY(-1px);
+}
+
+.run-agent-api-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .run-control-panel,
@@ -2719,8 +2826,18 @@ h1 {
 
   .run-mode-grid,
   .run-grid,
-  .run-agent-grid {
+  .run-agent-grid,
+  .run-agent-create-panel {
     grid-template-columns: 1fr;
+  }
+
+  .run-agent-create-card,
+  .run-agent-api-card {
+    padding: 18px;
+  }
+
+  .run-agent-card-head {
+    flex-direction: column;
   }
 
   .run-conversation {

--- a/bench/server/web/static/css/styles.css
+++ b/bench/server/web/static/css/styles.css
@@ -675,45 +675,9 @@ h1 {
   max-width: 240px;
 }
 
-.run-agent-prompt-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-.run-agent-prompt-field {
-  display: grid;
-  gap: 7px;
-  min-width: min(100%, 280px);
-}
-
-.run-agent-prompt-field span {
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 800;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.run-agent-prompt-input {
-  min-height: 42px;
-  padding: 0 13px;
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.9);
-  color: var(--text);
-  font: inherit;
-}
-
-.run-agent-prompt-input:focus {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(179, 92, 30, 0.12);
-}
-
 .run-agent-prompt-text {
   width: 100%;
-  min-height: 390px;
+  min-height: 260px;
   resize: vertical;
   padding: 16px 18px;
   border: 1px solid var(--border-strong);

--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -21,7 +21,8 @@
       bundles: null,
       bundleCache: {},
       search: '',
-      opinionFilter: 'all'
+      opinionFilter: 'all',
+      contextHidden: false
     },
     run: {
       mode: '',
@@ -2465,20 +2466,176 @@
     return renderReviewLayerPanel('judge_eval', 'Judge Evaluation', body, '<span class="meta-chip">' + escapeHtml(String(rows.length)) + ' rows</span>');
   }
 
-  function reviewOpinionCounts(opinions) {
-    var counts = {};
-    REVIEW_SECTIONS.forEach(function (section) { counts[section] = 0; });
-    (opinions || []).forEach(function (opinion) {
-      var section = opinion.section || 'overall';
-      counts[section] = (counts[section] || 0) + 1;
-    });
-    return counts;
+  function renderReviewContextPanel(layers) {
+    layers = layers || {};
+    if (state.review.contextHidden) {
+      return '' +
+        '<aside class="panel review-context-rail">' +
+          '<button id="review-context-toggle" class="btn btn-secondary btn-small review-context-toggle" type="button">Open Task Spec</button>' +
+        '</aside>';
+    }
+
+    var taskLayer = layers.task_spec || {};
+    var task = taskLayer.task || {};
+    var persona = taskLayer.persona || {};
+    var rubric = taskLayer.judge_rubric || {};
+    var calls = layers.tool_log && layers.tool_log.tool_calls ? layers.tool_log.tool_calls : [];
+    var workspace = layers.workspace || {};
+    var files = workspace.tree || [];
+    var judge = layers.judge_eval || {};
+    var rows = judge.rows || [];
+    var tracks = rubric.tracks || [];
+
+    var trackHtml = tracks.length
+      ? '<div class="detail-chip-list">' + tracks.map(function (track) {
+        return '<span class="detail-chip">' + escapeHtml((track.track || '').toUpperCase()) + ' ' +
+          escapeHtml(track.score == null ? 'pending' : formatScore(track.score)) + '</span>';
+      }).join('') + '</div>'
+      : '<p class="detail-empty-note">Rubric metadata appears after scoring completes.</p>';
+
+    var toolHtml = calls.length
+      ? '<div class="review-context-list">' + calls.map(function (call, index) {
+        var name = call.name || call.tool_name || 'tool';
+        var duration = call.duration_ms == null ? '' : formatDuration(Number(call.duration_ms) / 1000);
+        return '' +
+          '<details class="review-context-evidence">' +
+            '<summary><span>' + escapeHtml(name) + '</span><span class="meta-chip">call ' + escapeHtml(String(index)) + '</span>' +
+              (duration ? '<span class="meta-chip">' + escapeHtml(duration) + '</span>' : '') +
+            '</summary>' +
+            '<div class="review-context-evidence-body">' +
+              '<h4>Arguments</h4>' +
+              '<pre class="detail-json-block">' + escapeHtml(JSON.stringify(call.args || call.input || {}, null, 2)) + '</pre>' +
+              '<h4>Result</h4>' +
+              '<pre class="detail-json-block">' + escapeHtml(stringifyReviewValue(call.result || call.output || call.error || '')) + '</pre>' +
+            '</div>' +
+          '</details>';
+      }).join('') + '</div>'
+      : '<p class="detail-empty-note">Tool calls appear when the tutor used tools.</p>';
+
+    var diffs = workspace.diffs || [];
+    var stdout = workspace.stdout || '';
+    var stderr = workspace.stderr || '';
+    var fileHtml = files.length
+      ? '<div class="review-context-list">' + files.map(function (file) {
+        var path = file.path || file.name || '';
+        return '<div class="review-context-row"><code>' + escapeHtml(path) + '</code><span class="meta-chip">' +
+          escapeHtml(titleCase(file.kind || 'file')) + '</span></div>';
+      }).join('') + '</div>'
+      : '<p class="detail-empty-note">Archived workspace files appear here.</p>';
+    var workspaceHtml =
+      '<details open class="review-context-evidence">' +
+        '<summary>Final Tree</summary>' +
+        fileHtml +
+      '</details>' +
+      '<details class="review-context-evidence">' +
+        '<summary>Diffs</summary>' +
+        (diffs.length ? '<pre class="detail-json-block">' + escapeHtml(JSON.stringify(diffs, null, 2)) + '</pre>' : '<p class="detail-empty-note">Diff data is empty for this bundle.</p>') +
+      '</details>' +
+      '<details class="review-context-evidence">' +
+        '<summary>Stdout</summary>' +
+        (stdout ? '<pre class="detail-json-block">' + escapeHtml(stdout) + '</pre>' : '<p class="detail-empty-note">Stdout is empty for this bundle.</p>') +
+      '</details>' +
+      '<details class="review-context-evidence">' +
+        '<summary>Stderr</summary>' +
+        (stderr ? '<pre class="detail-json-block">' + escapeHtml(stderr) + '</pre>' : '<p class="detail-empty-note">Stderr is empty for this bundle.</p>') +
+      '</details>';
+
+    var judgeHtml = rows.length
+      ? '<div class="review-context-list">' + rows.map(function (row) {
+        var score = row.score == null ? 'pending' : formatScore(Number(row.score));
+        return '' +
+          '<article class="review-context-judge-row">' +
+            '<div class="review-context-row"><span>' + escapeHtml(row.criterion || row.criterion_id || 'criterion') + '</span>' +
+              '<span class="meta-chip">' + escapeHtml(score) + '</span></div>' +
+            (row.reasoning ? '<p class="detail-empty-note">' + escapeHtml(row.reasoning) + '</p>' : '<p class="detail-empty-note">Reasoning field is empty.</p>') +
+          '</article>';
+      }).join('') + '</div>'
+      : '<p class="detail-empty-note">Judge criteria appear after scoring completes.</p>';
+
+    return '' +
+      '<aside class="panel review-context-panel">' +
+        '<header class="review-layer-head">' +
+          '<div>' +
+            '<p class="eyebrow">Task Spec</p>' +
+            '<h2>Bundle Context</h2>' +
+          '</div>' +
+          '<button id="review-context-toggle" class="btn btn-secondary btn-small review-context-toggle" type="button">Hide</button>' +
+        '</header>' +
+        '<div class="review-context-stack">' +
+          '<section class="review-context-section">' +
+            '<h3>Task</h3>' +
+            '<div class="detail-meta-grid">' +
+              metaItem('Task ID', task.task_id || '') +
+              metaItem('Category', titleCase(task.category || 'unknown')) +
+              metaItem('Difficulty', titleCase(task.difficulty || 'unknown')) +
+              metaItem('Requires Code', task.requires_code ? 'Yes' : 'No') +
+            '</div>' +
+            '<div class="review-markdown review-context-markdown">' + safeRenderMarkdown(task.description || 'Task description unavailable.') + '</div>' +
+          '</section>' +
+          '<section class="review-context-section">' +
+            '<h3>Student Persona</h3>' +
+            '<div class="detail-meta-grid">' +
+              metaItem('Persona ID', persona.persona_id || '') +
+              metaItem('Knowledge Level', persona.knowledge_level || 'Unspecified') +
+            '</div>' +
+            '<p class="detail-empty-note">' + escapeHtml(persona.description || 'Persona description unavailable.') + '</p>' +
+          '</section>' +
+          '<section class="review-context-section">' +
+            '<h3>Judge Rubric</h3>' +
+            '<div class="detail-meta-grid">' +
+              metaItem('Score ID', rubric.score_id || 'Pending') +
+              metaItem('Eval Model', rubric.eval_model || 'Pending') +
+              metaItem('Eval Mode', rubric.eval_mode || 'Pending') +
+              metaItem('Validation Run', rubric.judge_validation_run || 'Pending') +
+            '</div>' +
+            trackHtml +
+          '</section>' +
+          '<details class="review-context-details">' +
+            '<summary>Tool Log</summary>' +
+            toolHtml +
+          '</details>' +
+          '<details class="review-context-details">' +
+            '<summary>Workspace State</summary>' +
+            workspaceHtml +
+          '</details>' +
+          '<details class="review-context-details">' +
+            '<summary>Judge Evaluation</summary>' +
+            '<div class="detail-meta-grid">' +
+              metaItem('Status', titleCase(judge.status || 'pending')) +
+              metaItem('Overall Score', judge.overall_score == null ? 'Pending' : formatScore(judge.overall_score)) +
+            '</div>' +
+            judgeHtml +
+            '<details class="review-context-evidence">' +
+              '<summary>Raw Score JSON</summary>' +
+              renderJsonBlock(judge.score_json) +
+            '</details>' +
+          '</details>' +
+        '</div>' +
+      '</aside>';
+  }
+
+  function renderReviewChatPanel(layers, detail) {
+    layers = layers || {};
+    detail = detail || {};
+    var conversation = layers.conversation && layers.conversation.turns ? layers.conversation.turns : [];
+    return '' +
+      '<main class="panel review-chat-panel">' +
+        '<header class="review-layer-head">' +
+          '<div>' +
+            '<p class="eyebrow">Conversation</p>' +
+            '<h2>Assistant / Student Chat</h2>' +
+          '</div>' +
+          '<div class="review-layer-actions">' +
+            '<span class="meta-chip">' + escapeHtml(String(conversation.length || detail.turn_count || 0)) + ' turns</span>' +
+          '</div>' +
+        '</header>' +
+        '<div id="review-chat" class="chat-area review-chat-area"></div>' +
+      '</main>';
   }
 
   function renderReviewOpinionPanel(bundle) {
     var review = bundle.review || {};
     var opinions = review.opinions || [];
-    var counts = reviewOpinionCounts(opinions);
     var filter = state.review.opinionFilter || 'all';
     var visible = opinions.filter(function (opinion) {
       return filter === 'all' || opinion.section === filter;
@@ -2487,12 +2644,6 @@
       return '<option value="' + escapeHtml(section) + '"' + (filter === section ? ' selected' : '') + '>' +
         escapeHtml(reviewSectionLabel(section)) + '</option>';
     })).join('');
-    var slots = REVIEW_SECTIONS.map(function (section) {
-      return '<div class="review-slot">' +
-        '<span>' + escapeHtml(reviewSectionLabel(section)) + '</span>' +
-        '<strong>' + escapeHtml(String(counts[section] || 0)) + '</strong>' +
-      '</div>';
-    }).join('');
     return '' +
       '<aside class="panel review-opinion-panel">' +
         '<header class="review-layer-head">' +
@@ -2500,9 +2651,8 @@
             '<p class="eyebrow">Opinion Cards</p>' +
             '<h2>Structured Feedback</h2>' +
           '</div>' +
-          reviewAddButton('overall', 'Add Overall Card') +
         '</header>' +
-        '<div class="review-slot-grid">' + slots + '</div>' +
+        renderReviewOpinionForm() +
         '<label class="filter-field">' +
           '<span class="filter-label">Section Filter</span>' +
           '<select id="review-opinion-filter" class="filter-select">' + options + '</select>' +
@@ -2511,6 +2661,81 @@
           (visible.length ? visible.map(renderReviewOpinionCard).join('') : '<p class="detail-empty-note">Cards for the selected section will appear here.</p>') +
         '</div>' +
       '</aside>';
+  }
+
+  function renderReviewOpinionForm() {
+    var sectionOptions = REVIEW_SECTIONS.map(function (section) {
+      return '<option value="' + escapeHtml(section) + '"' + (section === 'overall' ? ' selected' : '') + '>' +
+        escapeHtml(reviewSectionLabel(section)) + '</option>';
+    }).join('');
+    var targetOptions = [
+      ['none', 'Section-level'],
+      ['turn_index', 'Turn'],
+      ['tool_call_index', 'Tool Call'],
+      ['file_path', 'File Path'],
+      ['criterion_id', 'Criterion']
+    ].map(function (item) {
+      return '<option value="' + item[0] + '">' + item[1] + '</option>';
+    }).join('');
+
+    return '' +
+      '<section class="review-opinion-editor">' +
+        '<div class="review-editor-title">' +
+          '<p class="eyebrow">Human Review Edit</p>' +
+          '<h3>New Opinion Card</h3>' +
+        '</div>' +
+        '<form id="review-opinion-form" class="review-opinion-form review-inline-form">' +
+          '<label class="filter-field">' +
+            '<span class="filter-label">Section</span>' +
+            '<select id="review-card-section" class="filter-select" required>' + sectionOptions + '</select>' +
+          '</label>' +
+          '<label class="filter-field">' +
+            '<span class="filter-label">Comment</span>' +
+            '<textarea id="review-card-comment" class="run-textarea" rows="5" required></textarea>' +
+          '</label>' +
+          '<details class="review-advanced-fields">' +
+            '<summary>Advanced Metadata</summary>' +
+            '<div class="review-form-grid">' +
+              '<label class="filter-field">' +
+                '<span class="filter-label">Target Type</span>' +
+                '<select id="review-card-target-type" class="filter-select">' + targetOptions + '</select>' +
+              '</label>' +
+              '<label class="filter-field">' +
+                '<span class="filter-label">Target</span>' +
+                '<select id="review-card-target-value" class="filter-select" disabled>' +
+                  '<option value="">Section-level</option>' +
+                '</select>' +
+              '</label>' +
+            '</div>' +
+            '<label class="filter-field">' +
+              '<span class="filter-label">Severity</span>' +
+              '<select id="review-card-severity" class="filter-select">' +
+                '<option value="info">Info</option>' +
+                '<option value="concern">Concern</option>' +
+                '<option value="blocker">Blocker</option>' +
+              '</select>' +
+            '</label>' +
+            '<label class="filter-field">' +
+              '<span class="filter-label">Tags</span>' +
+              '<input id="review-card-tags" class="filter-input" type="text" placeholder="rubric_mismatch, persona_break">' +
+            '</label>' +
+            '<div id="review-judge-disagreement" class="review-form-grid">' +
+              '<label class="filter-field">' +
+                '<span class="filter-label">Judge Score</span>' +
+                '<input id="review-card-judge-score" class="filter-input" type="number" step="0.01">' +
+              '</label>' +
+              '<label class="filter-field">' +
+                '<span class="filter-label">Human Score</span>' +
+                '<input id="review-card-human-score" class="filter-input" type="number" step="0.01">' +
+              '</label>' +
+            '</div>' +
+          '</details>' +
+          '<div id="review-card-error" class="run-error" hidden></div>' +
+          '<div class="run-actions">' +
+            '<button class="btn btn-primary" type="submit">Save Card</button>' +
+          '</div>' +
+        '</form>' +
+      '</section>';
   }
 
   function renderReviewOpinionCard(opinion) {
@@ -2540,6 +2765,34 @@
     return 'Target: section-level';
   }
 
+  function relabelReviewChat(container) {
+    Array.prototype.forEach.call(container.querySelectorAll('.msg.tutor .msg-label'), function (label) {
+      label.textContent = 'Assistant';
+    });
+    Array.prototype.forEach.call(container.querySelectorAll('.msg.student .msg-label'), function (label) {
+      label.textContent = 'Student';
+    });
+  }
+
+  function renderReviewChatReplay(bundle) {
+    var layers = bundle.layers || {};
+    var detail = bundle.detail || {};
+    var conversation = layers.conversation && layers.conversation.turns ? layers.conversation.turns : (detail.conversation || []);
+    var toolLogs = layers.tool_log && layers.tool_log.tool_calls ? layers.tool_log.tool_calls : (detail.tool_logs || []);
+    var sendMessageEvents = detail.send_message_events || [];
+    var chatEl = document.getElementById('review-chat');
+    if (!chatEl) return;
+
+    if (window.QTB && typeof window.QTB.buildConversationReplay === 'function') {
+      window.QTB.buildConversationReplay(chatEl, conversation, toolLogs, sendMessageEvents);
+      relabelReviewChat(chatEl);
+      rewriteImages(chatEl, bundle.bundle_id || detail.session_id);
+      return;
+    }
+
+    chatEl.innerHTML = '<p class="detail-empty-note">Conversation renderer unavailable.</p>';
+  }
+
   function renderReviewBundlePage(bundle) {
     var layers = bundle.layers || {};
     var detail = bundle.detail || {};
@@ -2558,33 +2811,24 @@
             buildSummaryPill('Score', detail.overall_score == null ? 'Pending' : formatScore(detail.overall_score)) +
           '</div>' +
         '</header>' +
-        '<div class="review-layout">' +
-          '<main class="review-layer-stack">' +
-            renderReviewTaskSpec(layers.task_spec) +
-            renderReviewConversation(layers.conversation) +
-            renderReviewToolLog(layers.tool_log) +
-            renderReviewWorkspace(layers.workspace) +
-            renderReviewJudgeEval(layers.judge_eval) +
-          '</main>' +
+        '<div class="review-layout' + (state.review.contextHidden ? ' is-context-hidden' : '') + '">' +
+          renderReviewContextPanel(layers) +
+          renderReviewChatPanel(layers, detail) +
           renderReviewOpinionPanel(bundle) +
         '</div>' +
       '</section>';
-    rewriteImages(app.querySelector('.review-layer-stack'), bundle.bundle_id || detail.session_id);
+    renderReviewChatReplay(bundle);
     bindReviewBundleControls(bundle);
   }
 
   function bindReviewBundleControls(bundle) {
-    Array.prototype.forEach.call(document.querySelectorAll('.review-add-btn'), function (button) {
-      button.addEventListener('click', function () {
-        var targetType = button.getAttribute('data-target-type') || '';
-        var targetValue = button.getAttribute('data-target-value') || '';
-        openReviewOpinionModal(bundle, {
-          section: button.getAttribute('data-section') || 'overall',
-          targetType: targetType,
-          targetValue: targetValue
-        });
+    var contextToggle = document.getElementById('review-context-toggle');
+    if (contextToggle) {
+      contextToggle.addEventListener('click', function () {
+        state.review.contextHidden = !state.review.contextHidden;
+        renderReviewBundlePage(bundle);
       });
-    });
+    }
     var filter = document.getElementById('review-opinion-filter');
     if (filter) {
       filter.addEventListener('change', function (event) {
@@ -2592,78 +2836,83 @@
         renderReviewBundlePage(bundle);
       });
     }
+    bindReviewOpinionForm(bundle);
   }
 
-  function openReviewOpinionModal(bundle, preset) {
-    preset = preset || {};
-    var sectionOptions = REVIEW_SECTIONS.map(function (section) {
-      return '<option value="' + escapeHtml(section) + '"' + (preset.section === section ? ' selected' : '') + '>' +
-        escapeHtml(reviewSectionLabel(section)) + '</option>';
-    }).join('');
-    var targetOptions = [
-      ['none', 'Section-level'],
-      ['turn_index', 'Turn'],
-      ['tool_call_index', 'Tool Call'],
-      ['file_path', 'File Path'],
-      ['criterion_id', 'Criterion']
-    ].map(function (item) {
-      return '<option value="' + item[0] + '"' + (preset.targetType === item[0] ? ' selected' : '') + '>' + item[1] + '</option>';
-    }).join('');
-    var html =
-      '<form id="review-opinion-form" class="review-opinion-form">' +
-        '<label class="filter-field">' +
-          '<span class="filter-label">Section</span>' +
-          '<select id="review-card-section" class="filter-select" required>' + sectionOptions + '</select>' +
-        '</label>' +
-        '<div class="review-form-grid">' +
-          '<label class="filter-field">' +
-            '<span class="filter-label">Target Type</span>' +
-            '<select id="review-card-target-type" class="filter-select">' + targetOptions + '</select>' +
-          '</label>' +
-          '<label class="filter-field">' +
-            '<span class="filter-label">Target</span>' +
-            '<input id="review-card-target-value" class="filter-input" type="text" value="' + escapeHtml(preset.targetValue || '') + '">' +
-          '</label>' +
-        '</div>' +
-        '<label class="filter-field">' +
-          '<span class="filter-label">Severity</span>' +
-          '<select id="review-card-severity" class="filter-select">' +
-            '<option value="info">Info</option>' +
-            '<option value="concern">Concern</option>' +
-            '<option value="blocker">Blocker</option>' +
-          '</select>' +
-        '</label>' +
-        '<label class="filter-field">' +
-          '<span class="filter-label">Tags</span>' +
-          '<input id="review-card-tags" class="filter-input" type="text" placeholder="rubric_mismatch, persona_break">' +
-        '</label>' +
-        '<div id="review-judge-disagreement" class="review-form-grid">' +
-          '<label class="filter-field">' +
-            '<span class="filter-label">Judge Score</span>' +
-            '<input id="review-card-judge-score" class="filter-input" type="number" step="0.01">' +
-          '</label>' +
-          '<label class="filter-field">' +
-            '<span class="filter-label">Human Score</span>' +
-            '<input id="review-card-human-score" class="filter-input" type="number" step="0.01">' +
-          '</label>' +
-        '</div>' +
-        '<label class="filter-field">' +
-          '<span class="filter-label">Comment</span>' +
-          '<textarea id="review-card-comment" class="run-textarea" rows="5" required></textarea>' +
-        '</label>' +
-        '<div id="review-card-error" class="run-error" hidden></div>' +
-        '<div class="run-actions">' +
-          '<button class="btn btn-primary" type="submit">Save Card</button>' +
-        '</div>' +
-      '</form>';
-    showModal('Opinion Card', html);
-    bindReviewOpinionForm(bundle);
+  function truncateReviewOption(value, limit) {
+    var text = String(value || '').replace(/\s+/g, ' ').trim();
+    if (text.length <= limit) return text;
+    return text.slice(0, limit - 3) + '...';
+  }
+
+  function reviewTargetOptionGroups(bundle) {
+    var layers = bundle.layers || {};
+    var detail = bundle.detail || {};
+    var conversation = layers.conversation && layers.conversation.turns ? layers.conversation.turns : (detail.conversation || []);
+    var calls = layers.tool_log && layers.tool_log.tool_calls ? layers.tool_log.tool_calls : (detail.tool_logs || []);
+    var files = layers.workspace && layers.workspace.tree ? layers.workspace.tree : [];
+    var rows = layers.judge_eval && layers.judge_eval.rows ? layers.judge_eval.rows : [];
+
+    return {
+      none: [{value: '', label: 'Section-level'}],
+      turn_index: conversation.map(function (turn, index) {
+        var role = turn.role === 'user' || turn.role === 'student' ? 'Student' : 'Assistant';
+        return {
+          value: String(index),
+          label: 'Turn ' + index + ' - ' + role + ' - ' + truncateReviewOption(turn.content || turn.message || '', 72)
+        };
+      }),
+      tool_call_index: calls.map(function (call, index) {
+        return {
+          value: String(index),
+          label: 'Call ' + index + ' - ' + (call.name || call.tool_name || 'tool')
+        };
+      }),
+      file_path: files.map(function (file) {
+        var path = file.path || file.name || '';
+        return {value: path, label: path};
+      }).filter(function (item) { return item.value; }),
+      criterion_id: rows.map(function (row) {
+        var id = row.criterion_id || '';
+        var label = row.criterion || id || 'criterion';
+        return {value: id, label: id ? id + ' - ' + label : label};
+      }).filter(function (item) { return item.value; })
+    };
+  }
+
+  function populateReviewTargetOptions(groups) {
+    var targetType = document.getElementById('review-card-target-type');
+    var targetValue = document.getElementById('review-card-target-value');
+    if (!targetType || !targetValue) return;
+
+    var type = targetType.value || 'none';
+    var options = groups[type] || [];
+    targetValue.innerHTML = '';
+
+    if (!options.length) {
+      var empty = document.createElement('option');
+      empty.value = '';
+      empty.textContent = type === 'none' ? 'Section-level' : 'No targets available';
+      targetValue.appendChild(empty);
+      targetValue.disabled = true;
+      return;
+    }
+
+    options.forEach(function (item) {
+      var option = document.createElement('option');
+      option.value = item.value;
+      option.textContent = item.label || item.value || 'Section-level';
+      targetValue.appendChild(option);
+    });
+    targetValue.disabled = type === 'none';
   }
 
   function bindReviewOpinionForm(bundle) {
     var form = document.getElementById('review-opinion-form');
     var section = document.getElementById('review-card-section');
+    var targetType = document.getElementById('review-card-target-type');
     var judgeBlock = document.getElementById('review-judge-disagreement');
+    var targetGroups = reviewTargetOptionGroups(bundle);
 
     function syncJudgeFields() {
       if (!judgeBlock || !section) return;
@@ -2671,7 +2920,13 @@
     }
 
     if (section) section.addEventListener('change', syncJudgeFields);
+    if (targetType) {
+      targetType.addEventListener('change', function () {
+        populateReviewTargetOptions(targetGroups);
+      });
+    }
     syncJudgeFields();
+    populateReviewTargetOptions(targetGroups);
     if (!form) return;
     form.addEventListener('submit', function (event) {
       event.preventDefault();
@@ -2697,7 +2952,7 @@
       tags: String(tags ? tags.value : '').split(',').map(function (item) { return item.trim(); }).filter(Boolean),
       comment: String(comment ? comment.value : '').trim()
     };
-    if (payload.section === 'judge_eval') {
+    if (payload.section === 'judge_eval' && ((judgeScore && judgeScore.value) || (humanScore && humanScore.value))) {
       payload.judge_disagreement = {
         judge_score: judgeScore ? judgeScore.value : '',
         human_score: humanScore ? humanScore.value : ''
@@ -2710,7 +2965,6 @@
     }).then(function (updated) {
       state.review.bundleCache[updated.bundle_id] = updated;
       state.review.bundles = null;
-      closeModal();
       renderReviewBundlePage(updated);
     }).catch(function (error) {
       if (errorEl) {

--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -13,6 +13,9 @@
     },
     results: null,
     tasksPayload: null,
+    taskCatalog: {
+      selectedClass: ''
+    },
     detailCache: {},
     workspaceIndexCache: {},
     workspacePreviewCache: {},
@@ -649,25 +652,32 @@
     });
 
     var categories = Object.keys(grouped).sort();
-    var groupsHtml = categories.map(function (category) {
-      var items = grouped[category];
+    var selectedClass = state.taskCatalog.selectedClass;
+    if (selectedClass && !grouped[selectedClass]) {
+      selectedClass = '';
+      state.taskCatalog.selectedClass = '';
+    }
+    var selectedTasks = grouped[selectedClass] || [];
+    var classButtons = categories.map(function (category) {
+      var active = category === selectedClass ? ' is-active' : '';
       return '' +
-        '<section class="tasks-group">' +
-          '<header class="tasks-group-header">' +
-            '<h2 class="tasks-group-title">' + escapeHtml(titleCase(category)) + '</h2>' +
-            '<span class="summary-pill"><strong>Tasks</strong> ' + escapeHtml(String(items.length)) + '</span>' +
-          '</header>' +
-          '<div class="tasks-grid">' + items.map(renderTaskCard).join('') + '</div>' +
-        '</section>';
+        '<button class="task-class-btn' + active + '" type="button" data-task-class="' + escapeHtml(category) + '">' +
+          '<span>' + escapeHtml(titleCase(category)) + '</span>' +
+          '<strong>' + escapeHtml(String((grouped[category] || []).length)) + '</strong>' +
+        '</button>';
     }).join('');
+    var tasksHtml = selectedTasks.length
+      ? '<div class="tasks-grid">' + selectedTasks.map(renderTaskCard).join('') + '</div>'
+      : renderEmptyInline('Select a task class to view its tasks.');
+    var selectedClassLabel = selectedClass ? titleCase(selectedClass) : 'Select a class';
 
     app.innerHTML =
       '<section class="page">' +
         '<header class="page-header">' +
           '<div class="page-title-wrap">' +
             '<p class="eyebrow">Task Catalog</p>' +
-            '<h1>Task inventory for the new session-centric UI.</h1>' +
-            '<p class="subtitle">Grouped by benchmark category and served from the new isolated API layer.</p>' +
+            '<h1>Task inventory by class.</h1>' +
+            '<p class="subtitle">Select a task class first, then inspect the tasks in that class.</p>' +
           '</div>' +
           '<div class="summary-strip">' +
             buildSummaryPill('Tasks', String(tasks.length)) +
@@ -675,8 +685,36 @@
             buildSummaryPill('Categories', String(categories.length)) +
           '</div>' +
         '</header>' +
-        groupsHtml +
+        '<div class="task-catalog-layout">' +
+          '<aside class="panel task-class-panel">' +
+            '<div class="task-class-panel-head">' +
+              '<h2>Task Class</h2>' +
+              '<span class="summary-pill"><strong>Total</strong> ' + escapeHtml(String(categories.length)) + '</span>' +
+            '</div>' +
+            '<div class="task-class-list">' + classButtons + '</div>' +
+          '</aside>' +
+          '<section class="tasks-group">' +
+            '<header class="tasks-group-header">' +
+              '<div>' +
+                '<p class="eyebrow">Selected Class</p>' +
+                '<h2 class="tasks-group-title">' + escapeHtml(selectedClassLabel) + '</h2>' +
+              '</div>' +
+              '<span class="summary-pill"><strong>Tasks</strong> ' + escapeHtml(String(selectedTasks.length)) + '</span>' +
+            '</header>' +
+            tasksHtml +
+          '</section>' +
+        '</div>' +
       '</section>';
+    bindTaskCatalog();
+  }
+
+  function bindTaskCatalog() {
+    document.querySelectorAll('.task-class-btn').forEach(function (button) {
+      button.addEventListener('click', function () {
+        state.taskCatalog.selectedClass = button.getAttribute('data-task-class') || '';
+        renderTasksPage(state.tasksPayload || {tasks: [], personas: []});
+      });
+    });
   }
 
   function renderTaskCard(task) {

--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -441,40 +441,20 @@
   }
 
   function agentSkillRawUrl() {
-    return window.location.origin + '/skills/quanttutorbench-rest-agent/raw';
+    return window.location.origin + '/skill.md';
   }
 
   function buildAgentPrompt(apiKey) {
-    var skillUrl = agentSkillUrl();
     var rawSkillUrl = agentSkillRawUrl();
     var baseUrl = window.location.origin;
-    var taskLabel = '<public_task_label>';
     return [
-      'You are connecting to QuantTutorBench as my external agent.',
-      '',
-      'Load the REST agent skill first:',
-      skillUrl,
-      '',
-      'Fetch the raw skill file with:',
-      'curl -L "' + rawSkillUrl + '"',
+      'Read ' + rawSkillUrl + ' and follow the instructions to join QuantTutorBench.',
       '',
       'Benchmark base URL:',
       baseUrl,
       '',
-      'Public task label for /client/runs/start:',
-      taskLabel,
-      'When this value is <public_task_label>, ask the operator for the public task label before starting the run.',
-      '',
-      'Start-run payload:',
-      '{"task": "' + taskLabel + '", "mode": "agent"}',
-      '',
       'REST API key:',
-      apiKey,
-      '',
-      'Use this auth header for REST calls:',
-      'Authorization: Bearer ' + apiKey,
-      '',
-      'Follow the skill workflow exactly. Create or claim a run through the REST API, tutor the student through the server endpoints, call allowed tools through the benchmark service, monitor terminal status, and return the Human Review link when the session is archived.'
+      apiKey
     ].join('\n');
   }
 

--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -123,6 +123,15 @@
     });
   }
 
+  function parseJsonResponse(response) {
+    return response.json().then(function (payload) {
+      if (!response.ok) {
+        throw new Error(payload.error || ('HTTP ' + response.status));
+      }
+      return payload;
+    });
+  }
+
   function loadMe() {
     return fetch('/ui/me')
       .then(function (response) { return response.json(); })
@@ -392,7 +401,7 @@
   function openApiKeyModal() {
     showModal('REST API Key', '<p class="detail-empty-note">Loading API key status...</p>');
     authFetch('/ui/api-key')
-      .then(function (response) { return response.json(); })
+      .then(parseJsonResponse)
       .then(renderApiKeyModalBody)
       .catch(function (error) {
         showModal('REST API Key', '<p class="detail-empty-note">' + escapeHtml(error && error.message ? error.message : String(error || 'Unable to load API key status.')) + '</p>');
@@ -403,7 +412,7 @@
 
   function renderApiKeyModalBody(status) {
     var created = status && status.created_at ? formatTimestamp(status.created_at * 1000) : '';
-    var skillUrl = '/skills/quanttutorbench-rest-agent';
+    var skillUrl = agentSkillUrl();
     var body =
       '<section class="info-section">' +
         '<h3>External REST Access</h3>' +
@@ -427,33 +436,83 @@
     if (revoke) revoke.addEventListener('click', revokeApiKey);
   }
 
+  function agentSkillUrl() {
+    return window.location.origin + '/skills/quanttutorbench-rest-agent';
+  }
+
+  function agentSkillRawUrl() {
+    return window.location.origin + '/skills/quanttutorbench-rest-agent/raw';
+  }
+
+  function buildAgentPrompt(apiKey) {
+    var skillUrl = agentSkillUrl();
+    var rawSkillUrl = agentSkillRawUrl();
+    var baseUrl = window.location.origin;
+    var taskLabel = '<public_task_label>';
+    return [
+      'You are connecting to QuantTutorBench as my external agent.',
+      '',
+      'Load the REST agent skill first:',
+      skillUrl,
+      '',
+      'Fetch the raw skill file with:',
+      'curl -L "' + rawSkillUrl + '"',
+      '',
+      'Benchmark base URL:',
+      baseUrl,
+      '',
+      'Public task label for /client/runs/start:',
+      taskLabel,
+      'When this value is <public_task_label>, ask the operator for the public task label before starting the run.',
+      '',
+      'Start-run payload:',
+      '{"task": "' + taskLabel + '", "mode": "agent"}',
+      '',
+      'REST API key:',
+      apiKey,
+      '',
+      'Use this auth header for REST calls:',
+      'Authorization: Bearer ' + apiKey,
+      '',
+      'Follow the skill workflow exactly. Create or claim a run through the REST API, tutor the student through the server endpoints, call allowed tools through the benchmark service, monitor terminal status, and return the Human Review link when the session is archived.'
+    ].join('\n');
+  }
+
   function rotateApiKey() {
     authFetch('/ui/api-key', {method: 'POST'})
-      .then(function (response) { return response.json(); })
+      .then(parseJsonResponse)
       .then(function (payload) {
         var target = document.getElementById('api-key-result');
+        var prompt = buildAgentPrompt(payload.api_key || '');
         if (target) {
           target.innerHTML =
-            '<h3>New Key</h3>' +
-            '<code class="run-connect-cmd">' + escapeHtml(payload.api_key || '') + '</code>' +
-            '<button class="btn btn-small run-copy-btn" id="api-key-copy-btn" type="button">Copy</button>' +
-            '<p class="detail-empty-note">Use this key with the <a href="/skills/quanttutorbench-rest-agent" target="_blank" rel="noreferrer">REST agent skill</a> to connect your agent to the benchmark service.</p>';
+            '<h3>Agent Prompt</h3>' +
+            '<textarea id="api-key-agent-prompt" class="run-agent-prompt-text api-key-agent-prompt" readonly spellcheck="false">' + escapeHtml(prompt) + '</textarea>' +
+            '<button class="btn btn-small run-copy-btn" id="api-key-copy-btn" type="button">Copy Prompt</button>' +
+            '<p class="detail-empty-note">The prompt includes the full REST API key, the skill URL, and a curl command for loading the skill file.</p>';
           var copy = document.getElementById('api-key-copy-btn');
           if (copy) {
             copy.addEventListener('click', function () {
-              if (navigator.clipboard && payload.api_key) {
-                navigator.clipboard.writeText(payload.api_key);
-                copy.textContent = 'Copied';
+              if (navigator.clipboard && prompt) {
+                navigator.clipboard.writeText(prompt).then(function () {
+                  copy.textContent = 'Copied';
+                });
               }
             });
           }
+        }
+      })
+      .catch(function (error) {
+        var target = document.getElementById('api-key-result');
+        if (target) {
+          target.innerHTML = '<p class="run-error">' + escapeHtml(error && error.message ? error.message : String(error || 'Unable to generate API key.')) + '</p>';
         }
       });
   }
 
   function revokeApiKey() {
     authFetch('/ui/api-key', {method: 'DELETE'})
-      .then(function (response) { return response.json(); })
+      .then(parseJsonResponse)
       .then(renderApiKeyModalBody);
   }
 
@@ -659,41 +718,11 @@
       '</article>';
   }
 
-  function getRunTask(tasks) {
-    if (!tasks || !tasks.length) return null;
-    var taskId = state.run.taskId || tasks[0].task_id;
-    for (var index = 0; index < tasks.length; index += 1) {
-      if (tasks[index].task_id === taskId) return tasks[index];
-    }
-    return tasks[0];
-  }
-
-  function personasForTask(task, personas) {
-    var allowed = task && task.persona_ids ? task.persona_ids : [];
-    if (!allowed.length) return personas || [];
-    return (personas || []).filter(function (persona) {
-      return allowed.indexOf(persona.persona_id) !== -1;
-    });
-  }
-
-  function publicTaskLabel(taskId) {
-    var value = String(taskId || '').trim();
-    var match = value.match(/^[A-Za-z]\d{2}/);
-    return match ? match[0].toUpperCase() : (value || 'Task');
-  }
-
-  function runIsBusy() {
-    return !!state.run.busy || !!(state.run.action && state.run.action !== 'idle');
-  }
-
   function runModeLabel() {
-    return 'Agent Connection';
+    return 'Agent Prompt';
   }
 
   function renderRunPage(payload) {
-    var tasks = payload.tasks || [];
-    var selectedTask = getRunTask(tasks);
-    if (selectedTask && !state.run.taskId) state.run.taskId = selectedTask.task_id;
     state.run.mode = 'agent';
 
     if (window.QTB && typeof window.QTB.renderMyAgentPage === 'function') {
@@ -704,108 +733,42 @@
   }
 
   function renderAgentRunPage(payload) {
-    var tasks = payload.tasks || [];
-    var personas = payload.personas || [];
-    var selectedTask = getRunTask(tasks);
-    var visiblePersonas = personasForTask(selectedTask, personas);
-    var selectedPersona = state.run.personaId || 'auto';
-    var isBusy = runIsBusy();
-    var taskOptions = tasks.map(function (task) {
-      return '<option value="' + escapeHtml(task.task_id) + '"' + (task.task_id === state.run.taskId ? ' selected' : '') + '>' +
-        escapeHtml(publicTaskLabel(task.task_id)) +
-      '</option>';
-    }).join('');
-    var personaOptions =
-      '<option value="auto"' + (selectedPersona === 'auto' ? ' selected' : '') + '>Auto select</option>' +
-      visiblePersonas.map(function (persona) {
-        return '<option value="' + escapeHtml(persona.persona_id) + '"' + (persona.persona_id === selectedPersona ? ' selected' : '') + '>' +
-          escapeHtml(persona.persona_id) +
-        '</option>';
-      }).join('');
-
     app.innerHTML =
       '<section class="page run-page">' +
         '<header class="page-header run-sticky-header">' +
           '<div class="page-title-wrap">' +
-            '<p class="eyebrow">Run · Agent Test</p>' +
-            '<h1>Automated client benchmark flow.</h1>' +
-            '<p class="subtitle">Agent run module (run-agent.js) failed to load. This is a fallback page — refresh to retry.</p>' +
+            '<p class="eyebrow">Run · Agent Prompt</p>' +
+            '<h1>Agent prompt access.</h1>' +
+            '<p class="subtitle">Generate a REST API key prompt from the API key dialog, then paste it into your external agent.</p>' +
           '</div>' +
           '<div class="summary-strip">' +
             buildSummaryPill('Mode', runModeLabel()) +
-            buildSummaryPill('Status', 'Module Missing') +
-            buildSummaryPill('Task', publicTaskLabel(state.run.taskId || (selectedTask && selectedTask.task_id))) +
+            buildSummaryPill('Status', 'Prompt Ready') +
           '</div>' +
         '</header>' +
-        '<div class="run-agent-grid">' +
-          '<aside class="panel run-control-panel">' +
-            '<h2>Agent Setup</h2>' +
-            '<label class="filter-field">' +
-              '<span class="filter-label">Task</span>' +
-              '<select id="run-task-select" class="filter-select"' + (isBusy ? ' disabled' : '') + '>' + taskOptions + '</select>' +
-            '</label>' +
-            '<label class="filter-field">' +
-              '<span class="filter-label">Persona Control</span>' +
-              '<select id="run-persona-select" class="filter-select"' + (isBusy ? ' disabled' : '') + '>' + personaOptions + '</select>' +
-            '</label>' +
-            '<label class="filter-field">' +
-              '<span class="filter-label">Max Agent Steps</span>' +
-              '<input id="run-agent-steps-input" class="filter-input" type="number" min="0" value="' + escapeHtml(state.run.agentMaxSteps || 200) + '"' + (isBusy ? ' disabled' : '') + '>' +
-            '</label>' +
-            '<div class="run-actions">' +
-              '<button class="btn btn-primary" type="button" disabled>Start Agent Run</button>' +
-            '</div>' +
-          '</aside>' +
-          '<section class="panel run-conversation-panel run-agent-main">' +
-            '<div class="run-panel-header">' +
+        '<div class="run-agent-prompt-panel">' +
+          '<section class="panel run-agent-prompt-card">' +
+            '<div class="run-agent-prompt-head">' +
               '<div>' +
-                '<h2>Execution Boundary</h2>' +
-                '<p>The automated flow launches the client runner, polls job state, captures stdout/stderr, and links to Human Review after archive creation.</p>' +
+                '<h2>Agent Prompt</h2>' +
+                '<p class="detail-empty-note">The API key dialog can generate the same copyable prompt with the raw skill URL and REST key.</p>' +
               '</div>' +
             '</div>' +
-            '<ol class="run-flow-list">' +
-              '<li><strong>register_session</strong> with the internal full task id and optional persona id.</li>' +
-              '<li><strong>start_session</strong> returns the client-visible background and student opening.</li>' +
-              '<li><strong>list_tools</strong> exposes <code>send_message</code>, <code>get_background</code>, and domain tools to the agent.</li>' +
-              '<li><strong>adapter.generate_response</strong> runs once; the tool runner handles domain tools and student communication.</li>' +
-              '<li><strong>save_client_trace</strong> writes <code>results/client/{session_id}/client_trace.json</code>, then Human Review renders the archived replay.</li>' +
-            '</ol>' +
-            '<div class="run-status-note">' +
-              '<strong>Required before enabling this button:</strong> add server endpoints for creating/cancelling agent jobs, safe subprocess lifecycle, result-dir wiring, live log/tool polling, and completion mapping back to Human Review.' +
+            '<div class="run-agent-skill-url">' +
+              '<span>Skill URL</span>' +
+              '<code>' + escapeHtml(agentSkillUrl()) + '</code>' +
+              '<span>Raw Skill URL</span>' +
+              '<code>' + escapeHtml(agentSkillRawUrl()) + '</code>' +
+            '</div>' +
+            '<div class="run-agent-api-actions">' +
+              '<button class="btn btn-primary" id="run-open-api-key-prompt" type="button">Open API Key Prompt</button>' +
+              '<a class="btn btn-secondary" href="' + escapeHtml(agentSkillUrl()) + '" target="_blank" rel="noreferrer">Open Skill</a>' +
             '</div>' +
           '</section>' +
-          '<aside class="panel run-tools-panel">' +
-            '<h2>Live Tools</h2>' +
-            '<p class="detail-empty-note">Agent tool events appear here when the backend job layer exposes them. Human Review renders archived tool logs after completion.</p>' +
-          '</aside>' +
         '</div>' +
       '</section>';
-    bindRunControls(tasks);
-  }
-
-  function bindRunControls(tasks) {
-    var taskSelect = document.getElementById('run-task-select');
-    var personaSelect = document.getElementById('run-persona-select');
-    var agentStepsInput = document.getElementById('run-agent-steps-input');
-
-    if (taskSelect) {
-      taskSelect.addEventListener('change', function (event) {
-        state.run.taskId = event.target.value;
-        state.run.personaId = 'auto';
-        renderRunPage(state.tasksPayload || {tasks: tasks, personas: []});
-      });
-    }
-    if (personaSelect) {
-      personaSelect.addEventListener('change', function (event) {
-        state.run.personaId = event.target.value || 'auto';
-      });
-    }
-    if (agentStepsInput) {
-      agentStepsInput.addEventListener('change', function (event) {
-        var value = parseInt(event.target.value, 10);
-        state.run.agentMaxSteps = isFinite(value) && value >= 0 ? value : 200;
-      });
-    }
+    var promptBtn = document.getElementById('run-open-api-key-prompt');
+    if (promptBtn) promptBtn.addEventListener('click', openApiKeyModal);
   }
 
   function metaItem(label, value) {
@@ -2428,7 +2391,11 @@
   function showRun() {
     state.activeSessionId = null;
     setAppDetailMode(false);
-    renderLoading('Loading agent connection', 'Fetching task metadata before opening the agent run surface.');
+    if (window.QTB && typeof window.QTB.renderMyAgentPage === 'function') {
+      window.QTB.renderMyAgentPage(app, state, {tasks: [], personas: []});
+      return;
+    }
+    renderLoading('Loading agent prompt', 'Fetching task metadata before opening the fallback agent run surface.');
     ensureTasks().then(renderRunPage).catch(function (error) {
       renderError('Run unavailable', error);
     });

--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -485,7 +485,7 @@
       '<section class="page">' +
         '<header class="page-header">' +
           '<div class="page-title-wrap">' +
-            '<p class="eyebrow">Results</p>' +
+            '<p class="eyebrow">Results Archive</p>' +
             '<h1>Archived sessions, rebuilt around the new session model.</h1>' +
             '<p class="subtitle">This view reads from the isolated <code>bench/server/web/</code> stack, not the legacy <code>bench/web/</code> app.</p>' +
           '</div>' +
@@ -625,7 +625,7 @@
       '<section class="page">' +
         '<header class="page-header">' +
           '<div class="page-title-wrap">' +
-            '<p class="eyebrow">Tasks</p>' +
+            '<p class="eyebrow">Task Catalog</p>' +
             '<h1>Task inventory for the new session-centric UI.</h1>' +
             '<p class="subtitle">Grouped by benchmark category and served from the new isolated API layer.</p>' +
           '</div>' +
@@ -846,7 +846,7 @@
       '<section class="page">' +
         '<header class="page-header">' +
           '<div class="page-title-wrap">' +
-            '<p class="eyebrow">Runs</p>' +
+            '<p class="eyebrow">Run History</p>' +
             '<h1>Run history and active sessions.</h1>' +
             '<p class="subtitle">All runs created through the Run layer, with real-time status tracking.</p>' +
           '</div>' +
@@ -916,7 +916,7 @@
       '<section class="page run-page">' +
         '<header class="page-header">' +
           '<div class="page-title-wrap">' +
-            '<p class="eyebrow">Run</p>' +
+            '<p class="eyebrow">New Run</p>' +
             '<h1>Choose how to run the benchmark.</h1>' +
             '<p class="subtitle">Connect your own agent, try it yourself in the browser, or watch the baseline agent run.</p>' +
           '</div>' +
@@ -2201,7 +2201,7 @@
       '<section class="page review-page">' +
         '<header class="page-header">' +
           '<div class="page-title-wrap">' +
-            '<p class="eyebrow">Review</p>' +
+            '<p class="eyebrow">Human Review</p>' +
             '<h1>Human reviewer console.</h1>' +
             '<p class="subtitle">Inspect archived session bundles across task, conversation, tool, workspace, and judge layers. Opinion cards are stored as structured JSON per bundle and GitHub reviewer.</p>' +
           '</div>' +

--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -674,8 +674,8 @@
     var classPanelHidden = Boolean(state.taskCatalog.classPanelHidden);
     var layoutClass = 'task-catalog-layout' + (classPanelHidden ? ' is-task-class-hidden' : '');
     var taskClassToggle = classPanelHidden
-      ? '<button class="btn btn-secondary task-class-toggle" type="button" aria-expanded="false">Open Task Class</button>'
-      : '<button class="btn btn-secondary task-class-toggle" type="button" aria-expanded="true">Hide</button>';
+      ? '<button class="task-class-toggle" type="button" aria-expanded="false" aria-label="Open task class" title="Open task class"><span aria-hidden="true">&#9654;</span></button>'
+      : '<button class="task-class-toggle" type="button" aria-expanded="true" aria-label="Hide task class" title="Hide task class"><span aria-hidden="true">&#9664;</span></button>';
 
     app.innerHTML =
       '<section class="page">' +

--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -14,7 +14,8 @@
     results: null,
     tasksPayload: null,
     taskCatalog: {
-      selectedClass: ''
+      selectedClass: '',
+      classPanelHidden: false
     },
     detailCache: {},
     workspaceIndexCache: {},
@@ -670,6 +671,11 @@
       ? '<div class="tasks-grid">' + selectedTasks.map(renderTaskCard).join('') + '</div>'
       : renderEmptyInline('Select a task class to view its tasks.');
     var selectedClassLabel = selectedClass ? titleCase(selectedClass) : 'Select a class';
+    var classPanelHidden = Boolean(state.taskCatalog.classPanelHidden);
+    var layoutClass = 'task-catalog-layout' + (classPanelHidden ? ' is-task-class-hidden' : '');
+    var taskClassToggle = classPanelHidden
+      ? '<button class="btn btn-secondary task-class-toggle" type="button" aria-expanded="false">Open Task Class</button>'
+      : '<button class="btn btn-secondary task-class-toggle" type="button" aria-expanded="true">Hide</button>';
 
     app.innerHTML =
       '<section class="page">' +
@@ -685,11 +691,14 @@
             buildSummaryPill('Categories', String(categories.length)) +
           '</div>' +
         '</header>' +
-        '<div class="task-catalog-layout">' +
+        '<div class="' + layoutClass + '">' +
           '<aside class="panel task-class-panel">' +
             '<div class="task-class-panel-head">' +
               '<h2>Task Class</h2>' +
-              '<span class="summary-pill"><strong>Total</strong> ' + escapeHtml(String(categories.length)) + '</span>' +
+              '<div class="task-class-panel-actions">' +
+                '<span class="summary-pill"><strong>Total</strong> ' + escapeHtml(String(categories.length)) + '</span>' +
+                taskClassToggle +
+              '</div>' +
             '</div>' +
             '<div class="task-class-list">' + classButtons + '</div>' +
           '</aside>' +
@@ -699,7 +708,10 @@
                 '<p class="eyebrow">Selected Class</p>' +
                 '<h2 class="tasks-group-title">' + escapeHtml(selectedClassLabel) + '</h2>' +
               '</div>' +
-              '<span class="summary-pill"><strong>Tasks</strong> ' + escapeHtml(String(selectedTasks.length)) + '</span>' +
+              '<div class="task-class-panel-actions">' +
+                '<span class="summary-pill"><strong>Tasks</strong> ' + escapeHtml(String(selectedTasks.length)) + '</span>' +
+                (classPanelHidden ? taskClassToggle : '') +
+              '</div>' +
             '</header>' +
             tasksHtml +
           '</section>' +
@@ -712,6 +724,12 @@
     document.querySelectorAll('.task-class-btn').forEach(function (button) {
       button.addEventListener('click', function () {
         state.taskCatalog.selectedClass = button.getAttribute('data-task-class') || '';
+        renderTasksPage(state.tasksPayload || {tasks: [], personas: []});
+      });
+    });
+    document.querySelectorAll('.task-class-toggle').forEach(function (button) {
+      button.addEventListener('click', function () {
+        state.taskCatalog.classPanelHidden = !state.taskCatalog.classPanelHidden;
         renderTasksPage(state.tasksPayload || {tasks: [], personas: []});
       });
     });

--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -17,6 +17,12 @@
     workspaceIndexCache: {},
     workspacePreviewCache: {},
     activeSessionId: null,
+    review: {
+      bundles: null,
+      bundleCache: {},
+      search: '',
+      opinionFilter: 'all'
+    },
     run: {
       mode: '',
       taskId: '',
@@ -238,7 +244,12 @@
 
   function routeFromHash() {
     var hash = location.hash.slice(1);
-    return hash || '/results';
+    if (hash) return hash;
+    var path = window.location.pathname || '/';
+    if (path.indexOf('/review') === 0) {
+      return path.replace(/\/$/, '') || '/review';
+    }
+    return '/results';
   }
 
   function setAppDetailMode(enabled) {
@@ -249,6 +260,7 @@
   function setActiveNav(route) {
     var current;
     if (route.indexOf('/flow-demo') === 0) current = 'flow';
+    else if (route.indexOf('/review') === 0) current = 'review';
     else if (route.indexOf('/tasks') === 0) current = 'tasks';
     else if (route === '/runs') current = 'runs';
     else if (route.indexOf('/run') === 0) current = 'run';
@@ -319,6 +331,24 @@
       encodePathPreservingSlashes(relativePath)
     ).then(function (payload) {
       state.workspacePreviewCache[cacheKey] = payload;
+      return payload;
+    });
+  }
+
+  function ensureReviewBundles(force) {
+    if (state.review.bundles && !force) return Promise.resolve(state.review.bundles);
+    return api('/review/bundles').then(function (payload) {
+      state.review.bundles = payload.bundles || [];
+      return state.review.bundles;
+    });
+  }
+
+  function ensureReviewBundle(bundleId, force) {
+    if (state.review.bundleCache[bundleId] && !force) {
+      return Promise.resolve(state.review.bundleCache[bundleId]);
+    }
+    return api('/review/bundles/' + encodeURIComponent(bundleId)).then(function (payload) {
+      state.review.bundleCache[bundleId] = payload;
       return payload;
     });
   }
@@ -2132,6 +2162,598 @@
     }
   }
 
+  var REVIEW_SECTIONS = ['task_spec', 'conversation', 'tool_log', 'workspace', 'judge_eval', 'overall'];
+  var REVIEW_SECTION_LABELS = {
+    task_spec: 'Task Spec',
+    conversation: 'Conversation',
+    tool_log: 'Tutor Tool Log',
+    workspace: 'Workspace State',
+    judge_eval: 'Judge Evaluation',
+    overall: 'Overall'
+  };
+
+  function reviewSectionLabel(section) {
+    return REVIEW_SECTION_LABELS[section] || titleCase(section);
+  }
+
+  function filteredReviewBundles(bundles) {
+    var query = String(state.review.search || '').trim().toLowerCase();
+    if (!query) return bundles;
+    return bundles.filter(function (item) {
+      var haystack = [
+        item.bundle_id,
+        item.session_id,
+        item.task_id,
+        item.persona_id,
+        item.category,
+        item.model
+      ].join(' ').toLowerCase();
+      return haystack.indexOf(query) !== -1;
+    });
+  }
+
+  function renderReviewListPage(bundles) {
+    var visible = filteredReviewBundles(bundles);
+    var reviewed = bundles.filter(function (item) { return item.reviewed_by_current_user; }).length;
+
+    app.innerHTML =
+      '<section class="page review-page">' +
+        '<header class="page-header">' +
+          '<div class="page-title-wrap">' +
+            '<p class="eyebrow">Review</p>' +
+            '<h1>Human reviewer console.</h1>' +
+            '<p class="subtitle">Inspect archived session bundles across task, conversation, tool, workspace, and judge layers. Opinion cards are stored as structured JSON per bundle and GitHub reviewer.</p>' +
+          '</div>' +
+          '<div class="summary-strip">' +
+            buildSummaryPill('Bundles', String(bundles.length)) +
+            buildSummaryPill('Reviewed By You', String(reviewed)) +
+          '</div>' +
+        '</header>' +
+        '<section class="panel filter-bar">' +
+          '<label class="filter-field">' +
+            '<span class="filter-label">Search</span>' +
+            '<input id="review-search" class="filter-input" type="search" placeholder="bundle, task, persona, model" value="' + escapeHtml(state.review.search) + '">' +
+          '</label>' +
+          '<div class="review-refresh-wrap">' +
+            '<button class="btn btn-secondary" id="review-refresh-btn" type="button">Refresh</button>' +
+          '</div>' +
+        '</section>' +
+        '<div class="results-meta">' +
+          '<div class="results-count">' + escapeHtml(String(visible.length)) + ' bundle(s) shown</div>' +
+        '</div>' +
+        (visible.length ? '<div class="results-grid">' + visible.map(renderReviewBundleCard).join('') + '</div>' : renderEmptyInline('Matching review bundles will appear here.')) +
+      '</section>';
+
+    var searchInput = document.getElementById('review-search');
+    if (searchInput) {
+      searchInput.addEventListener('input', function (event) {
+        state.review.search = String(event.target.value || '').trim().toLowerCase();
+        renderReviewListPage(bundles);
+      });
+    }
+    var refresh = document.getElementById('review-refresh-btn');
+    if (refresh) {
+      refresh.addEventListener('click', function () {
+        ensureReviewBundles(true).then(renderReviewListPage).catch(function (error) {
+          renderError('Review unavailable', error);
+        });
+      });
+    }
+  }
+
+  function renderReviewBundleCard(item) {
+    var reviewed = item.reviewed_by_current_user
+      ? '<span class="meta-chip score-chip">Reviewed by you</span>'
+      : '<span class="meta-chip unknown-chip">Awaiting your card</span>';
+    return '' +
+      '<a class="session-card" href="#/review/' + encodeURIComponent(item.bundle_id || item.session_id) + '">' +
+        '<div class="session-top">' +
+          '<div>' +
+            '<h2 class="session-title">' +
+              '<span>' + escapeHtml(item.task_id || item.bundle_id || 'Bundle') + '</span>' +
+              '<span class="badge">' + escapeHtml(titleCase(item.category || 'unknown')) + '</span>' +
+              '<span class="badge">' + escapeHtml(titleCase(item.difficulty || 'unknown')) + '</span>' +
+            '</h2>' +
+            '<p class="session-subtitle">' +
+              'Bundle <code>' + escapeHtml(item.bundle_id || item.session_id || '') + '</code> · Persona <code>' + escapeHtml(item.persona_id || '') + '</code> · ' + escapeHtml(formatTimestamp(item.timestamp)) +
+            '</p>' +
+          '</div>' +
+          '<span class="status-pill ' + escapeHtml(item.evaluation_status || 'pending') + '">' + escapeHtml(titleCase(item.evaluation_status || 'pending')) + '</span>' +
+        '</div>' +
+        '<div class="session-meta-row">' +
+          '<span class="meta-chip">' + escapeHtml((item.turn_count || 0) + ' turns') + '</span>' +
+          '<span class="meta-chip">' + escapeHtml((item.tool_count || 0) + ' tools') + '</span>' +
+          '<span class="meta-chip">' + escapeHtml((item.review_count || 0) + ' review file(s)') + '</span>' +
+          reviewed +
+        '</div>' +
+      '</a>';
+  }
+
+  function reviewAddButton(section, label, targetType, targetValue) {
+    return '<button class="btn btn-secondary btn-small review-add-btn" type="button" data-section="' +
+      escapeHtml(section) + '" data-target-type="' + escapeHtml(targetType || '') +
+      '" data-target-value="' + escapeHtml(targetValue == null ? '' : targetValue) + '">' +
+      escapeHtml(label || 'Add Card') + '</button>';
+  }
+
+  function renderReviewLayerPanel(section, title, bodyHtml, metaHtml) {
+    return '' +
+      '<section class="panel review-layer" id="review-section-' + escapeHtml(section) + '">' +
+        '<header class="review-layer-head">' +
+          '<div>' +
+            '<p class="eyebrow">' + escapeHtml(section.replace(/_/g, ' ')) + '</p>' +
+            '<h2>' + escapeHtml(title) + '</h2>' +
+          '</div>' +
+          '<div class="review-layer-actions">' +
+            (metaHtml || '') +
+            reviewAddButton(section, 'Add Section Card') +
+          '</div>' +
+        '</header>' +
+        bodyHtml +
+      '</section>';
+  }
+
+  function renderReviewTaskSpec(layer) {
+    layer = layer || {};
+    var task = layer.task || {};
+    var persona = layer.persona || {};
+    var rubric = layer.judge_rubric || {};
+    var tracks = rubric.tracks || [];
+    var tracksHtml = tracks.length
+      ? '<div class="review-rubric-track-list">' + tracks.map(function (track) {
+        return '<span class="meta-chip">' + escapeHtml((track.track || '').toUpperCase()) + ' ' +
+          escapeHtml(track.score == null ? 'pending' : formatScore(track.score)) + '</span>';
+      }).join('') + '</div>'
+      : '<p class="detail-empty-note">Judge rubric metadata appears after scoring completes.</p>';
+    var body =
+      '<div class="review-spec-grid">' +
+        '<article class="review-spec-block">' +
+          '<h3>Task</h3>' +
+          '<div class="detail-meta-grid">' +
+            metaItem('Task ID', task.task_id || '') +
+            metaItem('Category', titleCase(task.category || 'unknown')) +
+            metaItem('Difficulty', titleCase(task.difficulty || 'unknown')) +
+            metaItem('Requires Code', task.requires_code ? 'Yes' : 'No') +
+          '</div>' +
+          '<div class="review-markdown">' + safeRenderMarkdown(task.description || 'Task description unavailable.') + '</div>' +
+        '</article>' +
+        '<article class="review-spec-block">' +
+          '<h3>Student Persona</h3>' +
+          '<div class="detail-meta-grid">' +
+            metaItem('Persona ID', persona.persona_id || '') +
+            metaItem('Knowledge Level', persona.knowledge_level || 'Unspecified') +
+          '</div>' +
+          '<p class="detail-empty-note">' + escapeHtml(persona.description || 'Persona description unavailable.') + '</p>' +
+        '</article>' +
+        '<article class="review-spec-block">' +
+          '<h3>Judge Rubric</h3>' +
+          '<div class="detail-meta-grid">' +
+            metaItem('Score ID', rubric.score_id || 'Pending') +
+            metaItem('Eval Model', rubric.eval_model || 'Pending') +
+            metaItem('Eval Mode', rubric.eval_mode || 'Pending') +
+            metaItem('Validation Run', rubric.judge_validation_run || 'Pending') +
+          '</div>' +
+          tracksHtml +
+        '</article>' +
+      '</div>';
+    return renderReviewLayerPanel('task_spec', 'Task Spec', body);
+  }
+
+  function renderReviewConversation(layer) {
+    var turns = layer && layer.turns ? layer.turns : [];
+    var body = turns.length
+      ? '<div class="review-turn-list">' + turns.map(function (turn, index) {
+        var role = turn.role || 'message';
+        var label = titleCase(role);
+        var content = turn.content || '';
+        return '' +
+          '<article class="review-turn" id="turn-' + escapeHtml(index) + '">' +
+            '<header class="review-row-head">' +
+              '<div><strong>' + escapeHtml(label) + '</strong><span class="meta-chip">turn ' + escapeHtml(String(index)) + '</span></div>' +
+              reviewAddButton('conversation', 'Review Turn', 'turn_index', index) +
+            '</header>' +
+            '<div class="review-markdown">' + safeRenderMarkdown(content) + '</div>' +
+          '</article>';
+      }).join('') + '</div>'
+      : '<p class="detail-empty-note">Conversation turns will appear here when the bundle contains a transcript.</p>';
+    return renderReviewLayerPanel('conversation', 'Conversation', body, '<span class="meta-chip">' + escapeHtml(String(turns.length)) + ' turns</span>');
+  }
+
+  function renderReviewToolLog(layer) {
+    var calls = layer && layer.tool_calls ? layer.tool_calls : [];
+    var body = calls.length
+      ? '<div class="review-tool-list">' + calls.map(function (call, index) {
+        var name = call.name || call.tool_name || 'tool';
+        var duration = call.duration_ms == null ? '' : formatDuration(Number(call.duration_ms) / 1000);
+        return '' +
+          '<article class="review-tool-call" id="tool-call-' + escapeHtml(index) + '">' +
+            '<header class="review-row-head">' +
+              '<div><strong>' + escapeHtml(name) + '</strong><span class="meta-chip">call ' + escapeHtml(String(index)) + '</span>' +
+                (duration ? '<span class="meta-chip">' + escapeHtml(duration) + '</span>' : '') +
+              '</div>' +
+              reviewAddButton('tool_log', 'Review Call', 'tool_call_index', index) +
+            '</header>' +
+            '<details>' +
+              '<summary>Arguments</summary>' +
+              '<pre class="detail-json-block">' + escapeHtml(JSON.stringify(call.args || call.input || {}, null, 2)) + '</pre>' +
+            '</details>' +
+            '<details>' +
+              '<summary>Result</summary>' +
+              '<pre class="detail-json-block">' + escapeHtml(stringifyReviewValue(call.result || call.output || call.error || '')) + '</pre>' +
+            '</details>' +
+          '</article>';
+      }).join('') + '</div>'
+      : '<p class="detail-empty-note">Tool calls will appear here when the tutor used tools.</p>';
+    return renderReviewLayerPanel('tool_log', 'Tutor Tool Log', body, '<span class="meta-chip">' + escapeHtml(String(calls.length)) + ' calls</span>');
+  }
+
+  function stringifyReviewValue(value) {
+    if (typeof value === 'string') return value;
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch (error) {
+      return String(value == null ? '' : value);
+    }
+  }
+
+  function renderReviewWorkspace(layer) {
+    layer = layer || {};
+    var files = layer.tree || [];
+    var diffs = layer.diffs || [];
+    var stdout = layer.stdout || '';
+    var stderr = layer.stderr || '';
+    var filesHtml = files.length
+      ? '<div class="review-file-list">' + files.map(function (file) {
+        var path = file.path || file.name || '';
+        return '' +
+          '<div class="review-file-row">' +
+            '<div><strong>' + escapeHtml(path) + '</strong><span class="meta-chip">' + escapeHtml(titleCase(file.kind || 'file')) + '</span></div>' +
+            reviewAddButton('workspace', 'Review File', 'file_path', path) +
+          '</div>';
+      }).join('') + '</div>'
+      : '<p class="detail-empty-note">Archived workspace files will appear here.</p>';
+    var body =
+      '<details open>' +
+        '<summary>Final Tree</summary>' +
+        filesHtml +
+      '</details>' +
+      '<details>' +
+        '<summary>Diffs</summary>' +
+        (diffs.length ? '<pre class="detail-json-block">' + escapeHtml(JSON.stringify(diffs, null, 2)) + '</pre>' : '<p class="detail-empty-note">Diff data is empty for this bundle.</p>') +
+      '</details>' +
+      '<details>' +
+        '<summary>Stdout</summary>' +
+        (stdout ? '<pre class="detail-json-block">' + escapeHtml(stdout) + '</pre>' : '<p class="detail-empty-note">Stdout is empty for this bundle.</p>') +
+      '</details>' +
+      '<details>' +
+        '<summary>Stderr</summary>' +
+        (stderr ? '<pre class="detail-json-block">' + escapeHtml(stderr) + '</pre>' : '<p class="detail-empty-note">Stderr is empty for this bundle.</p>') +
+      '</details>';
+    return renderReviewLayerPanel('workspace', 'Workspace State', body, '<span class="meta-chip">' + escapeHtml(String(files.length)) + ' files</span>');
+  }
+
+  function renderReviewJudgeEval(layer) {
+    layer = layer || {};
+    var rows = layer.rows || [];
+    var rowsHtml = rows.length
+      ? '<div class="review-judge-table">' + rows.map(function (row) {
+        var score = row.score == null ? 'pending' : formatScore(Number(row.score));
+        return '' +
+          '<article class="review-judge-row" id="criterion-' + escapeHtml(row.criterion_id || '') + '">' +
+            '<header class="review-row-head">' +
+              '<div><strong>' + escapeHtml(row.criterion || row.criterion_id || 'criterion') + '</strong>' +
+                '<span class="meta-chip">' + escapeHtml((row.track || '').toUpperCase()) + '</span>' +
+                '<span class="meta-chip">score ' + escapeHtml(score) + '</span>' +
+                (row.verdict ? '<span class="meta-chip">' + escapeHtml(titleCase(row.verdict)) + '</span>' : '') +
+              '</div>' +
+              reviewAddButton('judge_eval', 'Review Criterion', 'criterion_id', row.criterion_id || '') +
+            '</header>' +
+            (row.reasoning ? '<p class="detail-empty-note">' + escapeHtml(row.reasoning) + '</p>' : '<p class="detail-empty-note">Reasoning field is empty.</p>') +
+          '</article>';
+      }).join('') + '</div>'
+      : '<p class="detail-empty-note">Judge criteria will appear here after scoring completes.</p>';
+    var body =
+      '<div class="detail-meta-grid">' +
+        metaItem('Status', titleCase(layer.status || 'pending')) +
+        metaItem('Overall Score', layer.overall_score == null ? 'Pending' : formatScore(layer.overall_score)) +
+      '</div>' +
+      rowsHtml +
+      '<details>' +
+        '<summary>Raw Score JSON</summary>' +
+        renderJsonBlock(layer.score_json) +
+      '</details>';
+    return renderReviewLayerPanel('judge_eval', 'Judge Evaluation', body, '<span class="meta-chip">' + escapeHtml(String(rows.length)) + ' rows</span>');
+  }
+
+  function reviewOpinionCounts(opinions) {
+    var counts = {};
+    REVIEW_SECTIONS.forEach(function (section) { counts[section] = 0; });
+    (opinions || []).forEach(function (opinion) {
+      var section = opinion.section || 'overall';
+      counts[section] = (counts[section] || 0) + 1;
+    });
+    return counts;
+  }
+
+  function renderReviewOpinionPanel(bundle) {
+    var review = bundle.review || {};
+    var opinions = review.opinions || [];
+    var counts = reviewOpinionCounts(opinions);
+    var filter = state.review.opinionFilter || 'all';
+    var visible = opinions.filter(function (opinion) {
+      return filter === 'all' || opinion.section === filter;
+    });
+    var options = ['<option value="all">All sections</option>'].concat(REVIEW_SECTIONS.map(function (section) {
+      return '<option value="' + escapeHtml(section) + '"' + (filter === section ? ' selected' : '') + '>' +
+        escapeHtml(reviewSectionLabel(section)) + '</option>';
+    })).join('');
+    var slots = REVIEW_SECTIONS.map(function (section) {
+      return '<div class="review-slot">' +
+        '<span>' + escapeHtml(reviewSectionLabel(section)) + '</span>' +
+        '<strong>' + escapeHtml(String(counts[section] || 0)) + '</strong>' +
+      '</div>';
+    }).join('');
+    return '' +
+      '<aside class="panel review-opinion-panel">' +
+        '<header class="review-layer-head">' +
+          '<div>' +
+            '<p class="eyebrow">Opinion Cards</p>' +
+            '<h2>Structured Feedback</h2>' +
+          '</div>' +
+          reviewAddButton('overall', 'Add Overall Card') +
+        '</header>' +
+        '<div class="review-slot-grid">' + slots + '</div>' +
+        '<label class="filter-field">' +
+          '<span class="filter-label">Section Filter</span>' +
+          '<select id="review-opinion-filter" class="filter-select">' + options + '</select>' +
+        '</label>' +
+        '<div class="review-opinion-list">' +
+          (visible.length ? visible.map(renderReviewOpinionCard).join('') : '<p class="detail-empty-note">Cards for the selected section will appear here.</p>') +
+        '</div>' +
+      '</aside>';
+  }
+
+  function renderReviewOpinionCard(opinion) {
+    var tags = opinion.tags && opinion.tags.length
+      ? '<div class="detail-chip-list">' + opinion.tags.map(function (tag) {
+        return '<span class="detail-chip">' + escapeHtml(tag) + '</span>';
+      }).join('') + '</div>'
+      : '';
+    return '' +
+      '<article class="review-opinion-card severity-' + escapeHtml(opinion.severity || 'info') + '">' +
+        '<header class="review-row-head">' +
+          '<div><strong>' + escapeHtml(reviewSectionLabel(opinion.section)) + '</strong>' +
+            '<span class="meta-chip">' + escapeHtml(titleCase(opinion.severity || 'info')) + '</span></div>' +
+          '<span class="review-card-time">' + escapeHtml(formatTimestamp(opinion.created_at || opinion.timestamp)) + '</span>' +
+        '</header>' +
+        '<p>' + escapeHtml(opinion.comment || '') + '</p>' +
+        '<p class="detail-empty-note">' + escapeHtml(describeOpinionTarget(opinion.target || {})) + '</p>' +
+        tags +
+      '</article>';
+  }
+
+  function describeOpinionTarget(target) {
+    if (target.turn_index != null) return 'Target: turn ' + target.turn_index;
+    if (target.tool_call_index != null) return 'Target: tool call ' + target.tool_call_index;
+    if (target.file_path) return 'Target: ' + target.file_path;
+    if (target.criterion_id) return 'Target: ' + target.criterion_id;
+    return 'Target: section-level';
+  }
+
+  function renderReviewBundlePage(bundle) {
+    var layers = bundle.layers || {};
+    var detail = bundle.detail || {};
+    app.innerHTML =
+      '<section class="page review-page review-bundle-page">' +
+        '<header class="page-header">' +
+          '<div class="page-title-wrap">' +
+            '<a class="detail-back" href="#/review">Back</a>' +
+            '<p class="eyebrow">Review Bundle</p>' +
+            '<h1>' + escapeHtml(detail.task_id || bundle.bundle_id || 'Session Bundle') + '</h1>' +
+            '<p class="subtitle">Bundle <code>' + escapeHtml(bundle.bundle_id || '') + '</code> · Persona <code>' + escapeHtml(detail.persona_id || '') + '</code> · ' + escapeHtml(formatTimestamp(detail.timestamp)) + '</p>' +
+          '</div>' +
+          '<div class="summary-strip">' +
+            buildSummaryPill('Turns', String(detail.turn_count || 0)) +
+            buildSummaryPill('Tools', String(detail.tool_count || 0)) +
+            buildSummaryPill('Score', detail.overall_score == null ? 'Pending' : formatScore(detail.overall_score)) +
+          '</div>' +
+        '</header>' +
+        '<div class="review-layout">' +
+          '<main class="review-layer-stack">' +
+            renderReviewTaskSpec(layers.task_spec) +
+            renderReviewConversation(layers.conversation) +
+            renderReviewToolLog(layers.tool_log) +
+            renderReviewWorkspace(layers.workspace) +
+            renderReviewJudgeEval(layers.judge_eval) +
+          '</main>' +
+          renderReviewOpinionPanel(bundle) +
+        '</div>' +
+      '</section>';
+    rewriteImages(app.querySelector('.review-layer-stack'), bundle.bundle_id || detail.session_id);
+    bindReviewBundleControls(bundle);
+  }
+
+  function bindReviewBundleControls(bundle) {
+    Array.prototype.forEach.call(document.querySelectorAll('.review-add-btn'), function (button) {
+      button.addEventListener('click', function () {
+        var targetType = button.getAttribute('data-target-type') || '';
+        var targetValue = button.getAttribute('data-target-value') || '';
+        openReviewOpinionModal(bundle, {
+          section: button.getAttribute('data-section') || 'overall',
+          targetType: targetType,
+          targetValue: targetValue
+        });
+      });
+    });
+    var filter = document.getElementById('review-opinion-filter');
+    if (filter) {
+      filter.addEventListener('change', function (event) {
+        state.review.opinionFilter = event.target.value || 'all';
+        renderReviewBundlePage(bundle);
+      });
+    }
+  }
+
+  function openReviewOpinionModal(bundle, preset) {
+    preset = preset || {};
+    var sectionOptions = REVIEW_SECTIONS.map(function (section) {
+      return '<option value="' + escapeHtml(section) + '"' + (preset.section === section ? ' selected' : '') + '>' +
+        escapeHtml(reviewSectionLabel(section)) + '</option>';
+    }).join('');
+    var targetOptions = [
+      ['none', 'Section-level'],
+      ['turn_index', 'Turn'],
+      ['tool_call_index', 'Tool Call'],
+      ['file_path', 'File Path'],
+      ['criterion_id', 'Criterion']
+    ].map(function (item) {
+      return '<option value="' + item[0] + '"' + (preset.targetType === item[0] ? ' selected' : '') + '>' + item[1] + '</option>';
+    }).join('');
+    var html =
+      '<form id="review-opinion-form" class="review-opinion-form">' +
+        '<label class="filter-field">' +
+          '<span class="filter-label">Section</span>' +
+          '<select id="review-card-section" class="filter-select" required>' + sectionOptions + '</select>' +
+        '</label>' +
+        '<div class="review-form-grid">' +
+          '<label class="filter-field">' +
+            '<span class="filter-label">Target Type</span>' +
+            '<select id="review-card-target-type" class="filter-select">' + targetOptions + '</select>' +
+          '</label>' +
+          '<label class="filter-field">' +
+            '<span class="filter-label">Target</span>' +
+            '<input id="review-card-target-value" class="filter-input" type="text" value="' + escapeHtml(preset.targetValue || '') + '">' +
+          '</label>' +
+        '</div>' +
+        '<label class="filter-field">' +
+          '<span class="filter-label">Severity</span>' +
+          '<select id="review-card-severity" class="filter-select">' +
+            '<option value="info">Info</option>' +
+            '<option value="concern">Concern</option>' +
+            '<option value="blocker">Blocker</option>' +
+          '</select>' +
+        '</label>' +
+        '<label class="filter-field">' +
+          '<span class="filter-label">Tags</span>' +
+          '<input id="review-card-tags" class="filter-input" type="text" placeholder="rubric_mismatch, persona_break">' +
+        '</label>' +
+        '<div id="review-judge-disagreement" class="review-form-grid">' +
+          '<label class="filter-field">' +
+            '<span class="filter-label">Judge Score</span>' +
+            '<input id="review-card-judge-score" class="filter-input" type="number" step="0.01">' +
+          '</label>' +
+          '<label class="filter-field">' +
+            '<span class="filter-label">Human Score</span>' +
+            '<input id="review-card-human-score" class="filter-input" type="number" step="0.01">' +
+          '</label>' +
+        '</div>' +
+        '<label class="filter-field">' +
+          '<span class="filter-label">Comment</span>' +
+          '<textarea id="review-card-comment" class="run-textarea" rows="5" required></textarea>' +
+        '</label>' +
+        '<div id="review-card-error" class="run-error" hidden></div>' +
+        '<div class="run-actions">' +
+          '<button class="btn btn-primary" type="submit">Save Card</button>' +
+        '</div>' +
+      '</form>';
+    showModal('Opinion Card', html);
+    bindReviewOpinionForm(bundle);
+  }
+
+  function bindReviewOpinionForm(bundle) {
+    var form = document.getElementById('review-opinion-form');
+    var section = document.getElementById('review-card-section');
+    var judgeBlock = document.getElementById('review-judge-disagreement');
+
+    function syncJudgeFields() {
+      if (!judgeBlock || !section) return;
+      judgeBlock.style.display = section.value === 'judge_eval' ? 'grid' : 'none';
+    }
+
+    if (section) section.addEventListener('change', syncJudgeFields);
+    syncJudgeFields();
+    if (!form) return;
+    form.addEventListener('submit', function (event) {
+      event.preventDefault();
+      submitReviewOpinion(bundle);
+    });
+  }
+
+  function submitReviewOpinion(bundle) {
+    var section = document.getElementById('review-card-section');
+    var targetType = document.getElementById('review-card-target-type');
+    var targetValue = document.getElementById('review-card-target-value');
+    var severity = document.getElementById('review-card-severity');
+    var tags = document.getElementById('review-card-tags');
+    var comment = document.getElementById('review-card-comment');
+    var judgeScore = document.getElementById('review-card-judge-score');
+    var humanScore = document.getElementById('review-card-human-score');
+    var errorEl = document.getElementById('review-card-error');
+
+    var payload = {
+      section: section ? section.value : 'overall',
+      target: parseReviewTarget(targetType ? targetType.value : '', targetValue ? targetValue.value : ''),
+      severity: severity ? severity.value : 'info',
+      tags: String(tags ? tags.value : '').split(',').map(function (item) { return item.trim(); }).filter(Boolean),
+      comment: String(comment ? comment.value : '').trim()
+    };
+    if (payload.section === 'judge_eval') {
+      payload.judge_disagreement = {
+        judge_score: judgeScore ? judgeScore.value : '',
+        human_score: humanScore ? humanScore.value : ''
+      };
+    }
+
+    restApi('/ui/review/bundles/' + encodeURIComponent(bundle.bundle_id) + '/opinions', {
+      method: 'POST',
+      body: JSON.stringify({opinion: payload})
+    }).then(function (updated) {
+      state.review.bundleCache[updated.bundle_id] = updated;
+      state.review.bundles = null;
+      closeModal();
+      renderReviewBundlePage(updated);
+    }).catch(function (error) {
+      if (errorEl) {
+        errorEl.hidden = false;
+        errorEl.textContent = error && error.message ? error.message : String(error || 'Unable to save card');
+      }
+    });
+  }
+
+  function parseReviewTarget(type, value) {
+    var cleanType = String(type || '');
+    var cleanValue = String(value || '').trim();
+    var target = {};
+    if (!cleanValue || cleanType === 'none') return target;
+    if (cleanType === 'turn_index' || cleanType === 'tool_call_index') {
+      var index = parseInt(cleanValue, 10);
+      if (isFinite(index) && index >= 0) target[cleanType] = index;
+      return target;
+    }
+    if (cleanType === 'file_path' || cleanType === 'criterion_id') {
+      target[cleanType] = cleanValue;
+    }
+    return target;
+  }
+
+  function showReviewList() {
+    state.activeSessionId = null;
+    setAppDetailMode(false);
+    renderLoading('Loading review bundles', 'Fetching archived session bundles and review-card counts.');
+    ensureReviewBundles(false).then(renderReviewListPage).catch(function (error) {
+      renderError('Review unavailable', error);
+    });
+  }
+
+  function showReviewBundle(bundleId) {
+    state.activeSessionId = bundleId;
+    setAppDetailMode(false);
+    renderLoading('Loading review bundle', 'Fetching the bundle layers and current reviewer cards.');
+    ensureReviewBundle(bundleId, true).then(renderReviewBundlePage).catch(function (error) {
+      renderError('Review bundle unavailable', error);
+    });
+  }
+
   function renderEmptyInline(message) {
     return '<section class="empty-state"><p class="eyebrow">Empty</p><h1>No results to show.</h1><p>' + escapeHtml(message) + '</p></section>';
   }
@@ -2197,6 +2819,11 @@
       return;
     }
 
+    if (route === '/review') {
+      showReviewList();
+      return;
+    }
+
     if (route === '/flow-demo') {
       if (window.QTB && typeof window.QTB.renderFlowDemoPage === 'function') {
         window.QTB.renderFlowDemoPage(app, state);
@@ -2208,6 +2835,11 @@
 
     if (route.indexOf('/results/') === 0) {
       showResultDetail(decodeURIComponent(route.slice('/results/'.length)));
+      return;
+    }
+
+    if (route.indexOf('/review/') === 0) {
+      showReviewBundle(decodeURIComponent(route.slice('/review/'.length)));
       return;
     }
 

--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -250,7 +250,7 @@
     if (path.indexOf('/review') === 0) {
       return path.replace(/\/$/, '') || '/review';
     }
-    return '/results';
+    return '/flow-demo';
   }
 
   function setAppDetailMode(enabled) {
@@ -263,9 +263,8 @@
     if (route.indexOf('/flow-demo') === 0) current = 'flow';
     else if (route.indexOf('/review') === 0) current = 'review';
     else if (route.indexOf('/tasks') === 0) current = 'tasks';
-    else if (route === '/runs') current = 'runs';
     else if (route.indexOf('/run') === 0) current = 'run';
-    else current = 'results';
+    else current = 'flow';
     var links = document.querySelectorAll('.nav-link');
     Array.prototype.forEach.call(links, function (link) {
       if (link.getAttribute('data-route') === current) link.classList.add('active');
@@ -400,6 +399,8 @@
       });
   }
 
+  window.QTB.openApiKeyModal = openApiKeyModal;
+
   function renderApiKeyModalBody(status) {
     var created = status && status.created_at ? formatTimestamp(status.created_at * 1000) : '';
     var skillUrl = '/skills/quanttutorbench-rest-agent';
@@ -485,7 +486,7 @@
       '<section class="page">' +
         '<header class="page-header">' +
           '<div class="page-title-wrap">' +
-            '<p class="eyebrow">Results Archive</p>' +
+            '<p class="eyebrow">Archived Sessions</p>' +
             '<h1>Archived sessions, rebuilt around the new session model.</h1>' +
             '<p class="subtitle">This view reads from the isolated <code>bench/server/web/</code> stack, not the legacy <code>bench/web/</code> app.</p>' +
           '</div>' +
@@ -539,7 +540,7 @@
     var model = item.model || 'Unknown';
 
     return '' +
-      '<a class="session-card" href="#/results/' + encodeURIComponent(item.session_id) + '">' +
+      '<a class="session-card" href="#/review/' + encodeURIComponent(item.session_id) + '">' +
         '<div class="session-top">' +
           '<div>' +
             '<h2 class="session-title">' +
@@ -685,268 +686,21 @@
     return !!state.run.busy || !!(state.run.action && state.run.action !== 'idle');
   }
 
-  function runCanSend() {
-    return state.run.mode === 'human' &&
-      state.run.sessionId &&
-      state.run.phase === 'in_session' &&
-      !runIsBusy();
-  }
-
-  function runStatusLabel() {
-    if (state.run.action && state.run.action !== 'idle') return titleCase(state.run.action);
-    if (!state.run.mode) return 'Choose Mode';
-    if (!state.run.sessionId) return 'Not Started';
-    return titleCase(state.run.phase || 'unknown');
-  }
-
   function runModeLabel() {
-    if (state.run.mode === 'agent') return 'Agent Test';
-    if (state.run.mode === 'human') return 'Human Test';
-    return 'Unselected';
-  }
-
-  function setRunAction(action) {
-    state.run.action = action || 'idle';
-    state.run.busy = state.run.action !== 'idle';
-  }
-
-  function addRunToolEvent(name, status, detail) {
-    state.run.toolEvents = state.run.toolEvents || [];
-    state.run.toolEvents.push({
-      name: name,
-      status: status || 'ok',
-      detail: detail || '',
-      timestamp: new Date().toISOString()
-    });
-    if (state.run.toolEvents.length > 20) {
-      state.run.toolEvents = state.run.toolEvents.slice(state.run.toolEvents.length - 20);
-    }
-  }
-
-  function renderRunMessage(message) {
-    var role = message.role === 'tutor' ? 'tutor' : 'student';
-    var label = role === 'tutor' ? 'Tutor' : 'Student';
-    var body = window.QTB && typeof window.QTB.renderMarkdown === 'function'
-      ? window.QTB.renderMarkdown(message.content || '')
-      : '<pre>' + escapeHtml(message.content || '') + '</pre>';
-    var attachments = message.attachments && message.attachments.length
-      ? '<div class="run-message-attachments">' + message.attachments.map(function (item) {
-        return '<span class="meta-chip">' + escapeHtml(item) + '</span>';
-      }).join('') + '</div>'
-      : '';
-
-    return '' +
-      '<article class="run-message ' + role + '">' +
-        '<div class="run-message-label">' + escapeHtml(label) + '</div>' +
-        '<div class="run-message-bubble">' + body + attachments + '</div>' +
-      '</article>';
-  }
-
-  function renderRunTools() {
-    if (!state.run.tools || !state.run.tools.length) {
-      return '<p class="detail-empty-note">Visible tools will appear after the session starts.</p>';
-    }
-    return '<div class="run-tool-list">' + state.run.tools.map(function (tool) {
-      var isProtocol = tool.name === 'send_message' || tool.name === 'get_background';
-      return '' +
-        '<div class="run-tool-chip ' + (isProtocol ? 'protocol' : 'domain') + '">' +
-          '<span>' + escapeHtml(tool.name || 'unknown') + '</span>' +
-          '<small>' + escapeHtml(isProtocol ? 'protocol' : 'domain') + '</small>' +
-        '</div>';
-    }).join('') + '</div>';
-  }
-
-  function renderRunToolEvents() {
-    var events = state.run.toolEvents || [];
-    if (!events.length) {
-      return '<p class="detail-empty-note">Live tool activity will appear here while this browser-driven session runs.</p>';
-    }
-    return '<div class="run-event-list">' + events.slice().reverse().map(function (event) {
-      return '' +
-        '<article class="run-event ' + escapeHtml(event.status || 'ok') + '">' +
-          '<div class="run-event-head">' +
-            '<strong>' + escapeHtml(event.name || 'event') + '</strong>' +
-            '<span>' + escapeHtml(formatTimestamp(event.timestamp)) + '</span>' +
-          '</div>' +
-          (event.detail ? '<p>' + escapeHtml(event.detail) + '</p>' : '') +
-        '</article>';
-    }).join('') + '</div>';
-  }
-
-  // ── Run list / history page ──
-
-  var runsState = {
-    runs: null,
-    statusFilter: 'all'
-  };
-
-  function ensureRuns(force) {
-    if (runsState.runs && !force) return Promise.resolve(runsState.runs);
-    return authFetch('/ui/runs').then(function (r) { return r.json(); })
-      .then(function (data) {
-        runsState.runs = data.runs || [];
-        return runsState.runs;
-      });
-  }
-
-  function filteredRuns(runs) {
-    if (runsState.statusFilter === 'all') return runs;
-    return runs.filter(function (r) { return r.status === runsState.statusFilter; });
-  }
-
-  function renderRunCard(run) {
-    var statusLabels = {
-      waiting: '● Waiting',
-      claimed: '● Claimed',
-      active: '● Active',
-      completed: '✓ Completed',
-      failed: '✗ Failed',
-      cancelled: '— Cancelled'
-    };
-    var label = run.public_task_label || '—';
-    var statusText = statusLabels[run.status] || run.status;
-    var isTerminal = run.status === 'completed' || run.status === 'failed' || run.status === 'cancelled';
-    var href;
-    if (run.status === 'completed' && run.session_id) {
-      href = '#/results/' + encodeURIComponent(run.session_id);
-    } else if (!isTerminal) {
-      href = '#/run';
-    } else {
-      href = 'javascript:void(0)';
-    }
-
-    return '' +
-      '<a class="run-card" href="' + href + '">' +
-        '<div class="run-card-top">' +
-          '<span class="run-card-label">' + escapeHtml(label) + '</span>' +
-          '<span class="summary-pill run-status-' + escapeHtml(run.status) + '">' + escapeHtml(statusText) + '</span>' +
-        '</div>' +
-        '<div class="run-card-mode">' + escapeHtml(run.mode || 'agent') + '</div>' +
-        '<div class="run-card-meta">' +
-          (run.persona_id ? '<span class="meta-chip">' + escapeHtml(run.persona_id) + '</span>' : '') +
-          (run.eval_status && run.eval_status !== 'pending' ? '<span class="meta-chip">Eval: ' + escapeHtml(run.eval_status) + '</span>' : '') +
-        '</div>' +
-        '<div class="run-card-time">' +
-          escapeHtml(formatTimestamp(run.created_at)) +
-          (run.completed_at ? ' → ' + escapeHtml(formatTimestamp(run.completed_at)) : '') +
-        '</div>' +
-      '</a>';
-  }
-
-  function renderRunsListPage(runs) {
-    var statuses = sortedUnique(runs.map(function (r) { return r.status; }));
-    var visible = filteredRuns(runs);
-
-    var statusOptions = ['<option value="all">All</option>'].concat(statuses.map(function (s) {
-      var sel = s === runsState.statusFilter ? ' selected' : '';
-      return '<option value="' + escapeHtml(s) + '"' + sel + '>' + escapeHtml(titleCase(s)) + '</option>';
-    }));
-
-    app.innerHTML =
-      '<section class="page">' +
-        '<header class="page-header">' +
-          '<div class="page-title-wrap">' +
-            '<p class="eyebrow">Run History</p>' +
-            '<h1>Run history and active sessions.</h1>' +
-            '<p class="subtitle">All runs created through the Run layer, with real-time status tracking.</p>' +
-          '</div>' +
-          '<div class="summary-strip">' +
-            buildSummaryPill('Total', String(runs.length)) +
-            buildSummaryPill('Active', String(runs.filter(function (r) { return r.status === 'active'; }).length)) +
-            buildSummaryPill('Completed', String(runs.filter(function (r) { return r.status === 'completed'; }).length)) +
-          '</div>' +
-        '</header>' +
-        '<section class="panel filter-bar">' +
-          '<label class="filter-field">' +
-            '<span class="filter-label">Status</span>' +
-            '<select id="runs-status-filter" class="filter-select">' + statusOptions.join('') + '</select>' +
-          '</label>' +
-        '</section>' +
-        '<div class="results-meta">' +
-          '<div class="results-count">' + escapeHtml(String(visible.length)) + ' run(s) shown</div>' +
-        '</div>' +
-        (visible.length
-          ? '<div class="runs-grid">' + visible.map(renderRunCard).join('') + '</div>'
-          : renderEmptyInline('No runs match the current filter.')) +
-      '</section>';
-
-    var filterEl = document.getElementById('runs-status-filter');
-    if (filterEl) {
-      filterEl.addEventListener('change', function (e) {
-        runsState.statusFilter = e.target.value || 'all';
-        renderRunsListPage(runs);
-      });
-    }
-  }
-
-  function showRuns() {
-    state.activeSessionId = null;
-    setAppDetailMode(false);
-    renderLoading('Loading runs', 'Fetching run history from the /ui/runs endpoint.');
-    ensureRuns(true).then(renderRunsListPage).catch(function (error) {
-      renderError('Runs unavailable', error);
-    });
+    return 'Agent Connection';
   }
 
   function renderRunPage(payload) {
     var tasks = payload.tasks || [];
     var selectedTask = getRunTask(tasks);
     if (selectedTask && !state.run.taskId) state.run.taskId = selectedTask.task_id;
+    state.run.mode = 'agent';
 
-    if (!state.run.mode) {
-      renderRunModePicker(payload);
+    if (window.QTB && typeof window.QTB.renderMyAgentPage === 'function') {
+      window.QTB.renderMyAgentPage(app, state, payload);
       return;
     }
-
-    if (state.run.mode === 'agent') {
-      if (window.QTB && typeof window.QTB.renderMyAgentPage === 'function') {
-        window.QTB.renderMyAgentPage(app, state, payload);
-      } else {
-        renderAgentRunPage(payload);
-      }
-      return;
-    }
-
-    renderHumanRunPage(payload);
-  }
-
-  function renderRunModePicker(payload) {
-    var tasks = payload.tasks || [];
-    app.innerHTML =
-      '<section class="page run-page">' +
-        '<header class="page-header">' +
-          '<div class="page-title-wrap">' +
-            '<p class="eyebrow">New Run</p>' +
-            '<h1>Choose how to run the benchmark.</h1>' +
-            '<p class="subtitle">Connect your own agent, try it yourself in the browser, or watch the baseline agent run.</p>' +
-          '</div>' +
-          '<div class="summary-strip">' +
-            buildSummaryPill('Mode', runModeLabel()) +
-            buildSummaryPill('Tasks', String(tasks.length)) +
-          '</div>' +
-        '</header>' +
-        '<div class="run-mode-grid">' +
-          '<article class="panel run-mode-card">' +
-            '<p class="eyebrow">Your Agent</p>' +
-            '<h2>My Agent</h2>' +
-            '<p>Create a run and get connection details (MCP URL + token or REST endpoints). Connect your own agent to execute the benchmark.</p>' +
-            '<button class="btn btn-primary" id="run-mode-agent" type="button">My Agent</button>' +
-          '</article>' +
-          '<article class="panel run-mode-card">' +
-            '<p class="eyebrow">Manual</p>' +
-            '<h2>Try it myself</h2>' +
-            '<p>Use the browser-driven REST harness to manually tutor the student. Useful for understanding the benchmark tasks.</p>' +
-            '<button class="btn btn-secondary" id="run-mode-human" type="button">Try it myself</button>' +
-          '</article>' +
-          '<article class="panel run-mode-card">' +
-            '<p class="eyebrow">Demo</p>' +
-            '<h2>Watch Baseline</h2>' +
-            '<p>Watch the baseline agent (Claude) complete the task automatically. Server starts the agent — just observe.</p>' +
-            '<button class="btn btn-secondary" id="run-mode-baseline" type="button" disabled title="Coming soon">Watch Baseline</button>' +
-          '</article>' +
-        '</div>' +
-      '</section>';
-    bindRunModeControls();
+    renderAgentRunPage(payload);
   }
 
   function renderAgentRunPage(payload) {
@@ -1000,14 +754,13 @@
             '</label>' +
             '<div class="run-actions">' +
               '<button class="btn btn-primary" type="button" disabled>Start Agent Run</button>' +
-              '<button class="btn btn-secondary" id="run-mode-reset-btn" type="button">Change Mode</button>' +
             '</div>' +
           '</aside>' +
           '<section class="panel run-conversation-panel run-agent-main">' +
             '<div class="run-panel-header">' +
               '<div>' +
                 '<h2>Execution Boundary</h2>' +
-                '<p>The automated flow is not a chat form. It should be a backend job that launches the client runner, polls job state, captures stdout/stderr, and links to the archived result when the client trace is written.</p>' +
+                '<p>The automated flow launches the client runner, polls job state, captures stdout/stderr, and links to Human Review after archive creation.</p>' +
               '</div>' +
             '</div>' +
             '<ol class="run-flow-list">' +
@@ -1015,180 +768,25 @@
               '<li><strong>start_session</strong> returns the client-visible background and student opening.</li>' +
               '<li><strong>list_tools</strong> exposes <code>send_message</code>, <code>get_background</code>, and domain tools to the agent.</li>' +
               '<li><strong>adapter.generate_response</strong> runs once; the tool runner handles domain tools and student communication.</li>' +
-              '<li><strong>save_client_trace</strong> writes <code>results/client/{session_id}/client_trace.json</code>, then Results can render the merged replay.</li>' +
+              '<li><strong>save_client_trace</strong> writes <code>results/client/{session_id}/client_trace.json</code>, then Human Review renders the archived replay.</li>' +
             '</ol>' +
             '<div class="run-status-note">' +
-              '<strong>Required before enabling this button:</strong> add server endpoints for creating/cancelling agent jobs, safe subprocess lifecycle, result-dir wiring, live log/tool polling, and completion mapping back to Results.' +
+              '<strong>Required before enabling this button:</strong> add server endpoints for creating/cancelling agent jobs, safe subprocess lifecycle, result-dir wiring, live log/tool polling, and completion mapping back to Human Review.' +
             '</div>' +
           '</section>' +
           '<aside class="panel run-tools-panel">' +
             '<h2>Live Tools</h2>' +
-            '<p class="detail-empty-note">Agent tool events cannot be streamed here until the backend job layer exposes them. Result detail already renders them after archive creation.</p>' +
+            '<p class="detail-empty-note">Agent tool events appear here when the backend job layer exposes them. Human Review renders archived tool logs after completion.</p>' +
           '</aside>' +
         '</div>' +
       '</section>';
     bindRunControls(tasks);
-  }
-
-  function renderHumanRunPage(payload) {
-    var tasks = payload.tasks || [];
-    var personas = payload.personas || [];
-    var selectedTask = getRunTask(tasks);
-    var visiblePersonas = personasForTask(selectedTask, personas);
-    var selectedPersona = state.run.personaId || 'auto';
-    var isBusy = runIsBusy();
-    var isLocked = !!state.run.sessionId || isBusy;
-    var taskOptions = tasks.map(function (task) {
-      return '<option value="' + escapeHtml(task.task_id) + '"' + (task.task_id === state.run.taskId ? ' selected' : '') + '>' +
-        escapeHtml(publicTaskLabel(task.task_id)) +
-      '</option>';
-    }).join('');
-    var personaOptions =
-      '<option value="auto"' + (selectedPersona === 'auto' ? ' selected' : '') + '>Auto select</option>' +
-      visiblePersonas.map(function (persona) {
-        return '<option value="' + escapeHtml(persona.persona_id) + '"' + (persona.persona_id === selectedPersona ? ' selected' : '') + '>' +
-          escapeHtml(persona.persona_id) +
-        '</option>';
-      }).join('');
-    var messagesHtml = state.run.messages.length
-      ? state.run.messages.map(renderRunMessage).join('')
-      : '<div class="run-empty-conversation">Start a human test session to see the student opening message here.</div>';
-    var sessionMeta = state.run.sessionId
-      ? [
-        metaItem('Session ID', state.run.sessionId),
-        metaItem('Phase', runStatusLabel()),
-        metaItem('Task', publicTaskLabel(state.run.taskId)),
-        metaItem('Client Context', state.run.background ? 'Loaded' : 'Waiting')
-      ].join('')
-      : '<p class="detail-empty-note">No active run yet. This panel will only show client-visible runtime context after start_session.</p>';
-    var actionButton = state.run.sessionId
-      ? '<button class="btn btn-secondary" id="run-refresh-btn" type="button"' + (isBusy ? ' disabled' : '') + '>Refresh</button>'
-      : '<button class="btn btn-primary" id="run-start-btn" type="button"' + (isBusy || !selectedTask ? ' disabled' : '') + '>Create & Start Session</button>';
-    var openResult = state.run.sessionId && state.run.phase === 'completed'
-      ? '<a class="btn btn-secondary" href="#/results/' + encodeURIComponent(state.run.sessionId) + '">Open Result</a>'
-      : '';
-    var cancelButton = state.run.sessionId && state.run.phase !== 'completed'
-      ? '<button class="btn btn-secondary" id="run-cancel-btn" type="button"' + (isBusy ? ' disabled' : '') + '>Cancel</button>'
-      : '';
-
-    app.innerHTML =
-      '<section class="page run-page">' +
-        '<header class="page-header run-sticky-header">' +
-          '<div class="page-title-wrap">' +
-            '<p class="eyebrow">Run · Human Test</p>' +
-            '<h1>Browser-driven REST session harness.</h1>' +
-            '<p class="subtitle">Manual mode is kept for human testing. The visible task label and info panel avoid exposing hidden task metadata during execution.</p>' +
-          '</div>' +
-          '<div class="summary-strip">' +
-            buildSummaryPill('Mode', runModeLabel()) +
-            buildSummaryPill('Status', runStatusLabel()) +
-            buildSummaryPill('Task', publicTaskLabel(state.run.taskId || (selectedTask && selectedTask.task_id))) +
-            buildSummaryPill('Tools', String(state.run.tools.length)) +
-          '</div>' +
-        '</header>' +
-        (state.run.error ? '<section class="run-error">' + escapeHtml(state.run.error) + '</section>' : '') +
-        '<div class="run-grid">' +
-          '<aside class="panel run-control-panel">' +
-            '<h2>Info</h2>' +
-            '<label class="filter-field">' +
-              '<span class="filter-label">Task</span>' +
-              '<select id="run-task-select" class="filter-select"' + (isLocked ? ' disabled' : '') + '>' + taskOptions + '</select>' +
-            '</label>' +
-            '<label class="filter-field">' +
-              '<span class="filter-label">Persona Control</span>' +
-              '<select id="run-persona-select" class="filter-select"' + (isLocked ? ' disabled' : '') + '>' + personaOptions + '</select>' +
-            '</label>' +
-            '<div class="run-actions">' + actionButton + openResult + cancelButton +
-              '<button class="btn btn-secondary" id="run-reset-btn" type="button"' + (isBusy ? ' disabled' : '') + '>Reset UI</button>' +
-              '<button class="btn btn-secondary" id="run-mode-reset-btn" type="button"' + (isBusy ? ' disabled' : '') + '>Change Mode</button>' +
-            '</div>' +
-            '<section class="run-meta-block">' +
-              '<h3>Client-Visible State</h3>' +
-              sessionMeta +
-            '</section>' +
-            '<section class="run-meta-block">' +
-              '<h3>Client Context</h3>' +
-              (state.run.background
-                ? '<div class="run-background-text">' + safeRenderMarkdown(state.run.background) + '</div>'
-                : '<p class="detail-empty-note">The background returned by start_session appears here. Hidden task metadata is not shown.</p>') +
-            '</section>' +
-          '</aside>' +
-          '<section class="panel run-conversation-panel">' +
-            '<div class="run-panel-header">' +
-              '<div>' +
-                '<h2>Conversation</h2>' +
-                '<p>Student messages returned by <code>start_session</code> and <code>send_message</code>. This column intentionally takes most of the width.</p>' +
-              '</div>' +
-            '</div>' +
-            '<div id="run-conversation" class="run-conversation">' + messagesHtml + '</div>' +
-            '<form id="run-send-form" class="run-send-form">' +
-              '<label class="filter-field">' +
-                '<span class="filter-label">Tutor Message</span>' +
-                '<textarea id="run-message-input" class="run-textarea" rows="5" placeholder="Write a message that will be delivered through send_message..."' + (!runCanSend() ? ' disabled' : '') + '></textarea>' +
-              '</label>' +
-              '<label class="filter-field">' +
-                '<span class="filter-label">Attachments</span>' +
-                '<input id="run-attachments-input" class="filter-input" type="text" placeholder="Optional: strategy.py, plots/chart.png" ' + (!runCanSend() ? ' disabled' : '') + '>' +
-              '</label>' +
-              '<button class="btn btn-primary" type="submit"' + (!runCanSend() ? ' disabled' : '') + '>' + (state.run.action === 'sending' ? 'Sending...' : 'Send Message') + '</button>' +
-            '</form>' +
-          '</section>' +
-          '<aside class="panel run-tools-panel">' +
-            '<h2>Tools</h2>' +
-            '<section class="run-meta-block compact">' +
-              '<h3>Visible To Client</h3>' +
-              renderRunTools() +
-            '</section>' +
-            '<section class="run-meta-block compact">' +
-              '<h3>Live Activity</h3>' +
-              renderRunToolEvents() +
-            '</section>' +
-          '</aside>' +
-        '</div>' +
-      '</section>';
-
-    bindRunControls(tasks);
-  }
-
-  function bindRunModeControls() {
-    var agentBtn = document.getElementById('run-mode-agent');
-    var humanBtn = document.getElementById('run-mode-human');
-    var baselineBtn = document.getElementById('run-mode-baseline');
-
-    // Allow run-agent.js to reset back to mode picker
-    if (window.QTB) {
-      window.QTB._resetRunMode = function () {
-        state.run.mode = '';
-        state.run.error = '';
-        renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-      };
-    }
-    if (agentBtn) {
-      agentBtn.addEventListener('click', function () {
-        state.run.mode = 'agent';
-        state.run.error = '';
-        renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-      });
-    }
-    if (humanBtn) {
-      humanBtn.addEventListener('click', function () {
-        state.run.mode = 'human';
-        state.run.error = '';
-        renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-      });
-    }
   }
 
   function bindRunControls(tasks) {
     var taskSelect = document.getElementById('run-task-select');
     var personaSelect = document.getElementById('run-persona-select');
     var agentStepsInput = document.getElementById('run-agent-steps-input');
-    var startBtn = document.getElementById('run-start-btn');
-    var refreshBtn = document.getElementById('run-refresh-btn');
-    var cancelBtn = document.getElementById('run-cancel-btn');
-    var resetBtn = document.getElementById('run-reset-btn');
-    var modeResetBtn = document.getElementById('run-mode-reset-btn');
-    var sendForm = document.getElementById('run-send-form');
 
     if (taskSelect) {
       taskSelect.addEventListener('change', function (event) {
@@ -1208,209 +806,6 @@
         state.run.agentMaxSteps = isFinite(value) && value >= 0 ? value : 200;
       });
     }
-    if (startBtn) startBtn.addEventListener('click', startRunSession);
-    if (refreshBtn) refreshBtn.addEventListener('click', refreshRunStatus);
-    if (cancelBtn) cancelBtn.addEventListener('click', cancelRunSession);
-    if (resetBtn) resetBtn.addEventListener('click', resetRunState);
-    if (modeResetBtn) modeResetBtn.addEventListener('click', resetRunMode);
-    if (sendForm) {
-      sendForm.addEventListener('submit', function (event) {
-        event.preventDefault();
-        sendRunMessage();
-      });
-    }
-
-    var conversationEl = document.getElementById('run-conversation');
-    if (conversationEl) conversationEl.scrollTop = conversationEl.scrollHeight;
-  }
-
-  function setRunBusy(busy) {
-    setRunAction(busy ? 'working' : 'idle');
-    renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-  }
-
-  function startRunSession() {
-    var taskId = state.run.taskId;
-    if (!taskId || state.run.mode !== 'human' || runIsBusy()) return;
-    setRunAction('registering');
-    state.run.error = '';
-    renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-
-    var registerBody = {task_id: taskId};
-    if (state.run.personaId && state.run.personaId !== 'auto') {
-      registerBody.persona_id = state.run.personaId;
-    }
-
-    restApi('/session/register', {
-      method: 'POST',
-      body: JSON.stringify(registerBody)
-    }).then(function (registered) {
-      if (!registered.accepted) {
-        throw new Error(registered.error || 'Session registration rejected.');
-      }
-      state.run.sessionId = registered.session_id;
-      state.run.phase = 'registered';
-      state.run.startedAt = new Date().toISOString();
-      addRunToolEvent('register_session', 'ok', 'REST session registered.');
-      setRunAction('starting');
-      renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-      return restApi('/session/' + encodeURIComponent(registered.session_id) + '/start', {
-        method: 'POST',
-        body: JSON.stringify({})
-      });
-    }).then(function (started) {
-      state.run.phase = 'in_session';
-      state.run.background = started.background || '';
-      state.run.messages = [];
-      if (started.student_message) {
-        state.run.messages.push({role: 'student', content: started.student_message});
-      }
-      addRunToolEvent('start_session', 'ok', started.student_message ? 'Student opening received.' : 'Session started.');
-      return refreshRunStatus({silent: true, preserveAction: true});
-    }).catch(function (error) {
-      state.run.error = error && error.message ? error.message : String(error || 'Unknown error');
-      addRunToolEvent('run_start', 'error', state.run.error);
-    }).then(function () {
-      setRunAction('idle');
-      renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-    });
-  }
-
-  function refreshRunStatus(options) {
-    options = options || {};
-    if (!state.run.sessionId) return Promise.resolve();
-    if (!options.silent) setRunAction('refreshing');
-    if (!options.silent) renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-
-    return restApi('/session/' + encodeURIComponent(state.run.sessionId), {
-      method: 'GET',
-      headers: {}
-    }).then(function (status) {
-      state.run.phase = status.phase || state.run.phase;
-      state.run.personaId = status.persona_id || state.run.personaId;
-      return restApi('/session/' + encodeURIComponent(state.run.sessionId) + '/tools', {
-        method: 'GET',
-        headers: {}
-      }).catch(function () {
-        return {tools: []};
-      });
-    }).then(function (toolsPayload) {
-      state.run.tools = toolsPayload.tools || [];
-      state.run.error = '';
-      if (!options.silent) addRunToolEvent('list_tools', 'ok', state.run.tools.length + ' visible tools.');
-    }).catch(function (error) {
-      state.run.error = error && error.message ? error.message : String(error || 'Unknown error');
-      if (!options.silent) addRunToolEvent('refresh', 'error', state.run.error);
-    }).then(function () {
-      if (!options.preserveAction) setRunAction('idle');
-      if (!options.silent) renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-    });
-  }
-
-  function parseRunAttachments(value) {
-    return String(value || '')
-      .split(/[,\n]/)
-      .map(function (item) { return item.trim(); })
-      .filter(Boolean)
-      .slice(0, 3);
-  }
-
-  function sendRunMessage() {
-    if (!runCanSend()) return;
-    var messageInput = document.getElementById('run-message-input');
-    var attachmentsInput = document.getElementById('run-attachments-input');
-    var text = messageInput ? String(messageInput.value || '').trim() : '';
-    var attachments = attachmentsInput ? parseRunAttachments(attachmentsInput.value) : [];
-    if (!text) {
-      state.run.error = 'Message text is required.';
-      renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-      return;
-    }
-
-    setRunAction('sending');
-    state.run.error = '';
-    renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-
-    restApi('/session/' + encodeURIComponent(state.run.sessionId) + '/send', {
-      method: 'POST',
-      body: JSON.stringify({text: text, attachments: attachments})
-    }).then(function (reply) {
-      if (reply.error) {
-        throw new Error(reply.error);
-      }
-      state.run.messages.push({role: 'tutor', content: text, attachments: attachments});
-      if (reply.student_message) {
-        state.run.messages.push({role: 'student', content: reply.student_message});
-      }
-      state.run.phase = reply.status === 'completed' ? 'completed' : 'in_session';
-      addRunToolEvent(
-        'send_message',
-        'ok',
-        (attachments.length ? attachments.length + ' attachment(s). ' : '') +
-          'Student status: ' + (reply.status || state.run.phase) + '.'
-      );
-      if (reply.status === 'completed') {
-        state.run.completedAt = new Date().toISOString();
-        state.results = null;
-        state.detailCache = {};
-      }
-      return refreshRunStatus({silent: true, preserveAction: true});
-    }).catch(function (error) {
-      state.run.error = error && error.message ? error.message : String(error || 'Unknown error');
-      addRunToolEvent('send_message', 'error', state.run.error);
-    }).then(function () {
-      setRunAction('idle');
-      renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-    });
-  }
-
-  function cancelRunSession() {
-    if (!state.run.sessionId || runIsBusy()) return;
-    setRunAction('cancelling');
-    state.run.error = '';
-    renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-    restApi('/session/' + encodeURIComponent(state.run.sessionId), {
-      method: 'DELETE',
-      headers: {}
-    }).then(function () {
-      state.run.phase = 'cancelled';
-      state.run.tools = [];
-      addRunToolEvent('cancel_session', 'ok', 'Session cancelled by UI.');
-    }).catch(function (error) {
-      state.run.error = error && error.message ? error.message : String(error || 'Unknown error');
-      addRunToolEvent('cancel_session', 'error', state.run.error);
-    }).then(function () {
-      setRunAction('idle');
-      renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-    });
-  }
-
-  function resetRunState() {
-    state.run = {
-      mode: state.run.mode,
-      taskId: state.run.taskId,
-      personaId: 'auto',
-      sessionId: null,
-      phase: 'idle',
-      action: 'idle',
-      background: '',
-      messages: [],
-      tools: [],
-      toolEvents: [],
-      error: '',
-      busy: false,
-      agentMaxSteps: state.run.agentMaxSteps || 200,
-      startedAt: null,
-      completedAt: null
-    };
-    renderRunPage(state.tasksPayload || {tasks: [], personas: []});
-  }
-
-  function resetRunMode() {
-    if (runIsBusy()) return;
-    resetRunState();
-    state.run.mode = '';
-    renderRunPage(state.tasksPayload || {tasks: [], personas: []});
   }
 
   function metaItem(label, value) {
@@ -2087,7 +1482,7 @@
     app.innerHTML =
       '<section class="page-run">' +
         '<div class="detail-header">' +
-          '<a class="detail-back" href="#/results">\u2190 Back</a>' +
+          '<a class="detail-back" href="#/review">\u2190 Back</a>' +
           '<div class="detail-title-block">' +
             '<div class="detail-task-id">' + escapeHtml(detail.task_id) + '</div>' +
             '<div class="detail-tags">' +
@@ -3033,7 +2428,7 @@
   function showRun() {
     state.activeSessionId = null;
     setAppDetailMode(false);
-    renderLoading('Loading run harness', 'Fetching task and persona metadata before choosing Human or Agent test mode.');
+    renderLoading('Loading agent connection', 'Fetching task metadata before opening the agent run surface.');
     ensureTasks().then(renderRunPage).catch(function (error) {
       renderError('Run unavailable', error);
     });
@@ -3053,13 +2448,27 @@
     setActiveNav(route);
     closeModal();
 
-    if (route === '/' || route === '/results') {
-      showResultsList();
+    if (route === '/' || route === '/flow-demo') {
+      if (window.QTB && typeof window.QTB.renderFlowDemoPage === 'function') {
+        window.QTB.renderFlowDemoPage(app, state);
+      } else {
+        renderError('Flow demo unavailable', new Error('flow-demo.js not loaded'));
+      }
       return;
     }
 
     if (route === '/runs') {
-      showRuns();
+      location.hash = '#/flow-demo';
+      return;
+    }
+
+    if (route === '/results') {
+      location.hash = '#/review';
+      return;
+    }
+
+    if (route.indexOf('/results/') === 0) {
+      location.hash = '#/review/' + route.slice('/results/'.length);
       return;
     }
 
@@ -3078,26 +2487,12 @@
       return;
     }
 
-    if (route === '/flow-demo') {
-      if (window.QTB && typeof window.QTB.renderFlowDemoPage === 'function') {
-        window.QTB.renderFlowDemoPage(app, state);
-      } else {
-        renderError('Flow demo unavailable', new Error('flow-demo.js not loaded'));
-      }
-      return;
-    }
-
-    if (route.indexOf('/results/') === 0) {
-      showResultDetail(decodeURIComponent(route.slice('/results/'.length)));
-      return;
-    }
-
     if (route.indexOf('/review/') === 0) {
       showReviewBundle(decodeURIComponent(route.slice('/review/'.length)));
       return;
     }
 
-    location.hash = '#/results';
+    location.hash = '#/flow-demo';
   }
 
   window.addEventListener('hashchange', onRouteChange);

--- a/bench/server/web/static/js/flow-demo.js
+++ b/bench/server/web/static/js/flow-demo.js
@@ -219,7 +219,7 @@
     var conversation = run.conversation || [];
     var logs = run.recent_tool_logs || [];
     var href = run.status === 'completed' && run.session_id
-      ? '#/results/' + encodeURIComponent(run.session_id)
+      ? '#/review/' + encodeURIComponent(run.session_id)
       : '';
     var tag = href ? 'a' : 'article';
     var open = href ? ' href="' + href + '"' : '';
@@ -304,7 +304,7 @@
     if (status === 'claimed') return 'Agent connected.';
     if (status === 'active') return 'Session starting.';
     if (status === 'stale') return 'Previous server process ended before archive creation.';
-    if (status === 'completed') return 'Open Results for the archived replay.';
+    if (status === 'completed') return 'Open Human Review for the archived replay.';
     if (status === 'failed') return run.error || 'Run failed.';
     if (status === 'cancelled') return 'Run cancelled.';
     return 'Waiting for session activity.';
@@ -313,7 +313,7 @@
   function emptyToolText(run) {
     var status = displayStatus(run);
     if (status === 'active') return 'Tool calls will appear as the agent works.';
-    if (status === 'completed') return 'Archived tool calls are available in Results.';
+    if (status === 'completed') return 'Archived tool calls are available in Human Review.';
     return statusLabel(status || 'pending');
   }
 

--- a/bench/server/web/static/js/flow-demo.js
+++ b/bench/server/web/static/js/flow-demo.js
@@ -127,7 +127,7 @@
       '<section class="page flow-demo">' +
         '<header class="page-header">' +
           '<div class="page-title-wrap">' +
-            '<p class="eyebrow">Flow</p>' +
+            '<p class="eyebrow">Session Flow</p>' +
             '<h1>Live benchmark monitor.</h1>' +
             '<p class="subtitle">Background REST/MCP runs appear here as the server updates their run state.</p>' +
           '</div>' +

--- a/bench/server/web/static/js/run-agent.js
+++ b/bench/server/web/static/js/run-agent.js
@@ -124,18 +124,21 @@
           '<div class="page-title-wrap">' +
             '<p class="eyebrow">Run · My Agent</p>' +
             '<h1>Connect your agent to the benchmark.</h1>' +
+            '<p class="subtitle">Create a task-specific run, manage the REST API key, or open the QuantTutorBench REST agent skill.</p>' +
           '</div>' +
         '</header>' +
         '<div class="run-agent-create-panel">' +
           '<aside class="panel">' +
-            '<h2>Select Task</h2>' +
+            '<h2>Agent Connection</h2>' +
+            '<p class="detail-empty-note">Use the REST agent skill for API-key based agents, or create a run here to receive a run token and connection details.</p>' +
             '<label class="filter-field">' +
               '<span class="filter-label">Task</span>' +
               '<select id="myagent-task-select" class="filter-select">' + taskOptions + '</select>' +
             '</label>' +
             '<div class="run-actions" style="margin-top:1rem;">' +
               '<button class="btn btn-primary" id="myagent-create-btn" type="button">Create Run</button>' +
-              '<button class="btn btn-secondary" id="myagent-back-btn" type="button">Back</button>' +
+              '<button class="btn btn-secondary" id="myagent-api-key-btn" type="button">API Key</button>' +
+              '<a class="btn btn-secondary" href="/skills/quanttutorbench-rest-agent" target="_blank" rel="noreferrer">REST Agent Skill</a>' +
             '</div>' +
             '<div id="myagent-error" class="run-error" style="display:none;"></div>' +
           '</aside>' +
@@ -144,15 +147,15 @@
 
     // Bind
     var createBtn = document.getElementById('myagent-create-btn');
-    var backBtn = document.getElementById('myagent-back-btn');
+    var apiKeyBtn = document.getElementById('myagent-api-key-btn');
     var taskSelect = document.getElementById('myagent-task-select');
     var errorDiv = document.getElementById('myagent-error');
 
-    if (backBtn) {
-      backBtn.addEventListener('click', function () {
-        _cleanup();
-        // Reset to mode picker — hack into app.js state
-        if (window.QTB._resetRunMode) window.QTB._resetRunMode();
+    if (apiKeyBtn) {
+      apiKeyBtn.addEventListener('click', function () {
+        if (window.QTB && typeof window.QTB.openApiKeyModal === 'function') {
+          window.QTB.openApiKeyModal();
+        }
       });
     }
 
@@ -254,7 +257,7 @@
         // Actions
         '<div class="run-actions" style="margin-top:1rem;">' +
           '<button class="btn btn-danger" id="myagent-cancel-btn" type="button">Cancel Run</button>' +
-          '<a class="btn btn-primary" id="myagent-results-link" href="#" style="display:none;">View Results</a>' +
+          '<a class="btn btn-primary" id="myagent-results-link" href="#" style="display:none;">Open Human Review</a>' +
         '</div>' +
       '</section>';
 
@@ -317,7 +320,7 @@
             if (data.status === 'completed' && data.session_id) {
               var link = document.getElementById('myagent-results-link');
               if (link) {
-                link.href = '#/results/' + data.session_id;
+                link.href = '#/review/' + data.session_id;
                 link.style.display = 'inline-block';
               }
             }
@@ -356,11 +359,11 @@
 
           if (data.run_status === 'completed' || data.run_status === 'failed' || data.run_status === 'cancelled') {
             _stopPolling();
-            // Show results link for completed runs
+            // Show review link for completed runs
             if (data.run_status === 'completed' && data.session_id) {
               var link = document.getElementById('myagent-results-link');
               if (link) {
-                link.href = '#/results/' + data.session_id;
+                link.href = '#/review/' + data.session_id;
                 link.style.display = 'inline-block';
               }
             }
@@ -388,7 +391,7 @@
       msg.className = 'run-token-lost';
       msg.textContent =
         'Run access expired or token lost. Cannot resume monitoring. ' +
-        'Results will still appear under Results once the run completes.';
+        'Archived sessions will still appear under Human Review once the run completes.';
       connectPanel.appendChild(msg);
     }
   }
@@ -530,8 +533,5 @@
     _lastToolLen = 0;
     _lastSendLen = 0;
   }
-
-  // Allow app.js to reset mode
-  window.QTB._resetRunMode = null; // set by app.js
 
 })();

--- a/bench/server/web/static/js/run-agent.js
+++ b/bench/server/web/static/js/run-agent.js
@@ -1,11 +1,10 @@
 /**
  * run-agent.js — "My Agent" flow for the Run page.
  *
- * 1. User selects task → POST /ui/runs → show connection info (MCP URL + token)
- * 2. Poll /ui/runs/{id} for status changes (waiting → claimed → active)
- * 3. Poll /ui/runs/{id}/live for real-time conversation + tool logs
- * 4. Cancel button → POST /ui/runs/{id}/cancel
- * 5. On completed → show link to Human Review
+ * 1. Generate a REST API key for the current reviewer.
+ * 2. Render a copyable prompt with the REST skill URL, curl command, and key.
+ * 3. Poll active runs when this module receives one from a server response.
+ * 4. On completed → show link to Human Review.
  */
 (function () {
   'use strict';
@@ -75,63 +74,175 @@
       .replace(/'/g, '&#39;');
   }
 
-  function publicTaskLabel(taskId) {
-    if (!taskId) return '—';
-    var m = taskId.match(/^([A-Za-z]\d{2})/);
-    return m ? m[1] : taskId;
-  }
-
-  // ── Catalog loading ──
-
-  var _catalog = null;
-
-  function loadCatalog(callback) {
-    if (_catalog) { callback(_catalog); return; }
-    _authFetch('/ui/tasks/catalog/labels')
-      .then(function (r) { return r.json(); })
-      .then(function (data) {
-        _catalog = data.tasks || [];
-        callback(_catalog);
-      })
-      .catch(function () { callback([]); });
-  }
-
   // ── Main render ──
 
   window.QTB.renderMyAgentPage = function (app, state, payload) {
-    // If we have an active run, show the monitor page
     if (_runId) {
       _renderMonitorPage(app);
       return;
     }
 
-    // Otherwise show task selection + create run form
-    loadCatalog(function (tasks) {
-      _renderCreatePage(app, tasks, payload && payload.tasks);
-    });
+    _renderPromptPage(app, {loading: true});
+    _loadApiKeyStatus()
+      .then(function (status) {
+        _renderPromptPage(app, {status: status});
+      })
+      .catch(function (error) {
+        _renderPromptPage(app, {
+          error: error && error.message ? error.message : String(error || 'Unable to load API key status.')
+        });
+      });
   };
 
-  function _taskLabels(tasks, fallbackTasks) {
-    var labels = [];
-    var seen = {};
-    (tasks || []).concat(fallbackTasks || []).forEach(function (task) {
-      var label = task && (task.label || publicTaskLabel(task.task_id || task.id));
-      if (!label || seen[label]) return;
-      seen[label] = true;
-      labels.push(label);
-    });
-    return labels;
+  function _absoluteUrl(path) {
+    if (/^https?:\/\//i.test(path)) return path;
+    return window.location.origin + path;
   }
 
-  function _renderCreatePage(app, tasks, fallbackTasks) {
-    var labels = _taskLabels(tasks, fallbackTasks);
-    var hasTasks = labels.length > 0;
-    var selectedLabel = hasTasks ? labels[0] : '';
-    var taskOptions = hasTasks ? labels.map(function (label) {
-      return '<option value="' + escapeHtml(label) + '">' +
-        escapeHtml(label) +
-        '</option>';
-    }).join('') : '<option value="">No tasks available</option>';
+  function _skillPageUrl() {
+    return _absoluteUrl('/skills/quanttutorbench-rest-agent');
+  }
+
+  function _skillRawUrl() {
+    return _absoluteUrl('/skills/quanttutorbench-rest-agent/raw');
+  }
+
+  function _taskLabelForPrompt(value) {
+    var label = String(value || '').trim();
+    return label || '<public_task_label>';
+  }
+
+  function _jsonResponse(response) {
+    return response.json().then(function (payload) {
+      if (!response.ok) {
+        throw new Error(payload.error || ('HTTP ' + response.status));
+      }
+      return payload;
+    });
+  }
+
+  function _loadApiKeyStatus() {
+    return _authFetch('/ui/api-key').then(_jsonResponse);
+  }
+
+  function _generateApiKey() {
+    return _authFetch('/ui/api-key', {method: 'POST'}).then(_jsonResponse)
+      .then(function (payload) {
+        if (!payload.api_key) {
+          throw new Error('API key was not returned.');
+        }
+        return payload;
+      });
+  }
+
+  function _buildAgentPrompt(apiKey, taskLabel) {
+    var baseUrl = window.location.origin;
+    var skillUrl = _skillPageUrl();
+    var rawSkillUrl = _skillRawUrl();
+    var label = _taskLabelForPrompt(taskLabel);
+    return [
+      'You are connecting to QuantTutorBench as my external agent.',
+      '',
+      'Load the REST agent skill first:',
+      skillUrl,
+      '',
+      'Fetch the raw skill file with:',
+      'curl -L "' + rawSkillUrl + '"',
+      '',
+      'Benchmark base URL:',
+      baseUrl,
+      '',
+      'Public task label for /client/runs/start:',
+      label,
+      'When this value is <public_task_label>, ask the operator for the public task label before starting the run.',
+      '',
+      'Start-run payload:',
+      '{"task": "' + label + '", "mode": "agent"}',
+      '',
+      'REST API key:',
+      apiKey,
+      '',
+      'Use this auth header for REST calls:',
+      'Authorization: Bearer ' + apiKey,
+      '',
+      'Follow the skill workflow exactly. Create or claim a run through the REST API, tutor the student through the server endpoints, call allowed tools through the benchmark service, monitor terminal status, and return the Human Review link when the session is archived.'
+    ].join('\n');
+  }
+
+  function _buildPromptPlaceholder(status, loading, error, taskLabel) {
+    var skillUrl = _skillPageUrl();
+    var rawSkillUrl = _skillRawUrl();
+    var label = _taskLabelForPrompt(taskLabel);
+    if (loading) {
+      return [
+        'Loading API key status...',
+        '',
+        'Public task label for /client/runs/start:',
+        label,
+        'When this value is <public_task_label>, ask the operator for the public task label before starting the run.',
+        '',
+        'Skill URL:',
+        skillUrl,
+        '',
+        'curl -L "' + rawSkillUrl + '"'
+      ].join('\n');
+    }
+    if (error) {
+      return [
+        'Unable to load API key status.',
+        error,
+        '',
+        'Public task label for /client/runs/start:',
+        label,
+        'When this value is <public_task_label>, ask the operator for the public task label before starting the run.',
+        '',
+        'Skill URL:',
+        skillUrl,
+        '',
+        'curl -L "' + rawSkillUrl + '"'
+      ].join('\n');
+    }
+    return [
+      status && status.has_key
+        ? 'Generate a fresh agent prompt to reveal a full REST API key in this text box.'
+        : 'Generate an agent prompt to create a REST API key and place it in this text box.',
+      '',
+      'Public task label for /client/runs/start:',
+      label,
+      'When this value is <public_task_label>, ask the operator for the public task label before starting the run.',
+      '',
+      'Skill URL:',
+      skillUrl,
+      '',
+      'curl -L "' + rawSkillUrl + '"'
+    ].join('\n');
+  }
+
+  function _apiKeyStatusText(status, apiKey, loading, error) {
+    if (loading) return 'Loading key status';
+    if (apiKey) return 'Fresh API key embedded';
+    if (error) return 'Key status unavailable';
+    if (status && status.has_key) {
+      return 'Active key: ' + (status.key_hint ? status.key_hint + '...' : 'available');
+    }
+    return 'Ready to generate';
+  }
+
+  function _renderPromptPage(app, options) {
+    options = options || {};
+    var status = options.status || {};
+    var apiKey = options.apiKey || '';
+    var taskLabel = options.taskLabel || '';
+    var loading = !!options.loading;
+    var error = options.error || '';
+    var skillUrl = _skillPageUrl();
+    var rawSkillUrl = _skillRawUrl();
+    var prompt = apiKey
+      ? _buildAgentPrompt(apiKey, taskLabel)
+      : _buildPromptPlaceholder(status, loading, error, taskLabel);
+    var copyDisabled = apiKey ? '' : ' disabled';
+    var generateDisabled = loading ? ' disabled' : '';
+    var generateText = status && status.has_key ? 'Generate Fresh Prompt' : 'Generate Prompt';
 
     app.innerHTML =
       '<section class="page run-page">' +
@@ -139,120 +250,104 @@
           '<div class="page-title-wrap">' +
             '<p class="eyebrow">Run · My Agent</p>' +
             '<h1>Connect your agent to the benchmark.</h1>' +
-            '<p class="subtitle">Create a task-specific run, manage the REST API key, or open the QuantTutorBench REST agent skill.</p>' +
+            '<p class="subtitle">Generate a copyable prompt with the REST skill URL and your API key.</p>' +
           '</div>' +
         '</header>' +
-        '<div class="run-agent-create-panel">' +
-          '<aside class="panel run-agent-create-card">' +
-            '<div class="run-agent-card-head">' +
+        '<div class="run-agent-prompt-panel">' +
+          '<section class="panel run-agent-prompt-card">' +
+            '<div class="run-agent-prompt-head">' +
               '<div>' +
-                '<h2>Agent Connection</h2>' +
-                '<p class="detail-empty-note">Create a task-specific run to receive a run token and connection details.</p>' +
+                '<h2>Agent Prompt</h2>' +
+                '<p class="detail-empty-note">Copy this text into your agent. It includes the API key after prompt generation.</p>' +
               '</div>' +
-              '<span class="run-selected-badge" id="myagent-selected-badge">' + escapeHtml(selectedLabel || 'No task') + '</span>' +
+              '<span class="run-selected-badge">' + escapeHtml(_apiKeyStatusText(status, apiKey, loading, error)) + '</span>' +
             '</div>' +
-            '<label class="filter-field">' +
-              '<span class="filter-label">Task</span>' +
-              '<select id="myagent-task-select" class="filter-select"' + (hasTasks ? '' : ' disabled') + '>' + taskOptions + '</select>' +
-            '</label>' +
-            '<div class="run-task-reflection" id="myagent-task-reflection" aria-live="polite">' +
-              '<span>Selected task</span>' +
-              '<strong id="myagent-task-reflection-value">' + escapeHtml(selectedLabel || 'Unavailable') + '</strong>' +
+            '<div class="run-agent-prompt-controls">' +
+              '<label class="run-agent-prompt-field" for="myagent-task-label-input">' +
+                '<span>Public Task Label</span>' +
+                '<input id="myagent-task-label-input" class="run-agent-prompt-input" type="text" placeholder="D01" value="' + escapeHtml(taskLabel) + '">' +
+              '</label>' +
             '</div>' +
-            '<div class="run-actions">' +
-              '<button class="btn btn-primary" id="myagent-create-btn" type="button"' + (hasTasks ? '' : ' disabled') + '>Create Run</button>' +
+            '<textarea id="myagent-prompt-text" class="run-agent-prompt-text" readonly spellcheck="false">' + escapeHtml(prompt) + '</textarea>' +
+            '<div class="run-agent-skill-url">' +
+              '<span>Skill URL</span>' +
+              '<code>' + escapeHtml(skillUrl) + '</code>' +
+              '<span>Raw Skill URL</span>' +
+              '<code>' + escapeHtml(rawSkillUrl) + '</code>' +
             '</div>' +
-            '<div id="myagent-error" class="run-error" style="display:none;"></div>' +
-          '</aside>' +
-          '<section class="panel run-agent-api-card">' +
-            '<h2>Agent API</h2>' +
-            '<p class="detail-empty-note">Use the REST agent skill for API-key based agents, or open the API key manager before connecting an external agent.</p>' +
             '<div class="run-agent-api-actions">' +
-              '<button class="btn btn-secondary" id="myagent-api-key-btn" type="button">API Key</button>' +
-              '<a class="btn btn-secondary" href="/skills/quanttutorbench-rest-agent" target="_blank" rel="noreferrer">REST Agent Skill</a>' +
+              '<button class="btn btn-primary" id="myagent-generate-prompt-btn" type="button"' + generateDisabled + '>' + escapeHtml(generateText) + '</button>' +
+              '<button class="btn btn-secondary" id="myagent-copy-prompt-btn" type="button"' + copyDisabled + '>Copy Prompt</button>' +
+              '<a class="btn btn-secondary" href="' + escapeHtml(skillUrl) + '" target="_blank" rel="noreferrer">Open Skill</a>' +
             '</div>' +
+            '<div id="myagent-error" class="run-error"' + (error ? '' : ' style="display:none;"') + '>' + escapeHtml(error) + '</div>' +
           '</section>' +
         '</div>' +
       '</section>';
 
-    // Bind
-    var createBtn = document.getElementById('myagent-create-btn');
-    var apiKeyBtn = document.getElementById('myagent-api-key-btn');
-    var taskSelect = document.getElementById('myagent-task-select');
+    var generateBtn = document.getElementById('myagent-generate-prompt-btn');
+    var copyBtn = document.getElementById('myagent-copy-prompt-btn');
+    var promptText = document.getElementById('myagent-prompt-text');
+    var taskLabelInput = document.getElementById('myagent-task-label-input');
     var errorDiv = document.getElementById('myagent-error');
-    var selectedBadge = document.getElementById('myagent-selected-badge');
-    var taskReflection = document.getElementById('myagent-task-reflection');
-    var taskReflectionValue = document.getElementById('myagent-task-reflection-value');
-    var pulseTimer = null;
 
-    if (apiKeyBtn) {
-      apiKeyBtn.addEventListener('click', function () {
-        if (window.QTB && typeof window.QTB.openApiKeyModal === 'function') {
-          window.QTB.openApiKeyModal();
+    if (taskLabelInput && promptText) {
+      taskLabelInput.addEventListener('input', function () {
+        if (apiKey) {
+          promptText.value = _buildAgentPrompt(apiKey, taskLabelInput.value);
+        } else {
+          promptText.value = _buildPromptPlaceholder(status, loading, error, taskLabelInput.value);
         }
       });
     }
 
-    function updateTaskReflection(active, pulse) {
-      var value = taskSelect && taskSelect.value ? taskSelect.value : 'Unavailable';
-      if (selectedBadge) selectedBadge.textContent = value;
-      if (taskReflectionValue) taskReflectionValue.textContent = value;
-      if (taskSelect) taskSelect.classList.toggle('is-active', !!active);
-      if (taskReflection) {
-        taskReflection.classList.toggle('is-active', !!active);
-        if (pulse) {
-          taskReflection.classList.add('is-updated');
-          clearTimeout(pulseTimer);
-          pulseTimer = setTimeout(function () {
-            taskReflection.classList.remove('is-updated');
-          }, 520);
-        }
-      }
-    }
-
-    if (taskSelect) {
-      updateTaskReflection(false, false);
-      taskSelect.addEventListener('focus', function () { updateTaskReflection(true, false); });
-      taskSelect.addEventListener('pointerdown', function () { updateTaskReflection(true, false); });
-      taskSelect.addEventListener('blur', function () { updateTaskReflection(false, false); });
-      taskSelect.addEventListener('change', function () { updateTaskReflection(true, true); });
-    }
-
-    if (createBtn) {
-      createBtn.addEventListener('click', function () {
-        var task = taskSelect ? taskSelect.value : '';
-        if (!task) return;
-        createBtn.disabled = true;
-        createBtn.textContent = 'Creating...';
-        errorDiv.style.display = 'none';
-
-        _authFetch('/ui/runs', {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({task: task, mode: 'agent'})
-        })
-        .then(function (r) { return r.json(); })
-        .then(function (data) {
-          if (data.error) {
-            errorDiv.textContent = data.error;
-            errorDiv.style.display = 'block';
-            createBtn.disabled = false;
-            createBtn.textContent = 'Create Run';
-            return;
-          }
-          _runId = data.run_id;
-          if (data.control_token) {
-            _rememberControlToken(data.run_id, data.control_token);
-          }
-          _renderMonitorPage(app, data);
-        })
-        .catch(function (err) {
-          errorDiv.textContent = 'Network error: ' + err.message;
-          errorDiv.style.display = 'block';
-          createBtn.disabled = false;
-          createBtn.textContent = 'Create Run';
-        });
+    if (generateBtn) {
+      generateBtn.addEventListener('click', function () {
+        generateBtn.disabled = true;
+        generateBtn.textContent = 'Generating...';
+        if (errorDiv) errorDiv.style.display = 'none';
+        var currentTaskLabel = taskLabelInput ? taskLabelInput.value : taskLabel;
+        _generateApiKey()
+          .then(function (payload) {
+            _renderPromptPage(app, {status: payload, apiKey: payload.api_key, taskLabel: currentTaskLabel});
+          })
+          .catch(function (err) {
+            if (errorDiv) {
+              errorDiv.textContent = err && err.message ? err.message : String(err || 'Unable to generate prompt.');
+              errorDiv.style.display = 'block';
+            }
+            generateBtn.disabled = false;
+            generateBtn.textContent = generateText;
+          });
       });
+    }
+    if (copyBtn) {
+      copyBtn.addEventListener('click', function () {
+        var value = promptText ? promptText.value : '';
+        if (!value) return;
+        if (navigator.clipboard) {
+          navigator.clipboard.writeText(value).then(function () {
+            copyBtn.textContent = 'Copied';
+          }).catch(function () {
+            _fallbackCopy(promptText);
+            copyBtn.textContent = 'Copied';
+          });
+        } else {
+          _fallbackCopy(promptText);
+          copyBtn.textContent = 'Copied';
+        }
+      });
+    }
+  }
+
+  function _fallbackCopy(textarea) {
+    if (!textarea) return;
+    textarea.focus();
+    textarea.select();
+    try {
+      document.execCommand('copy');
+    } catch (e) {
+      // Browser copy fallback failed; selected text is still ready for manual copy.
     }
   }
 

--- a/bench/server/web/static/js/run-agent.js
+++ b/bench/server/web/static/js/run-agent.js
@@ -5,7 +5,7 @@
  * 2. Poll /ui/runs/{id} for status changes (waiting → claimed → active)
  * 3. Poll /ui/runs/{id}/live for real-time conversation + tool logs
  * 4. Cancel button → POST /ui/runs/{id}/cancel
- * 5. On completed → show link to Results
+ * 5. On completed → show link to Human Review
  */
 (function () {
   'use strict';
@@ -107,16 +107,31 @@
 
     // Otherwise show task selection + create run form
     loadCatalog(function (tasks) {
-      _renderCreatePage(app, tasks);
+      _renderCreatePage(app, tasks, payload && payload.tasks);
     });
   };
 
-  function _renderCreatePage(app, tasks) {
-    var taskOptions = tasks.map(function (t) {
-      return '<option value="' + escapeHtml(t.label) + '">' +
-        escapeHtml(t.label) +
+  function _taskLabels(tasks, fallbackTasks) {
+    var labels = [];
+    var seen = {};
+    (tasks || []).concat(fallbackTasks || []).forEach(function (task) {
+      var label = task && (task.label || publicTaskLabel(task.task_id || task.id));
+      if (!label || seen[label]) return;
+      seen[label] = true;
+      labels.push(label);
+    });
+    return labels;
+  }
+
+  function _renderCreatePage(app, tasks, fallbackTasks) {
+    var labels = _taskLabels(tasks, fallbackTasks);
+    var hasTasks = labels.length > 0;
+    var selectedLabel = hasTasks ? labels[0] : '';
+    var taskOptions = hasTasks ? labels.map(function (label) {
+      return '<option value="' + escapeHtml(label) + '">' +
+        escapeHtml(label) +
         '</option>';
-    }).join('');
+    }).join('') : '<option value="">No tasks available</option>';
 
     app.innerHTML =
       '<section class="page run-page">' +
@@ -128,20 +143,35 @@
           '</div>' +
         '</header>' +
         '<div class="run-agent-create-panel">' +
-          '<aside class="panel">' +
-            '<h2>Agent Connection</h2>' +
-            '<p class="detail-empty-note">Use the REST agent skill for API-key based agents, or create a run here to receive a run token and connection details.</p>' +
+          '<aside class="panel run-agent-create-card">' +
+            '<div class="run-agent-card-head">' +
+              '<div>' +
+                '<h2>Agent Connection</h2>' +
+                '<p class="detail-empty-note">Create a task-specific run to receive a run token and connection details.</p>' +
+              '</div>' +
+              '<span class="run-selected-badge" id="myagent-selected-badge">' + escapeHtml(selectedLabel || 'No task') + '</span>' +
+            '</div>' +
             '<label class="filter-field">' +
               '<span class="filter-label">Task</span>' +
-              '<select id="myagent-task-select" class="filter-select">' + taskOptions + '</select>' +
+              '<select id="myagent-task-select" class="filter-select"' + (hasTasks ? '' : ' disabled') + '>' + taskOptions + '</select>' +
             '</label>' +
-            '<div class="run-actions" style="margin-top:1rem;">' +
-              '<button class="btn btn-primary" id="myagent-create-btn" type="button">Create Run</button>' +
-              '<button class="btn btn-secondary" id="myagent-api-key-btn" type="button">API Key</button>' +
-              '<a class="btn btn-secondary" href="/skills/quanttutorbench-rest-agent" target="_blank" rel="noreferrer">REST Agent Skill</a>' +
+            '<div class="run-task-reflection" id="myagent-task-reflection" aria-live="polite">' +
+              '<span>Selected task</span>' +
+              '<strong id="myagent-task-reflection-value">' + escapeHtml(selectedLabel || 'Unavailable') + '</strong>' +
+            '</div>' +
+            '<div class="run-actions">' +
+              '<button class="btn btn-primary" id="myagent-create-btn" type="button"' + (hasTasks ? '' : ' disabled') + '>Create Run</button>' +
             '</div>' +
             '<div id="myagent-error" class="run-error" style="display:none;"></div>' +
           '</aside>' +
+          '<section class="panel run-agent-api-card">' +
+            '<h2>Agent API</h2>' +
+            '<p class="detail-empty-note">Use the REST agent skill for API-key based agents, or open the API key manager before connecting an external agent.</p>' +
+            '<div class="run-agent-api-actions">' +
+              '<button class="btn btn-secondary" id="myagent-api-key-btn" type="button">API Key</button>' +
+              '<a class="btn btn-secondary" href="/skills/quanttutorbench-rest-agent" target="_blank" rel="noreferrer">REST Agent Skill</a>' +
+            '</div>' +
+          '</section>' +
         '</div>' +
       '</section>';
 
@@ -150,6 +180,10 @@
     var apiKeyBtn = document.getElementById('myagent-api-key-btn');
     var taskSelect = document.getElementById('myagent-task-select');
     var errorDiv = document.getElementById('myagent-error');
+    var selectedBadge = document.getElementById('myagent-selected-badge');
+    var taskReflection = document.getElementById('myagent-task-reflection');
+    var taskReflectionValue = document.getElementById('myagent-task-reflection-value');
+    var pulseTimer = null;
 
     if (apiKeyBtn) {
       apiKeyBtn.addEventListener('click', function () {
@@ -157,6 +191,31 @@
           window.QTB.openApiKeyModal();
         }
       });
+    }
+
+    function updateTaskReflection(active, pulse) {
+      var value = taskSelect && taskSelect.value ? taskSelect.value : 'Unavailable';
+      if (selectedBadge) selectedBadge.textContent = value;
+      if (taskReflectionValue) taskReflectionValue.textContent = value;
+      if (taskSelect) taskSelect.classList.toggle('is-active', !!active);
+      if (taskReflection) {
+        taskReflection.classList.toggle('is-active', !!active);
+        if (pulse) {
+          taskReflection.classList.add('is-updated');
+          clearTimeout(pulseTimer);
+          pulseTimer = setTimeout(function () {
+            taskReflection.classList.remove('is-updated');
+          }, 520);
+        }
+      }
+    }
+
+    if (taskSelect) {
+      updateTaskReflection(false, false);
+      taskSelect.addEventListener('focus', function () { updateTaskReflection(true, false); });
+      taskSelect.addEventListener('pointerdown', function () { updateTaskReflection(true, false); });
+      taskSelect.addEventListener('blur', function () { updateTaskReflection(false, false); });
+      taskSelect.addEventListener('change', function () { updateTaskReflection(true, true); });
     }
 
     if (createBtn) {

--- a/bench/server/web/static/js/run-agent.js
+++ b/bench/server/web/static/js/run-agent.js
@@ -104,12 +104,7 @@
   }
 
   function _skillRawUrl() {
-    return _absoluteUrl('/skills/quanttutorbench-rest-agent/raw');
-  }
-
-  function _taskLabelForPrompt(value) {
-    var label = String(value || '').trim();
-    return label || '<public_task_label>';
+    return _absoluteUrl('/skill.md');
   }
 
   function _jsonResponse(response) {
@@ -135,56 +130,27 @@
       });
   }
 
-  function _buildAgentPrompt(apiKey, taskLabel) {
+  function _buildAgentPrompt(apiKey) {
     var baseUrl = window.location.origin;
-    var skillUrl = _skillPageUrl();
     var rawSkillUrl = _skillRawUrl();
-    var label = _taskLabelForPrompt(taskLabel);
     return [
-      'You are connecting to QuantTutorBench as my external agent.',
-      '',
-      'Load the REST agent skill first:',
-      skillUrl,
-      '',
-      'Fetch the raw skill file with:',
-      'curl -L "' + rawSkillUrl + '"',
+      'Read ' + rawSkillUrl + ' and follow the instructions to join QuantTutorBench.',
       '',
       'Benchmark base URL:',
       baseUrl,
       '',
-      'Public task label for /client/runs/start:',
-      label,
-      'When this value is <public_task_label>, ask the operator for the public task label before starting the run.',
-      '',
-      'Start-run payload:',
-      '{"task": "' + label + '", "mode": "agent"}',
-      '',
       'REST API key:',
-      apiKey,
-      '',
-      'Use this auth header for REST calls:',
-      'Authorization: Bearer ' + apiKey,
-      '',
-      'Follow the skill workflow exactly. Create or claim a run through the REST API, tutor the student through the server endpoints, call allowed tools through the benchmark service, monitor terminal status, and return the Human Review link when the session is archived.'
+      apiKey
     ].join('\n');
   }
 
-  function _buildPromptPlaceholder(status, loading, error, taskLabel) {
-    var skillUrl = _skillPageUrl();
+  function _buildPromptPlaceholder(status, loading, error) {
     var rawSkillUrl = _skillRawUrl();
-    var label = _taskLabelForPrompt(taskLabel);
     if (loading) {
       return [
         'Loading API key status...',
         '',
-        'Public task label for /client/runs/start:',
-        label,
-        'When this value is <public_task_label>, ask the operator for the public task label before starting the run.',
-        '',
-        'Skill URL:',
-        skillUrl,
-        '',
-        'curl -L "' + rawSkillUrl + '"'
+        'Read ' + rawSkillUrl + ' and follow the instructions to join QuantTutorBench.'
       ].join('\n');
     }
     if (error) {
@@ -192,14 +158,7 @@
         'Unable to load API key status.',
         error,
         '',
-        'Public task label for /client/runs/start:',
-        label,
-        'When this value is <public_task_label>, ask the operator for the public task label before starting the run.',
-        '',
-        'Skill URL:',
-        skillUrl,
-        '',
-        'curl -L "' + rawSkillUrl + '"'
+        'Read ' + rawSkillUrl + ' and follow the instructions to join QuantTutorBench.'
       ].join('\n');
     }
     return [
@@ -207,14 +166,7 @@
         ? 'Generate a fresh agent prompt to reveal a full REST API key in this text box.'
         : 'Generate an agent prompt to create a REST API key and place it in this text box.',
       '',
-      'Public task label for /client/runs/start:',
-      label,
-      'When this value is <public_task_label>, ask the operator for the public task label before starting the run.',
-      '',
-      'Skill URL:',
-      skillUrl,
-      '',
-      'curl -L "' + rawSkillUrl + '"'
+      'Read ' + rawSkillUrl + ' and follow the instructions to join QuantTutorBench.'
     ].join('\n');
   }
 
@@ -232,14 +184,13 @@
     options = options || {};
     var status = options.status || {};
     var apiKey = options.apiKey || '';
-    var taskLabel = options.taskLabel || '';
     var loading = !!options.loading;
     var error = options.error || '';
     var skillUrl = _skillPageUrl();
     var rawSkillUrl = _skillRawUrl();
     var prompt = apiKey
-      ? _buildAgentPrompt(apiKey, taskLabel)
-      : _buildPromptPlaceholder(status, loading, error, taskLabel);
+      ? _buildAgentPrompt(apiKey)
+      : _buildPromptPlaceholder(status, loading, error);
     var copyDisabled = apiKey ? '' : ' disabled';
     var generateDisabled = loading ? ' disabled' : '';
     var generateText = status && status.has_key ? 'Generate Fresh Prompt' : 'Generate Prompt';
@@ -258,15 +209,9 @@
             '<div class="run-agent-prompt-head">' +
               '<div>' +
                 '<h2>Agent Prompt</h2>' +
-                '<p class="detail-empty-note">Copy this text into your agent. It includes the API key after prompt generation.</p>' +
+                '<p class="detail-empty-note">Copy this text into your agent after generation. It includes the REST API key.</p>' +
               '</div>' +
               '<span class="run-selected-badge">' + escapeHtml(_apiKeyStatusText(status, apiKey, loading, error)) + '</span>' +
-            '</div>' +
-            '<div class="run-agent-prompt-controls">' +
-              '<label class="run-agent-prompt-field" for="myagent-task-label-input">' +
-                '<span>Public Task Label</span>' +
-                '<input id="myagent-task-label-input" class="run-agent-prompt-input" type="text" placeholder="D01" value="' + escapeHtml(taskLabel) + '">' +
-              '</label>' +
             '</div>' +
             '<textarea id="myagent-prompt-text" class="run-agent-prompt-text" readonly spellcheck="false">' + escapeHtml(prompt) + '</textarea>' +
             '<div class="run-agent-skill-url">' +
@@ -288,28 +233,16 @@
     var generateBtn = document.getElementById('myagent-generate-prompt-btn');
     var copyBtn = document.getElementById('myagent-copy-prompt-btn');
     var promptText = document.getElementById('myagent-prompt-text');
-    var taskLabelInput = document.getElementById('myagent-task-label-input');
     var errorDiv = document.getElementById('myagent-error');
-
-    if (taskLabelInput && promptText) {
-      taskLabelInput.addEventListener('input', function () {
-        if (apiKey) {
-          promptText.value = _buildAgentPrompt(apiKey, taskLabelInput.value);
-        } else {
-          promptText.value = _buildPromptPlaceholder(status, loading, error, taskLabelInput.value);
-        }
-      });
-    }
 
     if (generateBtn) {
       generateBtn.addEventListener('click', function () {
         generateBtn.disabled = true;
         generateBtn.textContent = 'Generating...';
         if (errorDiv) errorDiv.style.display = 'none';
-        var currentTaskLabel = taskLabelInput ? taskLabelInput.value : taskLabel;
         _generateApiKey()
           .then(function (payload) {
-            _renderPromptPage(app, {status: payload, apiKey: payload.api_key, taskLabel: currentTaskLabel});
+            _renderPromptPage(app, {status: payload, apiKey: payload.api_key});
           })
           .catch(function (err) {
             if (errorDiv) {

--- a/bench/server/web/templates/index.html
+++ b/bench/server/web/templates/index.html
@@ -20,6 +20,7 @@
       <a href="#/run" class="nav-link" data-route="run">Run</a>
       <a href="#/runs" class="nav-link" data-route="runs">Runs</a>
       <a href="#/results" class="nav-link" data-route="results">Results</a>
+      <a href="#/review" class="nav-link" data-route="review">Review</a>
       <a href="#/tasks" class="nav-link" data-route="tasks">Tasks</a>
     </div>
     <div id="nav-user" class="nav-user"></div>

--- a/bench/server/web/templates/index.html
+++ b/bench/server/web/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>QuantTutorBench Isolated UI</title>
-  <link rel="stylesheet" href="/static/css/styles.css?v=20260430f">
+  <link rel="stylesheet" href="/static/css/styles.css?v=20260430g">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
@@ -29,8 +29,8 @@
   <script src="/static/js/render.js?v=20260421a"></script>
   <script src="/static/js/chat.js?v=20260421a"></script>
   <script src="/static/js/tools.js?v=20260421a"></script>
-  <script src="/static/js/run-agent.js?v=20260430f"></script>
-  <script src="/static/js/flow-demo.js?v=20260430f"></script>
-  <script src="/static/js/app.js?v=20260430f"></script>
+  <script src="/static/js/run-agent.js?v=20260430g"></script>
+  <script src="/static/js/flow-demo.js?v=20260430g"></script>
+  <script src="/static/js/app.js?v=20260430g"></script>
 </body>
 </html>

--- a/bench/server/web/templates/index.html
+++ b/bench/server/web/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>QuantTutorBench Isolated UI</title>
-  <link rel="stylesheet" href="/static/css/styles.css?v=20260430d">
+  <link rel="stylesheet" href="/static/css/styles.css?v=20260430e">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
@@ -29,8 +29,8 @@
   <script src="/static/js/render.js?v=20260421a"></script>
   <script src="/static/js/chat.js?v=20260421a"></script>
   <script src="/static/js/tools.js?v=20260421a"></script>
-  <script src="/static/js/run-agent.js?v=20260430d"></script>
-  <script src="/static/js/flow-demo.js?v=20260430d"></script>
-  <script src="/static/js/app.js?v=20260430d"></script>
+  <script src="/static/js/run-agent.js?v=20260430e"></script>
+  <script src="/static/js/flow-demo.js?v=20260430e"></script>
+  <script src="/static/js/app.js?v=20260430e"></script>
 </body>
 </html>

--- a/bench/server/web/templates/index.html
+++ b/bench/server/web/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>QuantTutorBench Isolated UI</title>
-  <link rel="stylesheet" href="/static/css/styles.css?v=20260430b">
+  <link rel="stylesheet" href="/static/css/styles.css?v=20260430d">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
@@ -29,8 +29,8 @@
   <script src="/static/js/render.js?v=20260421a"></script>
   <script src="/static/js/chat.js?v=20260421a"></script>
   <script src="/static/js/tools.js?v=20260421a"></script>
-  <script src="/static/js/run-agent.js?v=20260430b"></script>
-  <script src="/static/js/flow-demo.js?v=20260430b"></script>
-  <script src="/static/js/app.js?v=20260430b"></script>
+  <script src="/static/js/run-agent.js?v=20260430d"></script>
+  <script src="/static/js/flow-demo.js?v=20260430d"></script>
+  <script src="/static/js/app.js?v=20260430d"></script>
 </body>
 </html>

--- a/bench/server/web/templates/index.html
+++ b/bench/server/web/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>QuantTutorBench Isolated UI</title>
-  <link rel="stylesheet" href="/static/css/styles.css?v=20260430e">
+  <link rel="stylesheet" href="/static/css/styles.css?v=20260430f">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
@@ -29,8 +29,8 @@
   <script src="/static/js/render.js?v=20260421a"></script>
   <script src="/static/js/chat.js?v=20260421a"></script>
   <script src="/static/js/tools.js?v=20260421a"></script>
-  <script src="/static/js/run-agent.js?v=20260430e"></script>
-  <script src="/static/js/flow-demo.js?v=20260430e"></script>
-  <script src="/static/js/app.js?v=20260430e"></script>
+  <script src="/static/js/run-agent.js?v=20260430f"></script>
+  <script src="/static/js/flow-demo.js?v=20260430f"></script>
+  <script src="/static/js/app.js?v=20260430f"></script>
 </body>
 </html>

--- a/bench/server/web/templates/index.html
+++ b/bench/server/web/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>QuantTutorBench Isolated UI</title>
-  <link rel="stylesheet" href="/static/css/styles.css?v=20260422b">
+  <link rel="stylesheet" href="/static/css/styles.css?v=20260430a">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
@@ -29,8 +29,8 @@
   <script src="/static/js/render.js?v=20260421a"></script>
   <script src="/static/js/chat.js?v=20260421a"></script>
   <script src="/static/js/tools.js?v=20260421a"></script>
-  <script src="/static/js/run-agent.js?v=20260422c"></script>
-  <script src="/static/js/flow-demo.js?v=20260422c"></script>
-  <script src="/static/js/app.js?v=20260422c"></script>
+  <script src="/static/js/run-agent.js?v=20260430a"></script>
+  <script src="/static/js/flow-demo.js?v=20260430a"></script>
+  <script src="/static/js/app.js?v=20260430a"></script>
 </body>
 </html>

--- a/bench/server/web/templates/index.html
+++ b/bench/server/web/templates/index.html
@@ -16,12 +16,12 @@
       <span class="nav-subtitle">Isolated UI</span>
     </div>
     <div class="nav-links">
-      <a href="#/flow-demo" class="nav-link" data-route="flow">Flow</a>
-      <a href="#/run" class="nav-link" data-route="run">Run</a>
-      <a href="#/runs" class="nav-link" data-route="runs">Runs</a>
-      <a href="#/results" class="nav-link" data-route="results">Results</a>
-      <a href="#/review" class="nav-link" data-route="review">Review</a>
-      <a href="#/tasks" class="nav-link" data-route="tasks">Tasks</a>
+      <a href="#/flow-demo" class="nav-link" data-route="flow">Session Flow</a>
+      <a href="#/run" class="nav-link" data-route="run">New Run</a>
+      <a href="#/runs" class="nav-link" data-route="runs">Run History</a>
+      <a href="#/results" class="nav-link" data-route="results">Results Archive</a>
+      <a href="#/review" class="nav-link" data-route="review">Human Review</a>
+      <a href="#/tasks" class="nav-link" data-route="tasks">Task Catalog</a>
     </div>
     <div id="nav-user" class="nav-user"></div>
   </nav>

--- a/bench/server/web/templates/index.html
+++ b/bench/server/web/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>QuantTutorBench Isolated UI</title>
-  <link rel="stylesheet" href="/static/css/styles.css?v=20260430a">
+  <link rel="stylesheet" href="/static/css/styles.css?v=20260430b">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
@@ -29,8 +29,8 @@
   <script src="/static/js/render.js?v=20260421a"></script>
   <script src="/static/js/chat.js?v=20260421a"></script>
   <script src="/static/js/tools.js?v=20260421a"></script>
-  <script src="/static/js/run-agent.js?v=20260430a"></script>
-  <script src="/static/js/flow-demo.js?v=20260430a"></script>
-  <script src="/static/js/app.js?v=20260430a"></script>
+  <script src="/static/js/run-agent.js?v=20260430b"></script>
+  <script src="/static/js/flow-demo.js?v=20260430b"></script>
+  <script src="/static/js/app.js?v=20260430b"></script>
 </body>
 </html>

--- a/bench/server/web/templates/index.html
+++ b/bench/server/web/templates/index.html
@@ -12,14 +12,12 @@
 <body>
   <nav id="nav">
     <div class="nav-brand">
-      <a href="#/results" class="nav-logo">QuantTutorBench</a>
+      <a href="#/flow-demo" class="nav-logo">QuantTutorBench</a>
       <span class="nav-subtitle">Isolated UI</span>
     </div>
     <div class="nav-links">
       <a href="#/flow-demo" class="nav-link" data-route="flow">Session Flow</a>
       <a href="#/run" class="nav-link" data-route="run">New Run</a>
-      <a href="#/runs" class="nav-link" data-route="runs">Run History</a>
-      <a href="#/results" class="nav-link" data-route="results">Results Archive</a>
       <a href="#/review" class="nav-link" data-route="review">Human Review</a>
       <a href="#/tasks" class="nav-link" data-route="tasks">Task Catalog</a>
     </div>

--- a/bench/server/web/ui_app.py
+++ b/bench/server/web/ui_app.py
@@ -25,6 +25,7 @@ from starlette.requests import Request
 from starlette.responses import FileResponse, HTMLResponse, JSONResponse
 from starlette.routing import Route
 
+from .review_store import ReviewStore
 from .ui_indexer import ResultIndexer
 
 logger = logging.getLogger(__name__)
@@ -117,6 +118,7 @@ def ui_routes(manager) -> list[Route]:
     """
 
     indexer = ResultIndexer(manager.bench_root)
+    review_store = ReviewStore(manager.bench_root, indexer)
     auth = AuthService(manager.bench_root)
 
     def _scope_flags(request: Request, user) -> tuple[bool, bool]:
@@ -416,6 +418,151 @@ def ui_routes(manager) -> list[Route]:
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
         return JSONResponse({"tasks": run_service.catalog.list_labels_only()})
+
+    # -----------------------------------------------------------------------
+    # New: /ui/review/*
+    # -----------------------------------------------------------------------
+
+    async def list_review_bundles(request: Request) -> JSONResponse:
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
+        include_all, include_org = _scope_flags(request, user)
+        return JSONResponse(
+            _sanitize_for_json(
+                {
+                    "bundles": review_store.list_bundles(
+                        user,
+                        include_all=include_all,
+                        include_org=include_org,
+                    )
+                }
+            )
+        )
+
+    async def get_review_bundle(request: Request) -> JSONResponse:
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
+        bundle_id = request.path_params["bundle_id"]
+        include_all, include_org = _scope_flags(request, user)
+        try:
+            payload = review_store.get_bundle(
+                bundle_id,
+                user,
+                include_all=include_all,
+                include_org=include_org,
+            )
+        except PermissionError:
+            return JSONResponse({"error": "Bundle access denied"}, status_code=403)
+        if payload is None:
+            return JSONResponse({"error": "Bundle not found"}, status_code=404)
+        record_event(
+            manager.bench_root,
+            user,
+            "review.bundle_view",
+            request=request,
+            session_id=bundle_id,
+        )
+        return JSONResponse(_sanitize_for_json(payload))
+
+    async def append_review_opinion(request: Request) -> JSONResponse:
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
+        bundle_id = request.path_params["bundle_id"]
+        include_all, include_org = _scope_flags(request, user)
+        try:
+            existing = review_store.get_bundle(
+                bundle_id,
+                user,
+                include_all=include_all,
+                include_org=include_org,
+            )
+        except PermissionError:
+            return JSONResponse({"error": "Bundle access denied"}, status_code=403)
+        if existing is None:
+            return JSONResponse({"error": "Bundle not found"}, status_code=404)
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+        raw_card = body.get("opinion") if isinstance(body, dict) else body
+        if not isinstance(raw_card, dict):
+            return JSONResponse({"error": "Opinion card is required"}, status_code=400)
+        try:
+            review = review_store.append_opinion(
+                bundle_id,
+                user,
+                raw_card,
+                include_all=include_all,
+                include_org=include_org,
+            )
+        except PermissionError:
+            return JSONResponse({"error": "Bundle access denied"}, status_code=403)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        payload = review_store.get_bundle(
+            bundle_id,
+            user,
+            include_all=include_all,
+            include_org=include_org,
+        )
+        record_event(
+            manager.bench_root,
+            user,
+            "review.opinion_create",
+            request=request,
+            session_id=bundle_id,
+            payload={"section": raw_card.get("section")},
+        )
+        if payload is None:
+            return JSONResponse(_sanitize_for_json({"review": review}))
+        return JSONResponse(_sanitize_for_json(payload))
+
+    async def replace_review_opinions(request: Request) -> JSONResponse:
+        user, err = auth.require_user(request)
+        if err is not None:
+            return err
+        bundle_id = request.path_params["bundle_id"]
+        include_all, include_org = _scope_flags(request, user)
+        try:
+            existing = review_store.get_bundle(
+                bundle_id,
+                user,
+                include_all=include_all,
+                include_org=include_org,
+            )
+        except PermissionError:
+            return JSONResponse({"error": "Bundle access denied"}, status_code=403)
+        if existing is None:
+            return JSONResponse({"error": "Bundle not found"}, status_code=404)
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+        opinions = body.get("opinions") if isinstance(body, dict) else body
+        if not isinstance(opinions, list):
+            return JSONResponse({"error": "opinions must be a list"}, status_code=400)
+        try:
+            review_store.replace_opinions(
+                bundle_id,
+                user,
+                opinions,
+                include_all=include_all,
+                include_org=include_org,
+            )
+        except PermissionError:
+            return JSONResponse({"error": "Bundle access denied"}, status_code=403)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        payload = review_store.get_bundle(
+            bundle_id,
+            user,
+            include_all=include_all,
+            include_org=include_org,
+        )
+        return JSONResponse(_sanitize_for_json(payload or {"bundle_id": bundle_id}))
 
     # -----------------------------------------------------------------------
     # New: /ui/runs/*
@@ -906,6 +1053,19 @@ def ui_routes(manager) -> list[Route]:
         # New: public task catalog
         Route("/ui/tasks/catalog", task_catalog, methods=["GET"]),
         Route("/ui/tasks/catalog/labels", task_catalog_labels, methods=["GET"]),
+        # New: human review console
+        Route("/ui/review/bundles", list_review_bundles, methods=["GET"]),
+        Route("/ui/review/bundles/{bundle_id}", get_review_bundle, methods=["GET"]),
+        Route(
+            "/ui/review/bundles/{bundle_id}/opinions",
+            append_review_opinion,
+            methods=["POST"],
+        ),
+        Route(
+            "/ui/review/bundles/{bundle_id}/opinions",
+            replace_review_opinions,
+            methods=["PUT"],
+        ),
         # New: Run management (UI)
         Route("/ui/runs", create_run, methods=["POST"]),
         Route("/ui/runs", list_runs, methods=["GET"]),

--- a/bench/server/web/ui_app.py
+++ b/bench/server/web/ui_app.py
@@ -22,7 +22,12 @@ from server.audit import record_event
 from server.auth import AuthService
 from server.quota import QuotaExceeded
 from starlette.requests import Request
-from starlette.responses import FileResponse, HTMLResponse, JSONResponse
+from starlette.responses import (
+    FileResponse,
+    HTMLResponse,
+    JSONResponse,
+    PlainTextResponse,
+)
 from starlette.routing import Route
 
 from .review_store import ReviewStore
@@ -155,7 +160,7 @@ def ui_routes(manager) -> list[Route]:
     async def ui_me(request: Request) -> JSONResponse:
         return JSONResponse(auth.me_payload(request))
 
-    async def rest_agent_skill_page(request: Request) -> HTMLResponse:
+    def _load_rest_agent_skill_markdown() -> str | None:
         relative = Path("docs/skills/quanttutorbench-rest-agent/SKILL.md")
         candidates = [
             manager.bench_root / relative,
@@ -163,8 +168,19 @@ def ui_routes(manager) -> list[Route]:
         ]
         skill_path = next((path for path in candidates if path.exists()), candidates[0])
         try:
-            markdown = skill_path.read_text(encoding="utf-8")
+            return skill_path.read_text(encoding="utf-8")
         except OSError:
+            return None
+
+    async def rest_agent_skill_raw(request: Request) -> PlainTextResponse:
+        markdown = _load_rest_agent_skill_markdown()
+        if markdown is None:
+            return PlainTextResponse("Skill page not found.", status_code=404)
+        return PlainTextResponse(markdown, media_type="text/markdown; charset=utf-8")
+
+    async def rest_agent_skill_page(request: Request) -> HTMLResponse:
+        markdown = _load_rest_agent_skill_markdown()
+        if markdown is None:
             return HTMLResponse("Skill page not found.", status_code=404)
 
         body = html.escape(markdown)
@@ -1032,6 +1048,11 @@ def ui_routes(manager) -> list[Route]:
         Route(
             "/skills/quanttutorbench-rest-agent",
             rest_agent_skill_page,
+            methods=["GET"],
+        ),
+        Route(
+            "/skills/quanttutorbench-rest-agent/raw",
+            rest_agent_skill_raw,
             methods=["GET"],
         ),
         Route("/ui/me", ui_me, methods=["GET"]),

--- a/bench/server/web/ui_app.py
+++ b/bench/server/web/ui_app.py
@@ -1055,6 +1055,7 @@ def ui_routes(manager) -> list[Route]:
             rest_agent_skill_raw,
             methods=["GET"],
         ),
+        Route("/skill.md", rest_agent_skill_raw, methods=["GET"]),
         Route("/ui/me", ui_me, methods=["GET"]),
         Route("/ui/api-key", get_api_key, methods=["GET"]),
         Route("/ui/api-key", rotate_api_key, methods=["POST"]),

--- a/bench/server/web/ui_indexer.py
+++ b/bench/server/web/ui_indexer.py
@@ -455,16 +455,65 @@ class ResultIndexer:
                         yield run_dir
 
     def _find_result_dir(self, session_id: str) -> Path | None:
-        short_id = session_id[:12]
+        requested = str(session_id or "").strip()
+        if not requested:
+            return None
+        short_ids = {requested[:12], requested[:8]}
+        suffix_matches: list[Path] = []
         for result_dir in self._iter_result_dirs():
+            known_ids: list[str] = []
             sid_file = result_dir / ".session_id"
-            if sid_file.exists() and sid_file.read_text(
-                encoding="utf-8"
-            ).strip().startswith(session_id):
+            if sid_file.exists():
+                try:
+                    stored_id = sid_file.read_text(encoding="utf-8").strip()
+                except OSError:
+                    stored_id = ""
+                if stored_id:
+                    known_ids.append(stored_id)
+
+            run_state = self._load_json(result_dir / "run_state.json")
+            if isinstance(run_state, dict):
+                stored_id = str(run_state.get("session_id") or "").strip()
+                if stored_id:
+                    known_ids.append(stored_id)
+
+            manifest = self._load_json(result_dir / "manifest.json")
+            if isinstance(manifest, dict):
+                stored_id = str(manifest.get("session_id") or "").strip()
+                if stored_id:
+                    known_ids.append(stored_id)
+
+            if any(
+                self._session_id_matches(stored_id, requested)
+                for stored_id in known_ids
+            ):
                 return result_dir
-            if result_dir.name.endswith(f"_{short_id}"):
-                return result_dir
-        return None
+            if known_ids:
+                continue
+
+            if any(
+                short_id and result_dir.name.endswith(f"_{short_id}")
+                for short_id in short_ids
+            ):
+                suffix_matches.append(result_dir)
+        return suffix_matches[0] if suffix_matches else None
+
+    def _session_id_matches(self, stored_id: str, requested_id: str) -> bool:
+        stored = str(stored_id or "").strip()
+        requested = str(requested_id or "").strip()
+        return bool(
+            stored
+            and requested
+            and (
+                stored == requested
+                or stored.startswith(requested)
+                or (
+                    len(stored) in (8, 12)
+                    and re.fullmatch(r"[A-Fa-f0-9]+", stored) is not None
+                    and requested.startswith(stored)
+                )
+            )
+        )
 
     def _build_summary(self, result_dir: Path) -> dict[str, Any] | None:
         run_state = self._load_json(result_dir / "run_state.json")

--- a/bench/server/web/ui_indexer.py
+++ b/bench/server/web/ui_indexer.py
@@ -153,9 +153,11 @@ class ResultIndexer:
             raise PermissionError("Result access denied")
 
         task_id = str(run_state.get("task_id") or result_dir.parent.name)
+        persona_id = str(run_state.get("persona_id") or "unknown")
         task_meta = self._task_meta_cache.get(
             task_id, self._make_fallback_task_meta(task_id)
         )
+        persona_meta = self._persona_cache.get(persona_id, {})
         client_trace = self._load_client_trace(session_id)
         latest_score_id = self._resolve_latest_score_id(result_dir)
         latest_score = self._load_score_json(result_dir, latest_score_id)
@@ -187,7 +189,11 @@ class ResultIndexer:
             "category": task_meta.get("category", "unknown"),
             "difficulty": task_meta.get("difficulty", "unknown"),
             "description": task_meta.get("description", ""),
-            "persona_id": str(run_state.get("persona_id") or "unknown"),
+            "persona_id": persona_id,
+            "persona_description": str(persona_meta.get("description") or ""),
+            "persona_knowledge_level": str(
+                persona_meta.get("knowledge_level") or ""
+            ),
             "duration_seconds": self._coerce_float(
                 run_state.get("duration_seconds"), default=0.0
             ),
@@ -210,6 +216,15 @@ class ResultIndexer:
             "all_tool_logs": raw_tool_logs,
             "send_message_events": send_message_events,
             "workspace_files": workspace_files,
+            "workspace_diffs": self._ensure_list(
+                run_state.get("workspace_diffs") or run_state.get("diffs")
+            ),
+            "stdout": str(
+                run_state.get("stdout") or run_state.get("stdout_text") or ""
+            ),
+            "stderr": str(
+                run_state.get("stderr") or run_state.get("stderr_text") or ""
+            ),
             "distractor_names": distractor_names,
             "score_json": latest_score,
             "cost_json": latest_cost,

--- a/bench/tests/test_github_oauth_auth.py
+++ b/bench/tests/test_github_oauth_auth.py
@@ -42,6 +42,7 @@ class GithubOAuthAuthTests(unittest.TestCase):
                     auth,
                     "_fetch_profile",
                     return_value={
+                        "id": 12345,
                         "login": "alice",
                         "email": "alice@example.com",
                         "name": "Alice",
@@ -60,6 +61,7 @@ class GithubOAuthAuthTests(unittest.TestCase):
                 user = auth.store.get_session(cookie_value)
                 self.assertIsNotNone(user)
                 self.assertEqual(user.github_login, "alice")
+                self.assertEqual(user.github_user_id, "12345")
                 self.assertEqual(user.role, "admin")
 
     def test_public_login_does_not_request_org_scope(self):
@@ -180,12 +182,14 @@ class GithubOAuthAuthTests(unittest.TestCase):
                 auth = AuthService(Path(tmp))
                 user = auth._build_user(
                     {
+                        "id": 12345,
                         "login": "alice",
                         "email": "alice@example.com",
                         "name": "Alice",
                     }
                 )
                 self.assertEqual(user.role, "admin")
+                self.assertEqual(user.github_user_id, "12345")
 
 
 if __name__ == "__main__":

--- a/bench/tests/test_server_web_ui.py
+++ b/bench/tests/test_server_web_ui.py
@@ -357,6 +357,102 @@ class ResultIndexerTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 indexer.resolve_agent_file(session_id, "../secret.txt")
 
+    def test_detail_lookup_rejects_malformed_full_session_ids(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            session_id = "abcdef12aaaaaaaaaaaaaaaaaaaaaaaa"
+            result_dir = _make_server_result_dir(
+                root, "D01_demo", "beginner_persona", session_id
+            )
+            _write_json(
+                result_dir / "run_state.json",
+                {
+                    "session_id": session_id,
+                    "task_id": "D01_demo",
+                    "persona_id": "beginner_persona",
+                    "conversation": [],
+                    "tool_logs": [],
+                },
+            )
+
+            indexer = ResultIndexer(root)
+
+            self.assertIsNone(indexer.get_detail(f"{session_id}x"))
+
+    def test_detail_lookup_rejects_short_prefix_collision_with_known_id(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            stored_session_id = "abcdef12aaaaaaaaaaaaaaaaaaaaaaaa"
+            requested_session_id = "abcdef12bbbbbbbbbbbbbbbbbbbbbbbb"
+            result_dir = (
+                root
+                / "results"
+                / "server"
+                / "D01_demo"
+                / "beginner_persona"
+                / f"20260422_120000_{stored_session_id[:8]}"
+            )
+            _write_json(
+                result_dir / "run_state.json",
+                {
+                    "session_id": stored_session_id,
+                    "task_id": "D01_demo",
+                    "persona_id": "beginner_persona",
+                    "conversation": [],
+                    "tool_logs": [],
+                },
+            )
+
+            indexer = ResultIndexer(root)
+
+            self.assertIsNone(indexer.get_detail(requested_session_id))
+
+    def test_detail_lookup_prefers_known_id_before_suffix_fallback(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            requested_session_id = "abcdef12bbbbbbbbbbbbbbbbbbbbbbbb"
+            legacy_dir = (
+                root
+                / "results"
+                / "server"
+                / "A01_legacy"
+                / "beginner_persona"
+                / f"20260422_120000_{requested_session_id[:8]}"
+            )
+            _write_json(
+                legacy_dir / "run_state.json",
+                {
+                    "task_id": "A01_legacy",
+                    "persona_id": "beginner_persona",
+                    "conversation": [{"role": "assistant", "content": "Legacy"}],
+                    "tool_logs": [],
+                },
+            )
+            exact_dir = (
+                root
+                / "results"
+                / "server"
+                / "B01_exact"
+                / "beginner_persona"
+                / f"20260422_120001_{requested_session_id[:8]}"
+            )
+            _write_json(
+                exact_dir / "run_state.json",
+                {
+                    "session_id": requested_session_id,
+                    "task_id": "B01_exact",
+                    "persona_id": "beginner_persona",
+                    "conversation": [{"role": "assistant", "content": "Exact"}],
+                    "tool_logs": [],
+                },
+            )
+
+            detail = ResultIndexer(root).get_detail(requested_session_id)
+
+            self.assertIsNotNone(detail)
+            self.assertEqual(detail["task_id"], "B01_exact")
+            self.assertEqual(detail["conversation"][0]["content"], "Exact")
+
 
 class UiRoutesTests(unittest.TestCase):
     def test_ui_routes_serve_results_detail_and_files(self):
@@ -613,6 +709,48 @@ class UiRoutesTests(unittest.TestCase):
                 / "local-dev.json"
             )
             self.assertFalse(alias_review_file.exists())
+
+    def test_review_route_resolves_archives_without_session_id_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            session_id = "42e74d3a9ec94aa5b142f84474844be1"
+            result_dir = (
+                root
+                / "results"
+                / "server"
+                / "I01_implement_sma"
+                / "fullstack_practitioner"
+                / f"20260422_072509_{session_id[:8]}"
+            )
+            _write_json(
+                result_dir / "run_state.json",
+                {
+                    "session_id": session_id,
+                    "task_id": "I01_implement_sma",
+                    "persona_id": "fullstack_practitioner",
+                    "conversation": [{"role": "assistant", "content": "Answer"}],
+                    "tool_logs": [],
+                    "workspace_files": [],
+                },
+            )
+            _write_json(
+                result_dir / "manifest.json",
+                {"session_id": session_id, "task_id": "I01_implement_sma"},
+            )
+
+            app = Starlette(routes=ui_routes(_Manager(root)))
+            client = TestClient(app)
+
+            list_response = client.get("/ui/review/bundles")
+            detail_response = client.get(f"/ui/review/bundles/{session_id}")
+            prefix_response = client.get(f"/ui/review/bundles/{session_id[:12]}")
+
+            self.assertEqual(list_response.status_code, 200)
+            self.assertEqual(detail_response.status_code, 200)
+            self.assertEqual(prefix_response.status_code, 200)
+            self.assertEqual(list_response.json()["bundles"][0]["bundle_id"], session_id)
+            self.assertEqual(detail_response.json()["bundle_id"], session_id)
+            self.assertEqual(prefix_response.json()["bundle_id"], session_id)
 
     def test_review_routes_preserve_private_result_visibility(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/bench/tests/test_server_web_ui.py
+++ b/bench/tests/test_server_web_ui.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
@@ -10,6 +11,7 @@ from starlette.testclient import TestClient
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from server.api.http_app import create_app
+from server.auth import AuthService, SESSION_COOKIE, UserContext
 from server.web.ui_app import ui_routes
 from server.web.ui_indexer import ResultIndexer
 
@@ -456,6 +458,36 @@ class UiRoutesTests(unittest.TestCase):
                 f"/ui/results/{session_id}/workspace/preview/%2E%2E/secret.txt"
             )
             skill_response = client.get("/skills/quanttutorbench-rest-agent")
+            review_list_response = client.get("/ui/review/bundles")
+            review_bundle_response = client.get(f"/ui/review/bundles/{session_id}")
+            review_post_response = client.post(
+                f"/ui/review/bundles/{session_id}/opinions",
+                json={
+                    "opinion": {
+                        "section": "conversation",
+                        "target": {"turn_index": 0},
+                        "severity": "concern",
+                        "comment": "Student acknowledgement is terse.",
+                        "tags": ["persona_signal"],
+                    }
+                },
+            )
+            review_reload_response = client.get(f"/ui/review/bundles/{session_id}")
+            session_prefix = session_id[:7]
+            review_prefix_post_response = client.post(
+                f"/ui/review/bundles/{session_prefix}/opinions",
+                json={
+                    "opinion": {
+                        "section": "overall",
+                        "severity": "info",
+                        "comment": "Prefix routes use the canonical bundle id.",
+                    }
+                },
+            )
+            review_prefix_reload_response = client.get(
+                f"/ui/review/bundles/{session_prefix}"
+            )
+            review_list_after_response = client.get("/ui/review/bundles")
 
             self.assertEqual(tasks_response.status_code, 200)
             self.assertEqual(results_response.status_code, 200)
@@ -467,6 +499,13 @@ class UiRoutesTests(unittest.TestCase):
             self.assertEqual(image_preview_response.status_code, 200)
             self.assertEqual(file_response.status_code, 200)
             self.assertEqual(skill_response.status_code, 200)
+            self.assertEqual(review_list_response.status_code, 200)
+            self.assertEqual(review_bundle_response.status_code, 200)
+            self.assertEqual(review_post_response.status_code, 200)
+            self.assertEqual(review_reload_response.status_code, 200)
+            self.assertEqual(review_prefix_post_response.status_code, 200)
+            self.assertEqual(review_prefix_reload_response.status_code, 200)
+            self.assertEqual(review_list_after_response.status_code, 200)
             self.assertEqual(file_response.text, "report")
             self.assertIn("QuantTutorBench REST Agent", skill_response.text)
             self.assertIn("POST /client/runs/start", skill_response.text)
@@ -510,6 +549,170 @@ class UiRoutesTests(unittest.TestCase):
             self.assertEqual(image_payload["kind"], "image")
             self.assertIn("/ui/results/", image_payload["raw_url"])
 
+            review_list_payload = review_list_response.json()
+            self.assertEqual(review_list_payload["bundles"][0]["bundle_id"], session_id)
+            review_bundle_payload = review_bundle_response.json()
+            self.assertEqual(review_bundle_payload["bundle_id"], session_id)
+            self.assertEqual(
+                review_bundle_payload["layers"]["conversation"]["turns"][0]["content"],
+                "Answer",
+            )
+            self.assertEqual(
+                review_bundle_payload["layers"]["workspace"]["tree"][0]["path"],
+                "artifacts/report.md",
+            )
+
+            review_payload = review_post_response.json()
+            opinions = review_payload["review"]["opinions"]
+            self.assertEqual(len(opinions), 1)
+            self.assertEqual(opinions[0]["section"], "conversation")
+            self.assertEqual(opinions[0]["target"], {"turn_index": 0})
+            self.assertEqual(opinions[0]["reviewer_id"], "local-dev")
+            review_file = (
+                root
+                / "experiments"
+                / "human_review"
+                / session_id
+                / "local-dev.json"
+            )
+            self.assertTrue(review_file.exists())
+            saved = json.loads(review_file.read_text(encoding="utf-8"))
+            self.assertEqual(saved["sample_id"], session_id)
+            self.assertEqual(saved["github_user_id"], "local-dev")
+            self.assertEqual(
+                review_reload_response.json()["review"]["opinions"][0]["comment"],
+                "Student acknowledgement is terse.",
+            )
+            prefix_payload = review_prefix_post_response.json()
+            self.assertEqual(prefix_payload["bundle_id"], session_id)
+            self.assertEqual(prefix_payload["review"]["sample_id"], session_id)
+            self.assertEqual(len(prefix_payload["review"]["opinions"]), 2)
+            self.assertEqual(
+                prefix_payload["review"]["opinions"][1]["sample_id"], session_id
+            )
+            self.assertEqual(
+                prefix_payload["review"]["opinions"][1]["comment"],
+                "Prefix routes use the canonical bundle id.",
+            )
+            self.assertEqual(
+                review_prefix_reload_response.json()["review"]["opinions"][1][
+                    "bundle_id"
+                ],
+                session_id,
+            )
+            review_list_after_payload = review_list_after_response.json()
+            self.assertTrue(
+                review_list_after_payload["bundles"][0]["reviewed_by_current_user"]
+            )
+            self.assertEqual(review_list_after_payload["bundles"][0]["review_count"], 1)
+            alias_review_file = (
+                root
+                / "experiments"
+                / "human_review"
+                / session_prefix
+                / "local-dev.json"
+            )
+            self.assertFalse(alias_review_file.exists())
+
+    def test_review_routes_preserve_private_result_visibility(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _write_json(
+                root / "tasks" / "layer2" / "data_analysis" / "D01_demo.json",
+                {
+                    "task_id": "D01_demo",
+                    "category": "data_analysis",
+                    "difficulty": "easy",
+                    "description": "Demo task",
+                    "persona_ids": ["beginner_persona"],
+                },
+            )
+            _write_json(
+                root / "personas" / "beginner_persona.json",
+                {"persona_id": "beginner_persona", "description": "Demo persona"},
+            )
+
+            for session_id, owner_user_id in (
+                ("alice-session-001", "github:alice"),
+                ("bob-session-001", "github:bob"),
+            ):
+                result_dir = _make_server_result_dir(
+                    root, "D01_demo", "beginner_persona", session_id
+                )
+                _write_json(
+                    result_dir / "run_state.json",
+                    {
+                        "session_id": session_id,
+                        "task_id": "D01_demo",
+                        "persona_id": "beginner_persona",
+                        "owner_user_id": owner_user_id,
+                        "visibility": "private",
+                        "conversation": [
+                            {"role": "assistant", "content": f"Answer {session_id}"}
+                        ],
+                        "tool_logs": [],
+                        "workspace_files": [],
+                    },
+                )
+
+            with patch.dict("os.environ", {"QTB_AUTH_MODE": "github"}, clear=False):
+                app = Starlette(routes=ui_routes(_Manager(root)))
+                auth = AuthService(root)
+                alice_session = auth.store.create_session(
+                    UserContext(
+                        user_id="github:alice",
+                        github_login="alice",
+                        email="alice@example.com",
+                        display_name="Alice",
+                        avatar_url="",
+                        github_user_id="101",
+                    )
+                )
+                admin_session = auth.store.create_session(
+                    UserContext(
+                        user_id="github:admin",
+                        github_login="admin",
+                        email="admin@example.com",
+                        display_name="Admin",
+                        avatar_url="",
+                        github_user_id="999",
+                        role="admin",
+                    )
+                )
+
+                alice_client = TestClient(app)
+                alice_client.cookies.set(SESSION_COOKIE, alice_session)
+                alice_list = alice_client.get("/ui/review/bundles")
+                alice_own = alice_client.get("/ui/review/bundles/alice-session-001")
+                alice_bob = alice_client.get("/ui/review/bundles/bob-session-001")
+                alice_bob_post = alice_client.post(
+                    "/ui/review/bundles/bob-session-001/opinions",
+                    json={
+                        "opinion": {
+                            "section": "overall",
+                            "comment": "Should be denied.",
+                        }
+                    },
+                )
+
+                admin_client = TestClient(app)
+                admin_client.cookies.set(SESSION_COOKIE, admin_session)
+                admin_list = admin_client.get("/ui/review/bundles")
+
+            self.assertEqual(alice_list.status_code, 200)
+            self.assertEqual(alice_own.status_code, 200)
+            self.assertEqual(alice_bob.status_code, 403)
+            self.assertEqual(alice_bob_post.status_code, 403)
+            self.assertEqual(
+                {item["bundle_id"] for item in alice_list.json()["bundles"]},
+                {"alice-session-001"},
+            )
+            self.assertEqual(admin_list.status_code, 200)
+            self.assertEqual(
+                {item["bundle_id"] for item in admin_list.json()["bundles"]},
+                {"alice-session-001", "bob-session-001"},
+            )
+
 
 class HttpAppSmokeTests(unittest.TestCase):
     def test_create_app_serves_isolated_shell_and_static_assets(self):
@@ -524,11 +727,17 @@ class HttpAppSmokeTests(unittest.TestCase):
         self.assertEqual(index_response.status_code, 200)
         self.assertEqual(script_response.status_code, 200)
         self.assertEqual(render_response.status_code, 200)
+        review_response = client.get("/review")
+        review_detail_response = client.get("/review/demo-bundle")
+        self.assertEqual(review_response.status_code, 200)
+        self.assertEqual(review_detail_response.status_code, 200)
         self.assertIn("/static/js/chat.js", index_response.text)
         self.assertIn("/static/js/tools.js", index_response.text)
         self.assertIn("/static/js/app.js", index_response.text)
         self.assertIn("/static/js/run-agent.js", index_response.text)
         self.assertIn('href="#/run"', index_response.text)
+        self.assertIn('href="#/review"', index_response.text)
+        self.assertIn('data-route="review"', index_response.text)
         self.assertIn('data-route="run"', index_response.text)
         self.assertIn("Isolated UI", index_response.text)
 

--- a/bench/tests/test_server_web_ui.py
+++ b/bench/tests/test_server_web_ui.py
@@ -554,6 +554,7 @@ class UiRoutesTests(unittest.TestCase):
                 f"/ui/results/{session_id}/workspace/preview/%2E%2E/secret.txt"
             )
             skill_response = client.get("/skills/quanttutorbench-rest-agent")
+            skill_raw_response = client.get("/skills/quanttutorbench-rest-agent/raw")
             review_list_response = client.get("/ui/review/bundles")
             review_bundle_response = client.get(f"/ui/review/bundles/{session_id}")
             review_post_response = client.post(
@@ -595,6 +596,7 @@ class UiRoutesTests(unittest.TestCase):
             self.assertEqual(image_preview_response.status_code, 200)
             self.assertEqual(file_response.status_code, 200)
             self.assertEqual(skill_response.status_code, 200)
+            self.assertEqual(skill_raw_response.status_code, 200)
             self.assertEqual(review_list_response.status_code, 200)
             self.assertEqual(review_bundle_response.status_code, 200)
             self.assertEqual(review_post_response.status_code, 200)
@@ -605,6 +607,13 @@ class UiRoutesTests(unittest.TestCase):
             self.assertEqual(file_response.text, "report")
             self.assertIn("QuantTutorBench REST Agent", skill_response.text)
             self.assertIn("POST /client/runs/start", skill_response.text)
+            self.assertIn("QuantTutorBench REST Agent", skill_raw_response.text)
+            self.assertIn("POST /client/runs/start", skill_raw_response.text)
+            self.assertTrue(
+                skill_raw_response.headers.get("content-type", "").startswith(
+                    "text/markdown"
+                )
+            )
             self.assertEqual(export_response.json()["session_id"], session_id)
             self.assertIn(
                 "session-003_run_state.json",

--- a/bench/tests/test_server_web_ui.py
+++ b/bench/tests/test_server_web_ui.py
@@ -555,6 +555,7 @@ class UiRoutesTests(unittest.TestCase):
             )
             skill_response = client.get("/skills/quanttutorbench-rest-agent")
             skill_raw_response = client.get("/skills/quanttutorbench-rest-agent/raw")
+            skill_md_response = client.get("/skill.md")
             review_list_response = client.get("/ui/review/bundles")
             review_bundle_response = client.get(f"/ui/review/bundles/{session_id}")
             review_post_response = client.post(
@@ -597,6 +598,7 @@ class UiRoutesTests(unittest.TestCase):
             self.assertEqual(file_response.status_code, 200)
             self.assertEqual(skill_response.status_code, 200)
             self.assertEqual(skill_raw_response.status_code, 200)
+            self.assertEqual(skill_md_response.status_code, 200)
             self.assertEqual(review_list_response.status_code, 200)
             self.assertEqual(review_bundle_response.status_code, 200)
             self.assertEqual(review_post_response.status_code, 200)
@@ -609,6 +611,7 @@ class UiRoutesTests(unittest.TestCase):
             self.assertIn("POST /client/runs/start", skill_response.text)
             self.assertIn("QuantTutorBench REST Agent", skill_raw_response.text)
             self.assertIn("POST /client/runs/start", skill_raw_response.text)
+            self.assertEqual(skill_md_response.text, skill_raw_response.text)
             self.assertTrue(
                 skill_raw_response.headers.get("content-type", "").startswith(
                     "text/markdown"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,7 +190,9 @@ Any authenticated GitHub reviewer can inspect the task spec, transcript, tutor
 tool log, workspace tree, and judge evaluation for a completed bundle.
 
 The isolated frontend treats Human Review as the archive-facing session view:
-completed runs from Session Flow and New Run link to `/review/{session_id}`.
+completed runs from Session Flow link to `/review/{session_id}`. New Run hands
+external agents a copyable REST prompt with a public task label, API key, browser
+skill URL, and raw Markdown skill URL for `curl`.
 
 Reviewer output is stored separately from judge-validation labels:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,8 +191,8 @@ tool log, workspace tree, and judge evaluation for a completed bundle.
 
 The isolated frontend treats Human Review as the archive-facing session view:
 completed runs from Session Flow link to `/review/{session_id}`. New Run hands
-external agents a copyable REST prompt with a public task label, API key, browser
-skill URL, and raw Markdown skill URL for `curl`.
+external agents a copyable REST prompt with a Moltbook-style skill instruction,
+`/skill.md`, base URL, and API key.
 
 Reviewer output is stored separately from judge-validation labels:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,6 +181,26 @@ External-agent `score.json` exports carry the selected validation run through
 the `judge_reliability` metadata block, populated from
 `bench/server/eval/judge_reliability_reference.json`.
 
+## Human Review Console
+
+`bench/server/web/review_store.py` exposes archived session bundles for human
+inspection through `/ui/review/*`. The Vercel-facing shell serves `/review` and
+`/review/{bundle_id}` as SPA routes backed by the existing GitHub OAuth cookie.
+Any authenticated GitHub reviewer can inspect the task spec, transcript, tutor
+tool log, workspace tree, and judge evaluation for a completed bundle.
+
+Reviewer output is stored separately from judge-validation labels:
+
+```text
+bench/experiments/human_review/{bundle_id}/{github_user_id}.json
+```
+
+Each file follows `human_review_opinions_v1` and contains structured opinion
+cards with `section`, optional `target`, `severity`, `comment`, `tags`, reviewer
+metadata, and optional judge-disagreement scores. Overlapping fields such as
+`sample_id`, `reviewer_id`, `label_version`, and `timestamp` are preserved for
+downstream joins with `judge_validation/human_labels*.json`.
+
 ## Public Reads
 
 `GET /session/{sid}/results` returns only export-scope run fields such as
@@ -202,6 +222,9 @@ debugging.
 `bench/server/web/ui_indexer.py` walks the canonical result tree and reads
 in-bundle `evaluations/index.json` plus `score_n/score.json` and `cost.json`.
 It also applies owner filtering for private/org/admin views.
+`bench/server/web/review_store.py` builds the review read model from the same
+result indexer and writes per-reviewer opinion files under
+`bench/experiments/human_review/`.
 
 ## Tests
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,6 +189,9 @@ inspection through `/ui/review/*`. The Vercel-facing shell serves `/review` and
 Any authenticated GitHub reviewer can inspect the task spec, transcript, tutor
 tool log, workspace tree, and judge evaluation for a completed bundle.
 
+The isolated frontend treats Human Review as the archive-facing session view:
+completed runs from Session Flow and New Run link to `/review/{session_id}`.
+
 Reviewer output is stored separately from judge-validation labels:
 
 ```text

--- a/docs/skills/quanttutorbench-rest-agent/SKILL.md
+++ b/docs/skills/quanttutorbench-rest-agent/SKILL.md
@@ -208,7 +208,7 @@ At terminal status, return this to the operator:
 - terminal `status`
 - terminal `reason` or `error`
 - visible task label
-- result link when available: `${BASE}/#/results/{session_id}`
+- review link when available: `${BASE}/#/review/{session_id}`
 
 The agent may read exported result and score state with the run token:
 

--- a/vercel-frontend/vercel.json
+++ b/vercel-frontend/vercel.json
@@ -4,6 +4,8 @@
   "outputDirectory": "public",
   "rewrites": [
     { "source": "/", "destination": "https://217-15-165-83.sslip.io/" },
+    { "source": "/review", "destination": "https://217-15-165-83.sslip.io/review" },
+    { "source": "/review/:path*", "destination": "https://217-15-165-83.sslip.io/review/:path*" },
     { "source": "/health", "destination": "https://217-15-165-83.sslip.io/health" },
     { "source": "/auth/:path*", "destination": "https://217-15-165-83.sslip.io/auth/:path*" },
     { "source": "/session/:path*", "destination": "https://217-15-165-83.sslip.io/session/:path*" },


### PR DESCRIPTION
Closes #103

## Changes
- Adds a `/review` reviewer console with bundle search, five inspection layers, empty states, row-level review actions, and structured opinion-card capture.
- Adds review APIs and disk persistence for per-bundle, per-GitHub-user JSON cards.
- Preserves human-label-compatible fields such as `sample_id`, `reviewer_id`, `label_version`, and `timestamp`.
- Routes `/review` through the Vercel-facing shell and documents the new review storage schema.
- Applies result visibility checks to review reads and serializes same-reviewer card writes.

## Verification
- `pytest bench/tests/test_server_web_ui.py bench/tests/test_github_oauth_auth.py bench/tests/test_result_owner_filtering.py bench/tests/test_run_control_token.py bench/tests/test_run_owner_filtering.py bench/tests/api/test_permissions.py`
- `node --check bench/server/web/static/js/app.js`
- `.venv/bin/python -m py_compile bench/server/web/review_store.py bench/server/web/ui_app.py bench/tests/test_server_web_ui.py`
- `python3 -m json.tool vercel-frontend/vercel.json`
- `python3 -m json.tool bench/experiments/human_review/human_review.schema.json`
- `git diff --check`

## Review
- Codex review round 1: fixed canonical bundle writes and markdown image URL rewriting.
- Codex review round 2: fixed review visibility checks and serialized appends.
