### PR TITLE
Fix Vercel /skill.md rewrite

### DIFF
--- a/vercel-frontend/vercel.json
+++ b/vercel-frontend/vercel.json
@@ -11,6 +11,7 @@
     { "source": "/session/:path*", "destination": "https://217-15-165-83.sslip.io/session/:path*" },
     { "source": "/client/:path*", "destination": "https://217-15-165-83.sslip.io/client/:path*" },
     { "source": "/ui/:path*", "destination": "https://217-15-165-83.sslip.io/ui/:path*" },
+    { "source": "/skill.md", "destination": "https://217-15-165-83.sslip.io/skill.md" },
     { "source": "/skills/:path*", "destination": "https://217-15-165-83.sslip.io/skills/:path*" },
     { "source": "/static/:path*", "destination": "https://217-15-165-83.sslip.io/static/:path*" },
     { "source": "/mcp/:path*", "destination": "https://217-15-165-83.sslip.io/mcp/:path*" },


### PR DESCRIPTION
Add the missing Vercel rewrite for /skill.md so the public production prompt URL proxies to the backend skill markdown endpoint.\n\nVerification:\n- node JSON parse for vercel-frontend/vercel.json\n- git diff --check\n- backend /skill.md currently returns 200; Vercel /skill.md currently returns 404 before this config deploy