### PR TITLE
Expose client task catalog to external agents

### DIFF
--- a/bench/server/web/README.md
+++ b/bench/server/web/README.md
@@ -33,11 +33,12 @@ Current routes:
 - `GET /skill.md`
 - `GET /skills/quanttutorbench-rest-agent`
 - `GET /skills/quanttutorbench-rest-agent/raw`
+- `GET /client/tasks/catalog/labels`
 
 Run route scope:
 - `#/run` opens a copyable REST agent prompt directly.
 - The prompt surface generates a fresh REST API key through `/ui/api-key` and embeds a short Moltbook-style instruction, `/skill.md`, base URL, and key in a textarea.
-- External agents create or claim runs through the REST skill workflow; hidden task metadata stays in the server/client execution context.
+- External agents discover public labels through `/client/tasks/catalog/labels`, then create or claim runs through the REST skill workflow; hidden task metadata stays in the server/client execution context.
 - Session Flow owns run lifecycle browsing. Human Review owns archived session inspection.
 
 Task route scope:

--- a/bench/server/web/ui_app.py
+++ b/bench/server/web/ui_app.py
@@ -1,10 +1,11 @@
 """Starlette route factory for the web UI.
 
 Provides:
-- ``/ui/results/*``  — read-only result browsing (existing)
-- ``/ui/tasks/*``    — task listing + public catalog (existing + new)
-- ``/ui/runs/*``     — Run management (new)
-- ``/client/runs/*`` — Client-facing Run endpoints (new)
+- ``/ui/results/*``   — read-only result browsing (existing)
+- ``/ui/tasks/*``     — task listing + public catalog (existing + new)
+- ``/ui/runs/*``      — Run management (new)
+- ``/client/tasks/*`` — Client-facing task catalog endpoints
+- ``/client/runs/*``  — Client-facing Run endpoints (new)
 """
 
 from __future__ import annotations
@@ -433,6 +434,18 @@ def ui_routes(manager) -> list[Route]:
         run_service = getattr(manager, "_run_service", None)
         if run_service is None:
             return JSONResponse({"error": "Run service not initialized"}, 503)
+        return JSONResponse({"tasks": run_service.catalog.list_labels_only()})
+
+    async def client_task_catalog_labels(request: Request) -> JSONResponse:
+        """API-key catalog for external clients before creating runs."""
+        run_service = getattr(manager, "_run_service", None)
+        if run_service is None:
+            return JSONResponse({"error": "Run service not initialized"}, 503)
+
+        _, auth_err = auth.resolve_client_user(request)
+        if auth_err is not None:
+            return auth_err
+
         return JSONResponse({"tasks": run_service.catalog.list_labels_only()})
 
     # -----------------------------------------------------------------------
@@ -1095,7 +1108,12 @@ def ui_routes(manager) -> list[Route]:
         Route("/ui/runs/{run_id}", get_run, methods=["GET"]),
         Route("/ui/runs/{run_id}/live", get_run_live, methods=["GET"]),
         Route("/ui/runs/{run_id}/cancel", cancel_run, methods=["POST"]),
-        # New: Run management (Client)
+        # New: Client-facing task catalog + Run management
+        Route(
+            "/client/tasks/catalog/labels",
+            client_task_catalog_labels,
+            methods=["GET"],
+        ),
         Route("/client/runs/claim", client_claim_run, methods=["POST"]),
         Route("/client/runs/start", client_start_run, methods=["POST"]),
         Route("/client/runs/{run_id}/trace", client_upload_trace, methods=["POST"]),

--- a/bench/tests/api/test_rest_run_identity.py
+++ b/bench/tests/api/test_rest_run_identity.py
@@ -21,6 +21,13 @@ async def _post_json(app, path, payload, headers=None):
         return await client.post(path, json=payload, headers=headers or {})
 
 
+async def _get_json(app, path, headers=None):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        return await client.get(path, headers=headers or {})
+
+
 @pytest.mark.asyncio
 async def test_client_start_requires_api_key_when_auth_enabled(bench_root, monkeypatch):
     monkeypatch.setenv("QTB_AUTH_MODE", "github")
@@ -31,6 +38,43 @@ async def test_client_start_requires_api_key_when_auth_enabled(bench_root, monke
 
     assert resp.status_code == 401
     assert "client_api_key" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_client_task_catalog_requires_api_key_when_auth_enabled(
+    bench_root, monkeypatch
+):
+    monkeypatch.setenv("QTB_AUTH_MODE", "github")
+    monkeypatch.delenv("QTB_CLIENT_API_KEYS", raising=False)
+    app = _make_app(bench_root)
+
+    resp = await _get_json(app, "/client/tasks/catalog/labels")
+
+    assert resp.status_code == 401
+    assert "client_api_key" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_client_task_catalog_returns_labels_with_api_key(
+    bench_root, monkeypatch
+):
+    monkeypatch.setenv("QTB_AUTH_MODE", "github")
+    monkeypatch.setenv(
+        "QTB_CLIENT_API_KEYS",
+        "secret-alice=external:alice|alice|alice@example.com",
+    )
+    app = _make_app(bench_root)
+
+    resp = await _get_json(
+        app,
+        "/client/tasks/catalog/labels",
+        headers={"Authorization": "Bearer secret-alice"},
+    )
+
+    assert resp.status_code == 200
+    tasks = resp.json()["tasks"]
+    assert {"label": "D01"} in tasks
+    assert all(set(item) == {"label"} for item in tasks)
 
 
 @pytest.mark.asyncio

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,8 +47,9 @@ quota checks, background tool jobs, cleanup, and restore-from-storage.
 
 ## Permission Boundary
 
-Clients can create or claim runs, register/start sessions, send tutor messages,
-call allowed workspace tools, and read exported result or score state.
+Clients can read public task labels, create or claim runs, register/start
+sessions, send tutor messages, call allowed workspace tools, and read exported
+result or score state.
 
 Clients cannot trigger scoring:
 
@@ -65,6 +66,11 @@ Scoring is server/operator-owned:
 The `/ops/*` surface is gated by the admin-token mechanism in
 `server.web.ui_app`. Client read endpoints stay export-scoped and, when run
 auth is enabled, require the owning run token.
+
+`GET /client/tasks/catalog/labels` is the API-key catalog endpoint for external
+agents before run creation. It returns only public labels such as `D01`; task
+category, difficulty, internal task IDs, rubrics, and solution paths stay out of
+the client catalog.
 
 ## Session Lifecycle
 

--- a/docs/skills/quanttutorbench-rest-agent/SKILL.md
+++ b/docs/skills/quanttutorbench-rest-agent/SKILL.md
@@ -37,13 +37,14 @@ A 900 second timeout is a practical default.
 Prefer MCP when your runtime supports it. Use REST everywhere else. The same
 run/session lifecycle applies in both modes:
 
-1. Create or claim a run.
-2. Register and start a session.
-3. Read the student message.
-4. Call allowed tools when useful.
-5. Send the tutor reply.
-6. Repeat until the server returns `completed` or `failed`.
-7. Return the run summary to the operator.
+1. Fetch task labels when creating runs with an API key.
+2. Create or claim a run.
+3. Register and start a session.
+4. Read the student message.
+5. Call allowed tools when useful.
+6. Send the tutor reply.
+7. Repeat until the server returns `completed` or `failed`.
+8. Return the run summary to the operator.
 
 ### MCP
 
@@ -88,9 +89,9 @@ The run token authorizes `/session/*` requests and the control token authorizes
 ## Tokens
 
 The platform user generates a REST API key in the UI after GitHub OAuth login.
-Use it only to create runs.
+Use it for task label discovery and run creation.
 
-- `api_key`: user API key for `/client/runs/start`; send as `Authorization: Bearer <api_key>`.
+- `api_key`: user API key for `/client/tasks/catalog/labels` and `/client/runs/start`; send as `Authorization: Bearer <api_key>`.
 - `token`: run token for `/session/*`; send as `Authorization: Bearer <token>`.
 - `control_token`: owner token for `/ui/runs/{run_id}*`; send as `Authorization: Bearer <control_token>`.
 
@@ -98,6 +99,30 @@ Store raw tokens only in memory or secure local runtime state. Log token hints,
 run IDs, and session IDs.
 
 ## Create Or Claim A Run
+
+### Discover Task Labels
+
+When you have an API key, fetch the available public task labels:
+
+```http
+GET /client/tasks/catalog/labels
+Authorization: Bearer <api_key>
+```
+
+Response:
+
+```json
+{
+  "tasks": [
+    {"label": "D01"},
+    {"label": "D02"}
+  ]
+}
+```
+
+Use each `label` value as the `task` field for `/client/runs/start`. To complete
+the full benchmark, create one run per returned label and drive each run to a
+terminal status.
 
 ### Claim A Website Run
 
@@ -306,11 +331,15 @@ def get_json(client, path, token):
     return r.json()
 
 with httpx.Client(base_url=BASE, timeout=TIMEOUT) as client:
+    api_key = "<api_key_from_ui>"
+    catalog = get_json(client, "/client/tasks/catalog/labels", api_key)["tasks"]
+    public_task_label = catalog[0]["label"]
+
     run = post_json(client, "/client/runs/start", {
-        "task": "<public_task_label>",
+        "task": public_task_label,
         "mode": "agent",
         "client": {"name": "external_agent", "version": "1.0"},
-    }, token="<api_key_from_ui>")
+    }, token=api_key)
 
     token = run["token"]
     sid = post_json(client, "/session/register", {}, token)["session_id"]


### PR DESCRIPTION
Adds the labels-only task catalog to the client/API-key surface so external agents can discover run labels before calling /client/runs/start.

Changes:
- Add GET /client/tasks/catalog/labels using the same API-key resolver as /client/runs/start.
- Return labels only, preserving task execution and internal task metadata boundaries.
- Update skill.md so agents fetch labels and can create one run per returned task label.
- Update web/architecture docs and focused REST tests.

Business behavior:
- Run creation, task resolution, session lifecycle, tools, scoring, and existing UI routes are unchanged.
- Existing /ui/tasks/catalog* routes keep their current GitHub UI auth behavior.

Verification:
- pytest bench/tests/api/test_rest_run_identity.py bench/tests/test_server_web_ui.py -q: 19 passed
- pytest bench/tests/test_run_catalog.py bench/tests/test_server_web_ui.py -q: 11 passed
- git diff --check: passed
- codex exec review --uncommitted: no material findings