### PR TITLE
Show only raw skill URL in New Run

### DIFF
--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -424,11 +424,11 @@
 
   function renderApiKeyModalBody(status) {
     var created = status && status.created_at ? formatTimestamp(status.created_at * 1000) : '';
-    var skillUrl = agentSkillUrl();
+    var rawSkillUrl = agentSkillRawUrl();
     var body =
       '<section class="info-section">' +
         '<h3>External REST Access</h3>' +
-        '<p class="detail-empty-note">Use this key as <code>Authorization: Bearer &lt;api_key&gt;</code> when creating runs through <code>/client/runs/start</code>. The raw key is shown once after generation. See the <a href="' + skillUrl + '" target="_blank" rel="noreferrer">REST agent skill</a> for the full platform workflow.</p>' +
+        '<p class="detail-empty-note">Use this key as <code>Authorization: Bearer &lt;api_key&gt;</code> when creating runs through <code>/client/runs/start</code>. The raw key is shown once after generation. Read <a href="' + rawSkillUrl + '" target="_blank" rel="noreferrer">skill.md</a> for the full platform workflow.</p>' +
         (status && status.has_key
           ? '<div class="info-grid">' +
               metaItem('Current Key', status.key_hint ? status.key_hint + '...' : 'Active') +
@@ -446,10 +446,6 @@
     if (generate) generate.addEventListener('click', rotateApiKey);
     var revoke = document.getElementById('api-key-revoke-btn');
     if (revoke) revoke.addEventListener('click', revokeApiKey);
-  }
-
-  function agentSkillUrl() {
-    return window.location.origin + '/skills/quanttutorbench-rest-agent';
   }
 
   function agentSkillRawUrl() {
@@ -481,7 +477,7 @@
             '<h3>Agent Prompt</h3>' +
             '<textarea id="api-key-agent-prompt" class="run-agent-prompt-text api-key-agent-prompt" readonly spellcheck="false">' + escapeHtml(prompt) + '</textarea>' +
             '<button class="btn btn-small run-copy-btn" id="api-key-copy-btn" type="button">Copy Prompt</button>' +
-            '<p class="detail-empty-note">The prompt includes the full REST API key, the skill URL, and a curl command for loading the skill file.</p>';
+            '<p class="detail-empty-note">The prompt includes the full REST API key, raw skill URL, and benchmark base URL.</p>';
           var copy = document.getElementById('api-key-copy-btn');
           if (copy) {
             copy.addEventListener('click', function () {
@@ -799,14 +795,11 @@
               '</div>' +
             '</div>' +
             '<div class="run-agent-skill-url">' +
-              '<span>Skill URL</span>' +
-              '<code>' + escapeHtml(agentSkillUrl()) + '</code>' +
               '<span>Raw Skill URL</span>' +
               '<code>' + escapeHtml(agentSkillRawUrl()) + '</code>' +
             '</div>' +
             '<div class="run-agent-api-actions">' +
               '<button class="btn btn-primary" id="run-open-api-key-prompt" type="button">Open API Key Prompt</button>' +
-              '<a class="btn btn-secondary" href="' + escapeHtml(agentSkillUrl()) + '" target="_blank" rel="noreferrer">Open Skill</a>' +
             '</div>' +
           '</section>' +
         '</div>' +

--- a/bench/server/web/static/js/run-agent.js
+++ b/bench/server/web/static/js/run-agent.js
@@ -2,7 +2,7 @@
  * run-agent.js — "My Agent" flow for the Run page.
  *
  * 1. Generate a REST API key for the current reviewer.
- * 2. Render a copyable prompt with the REST skill URL, curl command, and key.
+ * 2. Render a copyable prompt with the raw skill URL and key.
  * 3. Poll active runs when this module receives one from a server response.
  * 4. On completed → show link to Human Review.
  */
@@ -99,10 +99,6 @@
     return window.location.origin + path;
   }
 
-  function _skillPageUrl() {
-    return _absoluteUrl('/skills/quanttutorbench-rest-agent');
-  }
-
   function _skillRawUrl() {
     return _absoluteUrl('/skill.md');
   }
@@ -186,7 +182,6 @@
     var apiKey = options.apiKey || '';
     var loading = !!options.loading;
     var error = options.error || '';
-    var skillUrl = _skillPageUrl();
     var rawSkillUrl = _skillRawUrl();
     var prompt = apiKey
       ? _buildAgentPrompt(apiKey)
@@ -201,7 +196,7 @@
           '<div class="page-title-wrap">' +
             '<p class="eyebrow">Run · My Agent</p>' +
             '<h1>Connect your agent to the benchmark.</h1>' +
-            '<p class="subtitle">Generate a copyable prompt with the REST skill URL and your API key.</p>' +
+            '<p class="subtitle">Generate a copyable prompt with the raw skill URL and your API key.</p>' +
           '</div>' +
         '</header>' +
         '<div class="run-agent-prompt-panel">' +
@@ -215,15 +210,12 @@
             '</div>' +
             '<textarea id="myagent-prompt-text" class="run-agent-prompt-text" readonly spellcheck="false">' + escapeHtml(prompt) + '</textarea>' +
             '<div class="run-agent-skill-url">' +
-              '<span>Skill URL</span>' +
-              '<code>' + escapeHtml(skillUrl) + '</code>' +
               '<span>Raw Skill URL</span>' +
               '<code>' + escapeHtml(rawSkillUrl) + '</code>' +
             '</div>' +
             '<div class="run-agent-api-actions">' +
               '<button class="btn btn-primary" id="myagent-generate-prompt-btn" type="button"' + generateDisabled + '>' + escapeHtml(generateText) + '</button>' +
               '<button class="btn btn-secondary" id="myagent-copy-prompt-btn" type="button"' + copyDisabled + '>Copy Prompt</button>' +
-              '<a class="btn btn-secondary" href="' + escapeHtml(skillUrl) + '" target="_blank" rel="noreferrer">Open Skill</a>' +
             '</div>' +
             '<div id="myagent-error" class="run-error"' + (error ? '' : ' style="display:none;"') + '>' + escapeHtml(error) + '</div>' +
           '</section>' +

--- a/bench/server/web/templates/index.html
+++ b/bench/server/web/templates/index.html
@@ -29,8 +29,8 @@
   <script src="/static/js/render.js?v=20260421a"></script>
   <script src="/static/js/chat.js?v=20260421a"></script>
   <script src="/static/js/tools.js?v=20260421a"></script>
-  <script src="/static/js/run-agent.js?v=20260430g"></script>
+  <script src="/static/js/run-agent.js?v=20260501a"></script>
   <script src="/static/js/flow-demo.js?v=20260430g"></script>
-  <script src="/static/js/app.js?v=20260430g"></script>
+  <script src="/static/js/app.js?v=20260501a"></script>
 </body>
 </html>


### PR DESCRIPTION
Removes the HTML skill-page URL from the New Run prompt UI and API-key prompt copy. The UI now points users to /skill.md only.

Changes:
- Remove the visible Skill URL row and Open Skill button from New Run.
- Point API-key modal copy at /skill.md.
- Bump app.js and run-agent.js query strings in the UI shell.

Business behavior:
- Backend routes remain unchanged.
- /skills/quanttutorbench-rest-agent remains available for compatibility.
- Run creation, sessions, tools, and scoring are unchanged.

Verification:
- node --check bench/server/web/static/js/app.js
- node --check bench/server/web/static/js/run-agent.js
- pytest bench/tests/test_server_web_ui.py bench/tests/test_vercel_frontend_preview.py -q: 13 passed
- git diff --check: passed
- Vercel preview build succeeded
- Built Vercel assets contain no /skills/quanttutorbench-rest-agent, Open Skill, or stale curl-command text
- codex exec review --uncommitted: UI edits parse cleanly; untracked local review/label artifacts kept out of commit