### PR TITLE
Fix session flow run detail links

### DIFF
--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -2438,6 +2438,16 @@
     });
   }
 
+  function showRunDetail(runId) {
+    state.activeSessionId = null;
+    setAppDetailMode(false);
+    if (window.QTB && typeof window.QTB.renderRunMonitorPage === 'function') {
+      window.QTB.renderRunMonitorPage(app, runId);
+      return;
+    }
+    renderError('Run monitor unavailable', new Error('run-agent.js not loaded'));
+  }
+
   function showResultDetail(sessionId) {
     state.activeSessionId = sessionId;
     setAppDetailMode(true);
@@ -2478,6 +2488,11 @@
 
     if (route === '/run') {
       showRun();
+      return;
+    }
+
+    if (route.indexOf('/run/') === 0) {
+      showRunDetail(decodeURIComponent(route.slice('/run/'.length)));
       return;
     }
 

--- a/bench/server/web/static/js/flow-demo.js
+++ b/bench/server/web/static/js/flow-demo.js
@@ -22,11 +22,7 @@
   var _pollTimer = null;
   var state = {
     runs: [],
-    loading: true,
-    error: '',
-    lastUpdated: '',
-    statusFilter: 'all',
-    search: ''
+    error: ''
   };
 
   function authFetch(url, options) {
@@ -73,13 +69,10 @@
       })
       .then(function (payload) {
         state.runs = sortRuns(payload.runs || []);
-        state.loading = false;
         state.error = '';
-        state.lastUpdated = new Date().toISOString();
         render();
       })
       .catch(function (err) {
-        state.loading = false;
         state.error = err && err.message ? err.message : String(err);
         render();
       });
@@ -100,29 +93,13 @@
   function bind() {
     var refreshBtn = document.getElementById('flow-refresh-btn');
     if (refreshBtn) refreshBtn.addEventListener('click', refresh);
-
-    var status = document.getElementById('flow-status-filter');
-    if (status) {
-      status.value = state.statusFilter;
-      status.addEventListener('change', function (event) {
-        state.statusFilter = event.target.value || 'all';
-        render();
-      });
-    }
-
-    var search = document.getElementById('flow-search');
-    if (search) {
-      search.value = state.search;
-      search.addEventListener('input', function (event) {
-        state.search = String(event.target.value || '').trim().toLowerCase();
-        render();
-      });
-    }
   }
 
   function pageHtml() {
-    var statuses = sortedUnique(state.runs.map(function (run) { return displayStatus(run); }));
-    var visible = filteredRuns();
+    var activeRun = currentActiveRun();
+    if (!activeRun && !state.error) {
+      return '<section class="page flow-demo flow-demo-blank"></section>';
+    }
     return '' +
       '<section class="page flow-demo">' +
         '<header class="page-header">' +
@@ -135,83 +112,28 @@
             '<button class="btn btn-secondary" id="flow-refresh-btn" type="button">Refresh</button>' +
           '</div>' +
         '</header>' +
-        summaryHtml() +
         statusBannerHtml() +
-        filterHtml(statuses) +
-        '<div class="results-meta">' +
-          '<div class="results-count">' + escapeHtml(String(visible.length)) + ' run(s) shown</div>' +
-        '</div>' +
-        (visible.length
-          ? '<div class="results-grid flow-results-grid">' + visible.map(runCardHtml).join('') + '</div>'
-          : emptyHtml()) +
+        (activeRun
+          ? '<div class="results-grid flow-results-grid">' + runCardHtml(activeRun) + '</div>'
+          : '') +
       '</section>';
-  }
-
-  function summaryHtml() {
-    var live = state.runs.filter(isLiveRun).length;
-    var completed = state.runs.filter(function (run) { return run.status === 'completed'; }).length;
-    var failed = state.runs.filter(function (run) { return run.status === 'failed'; }).length;
-    var updated = state.lastUpdated ? formatTime(state.lastUpdated) : 'pending';
-    return '' +
-      '<div class="summary-strip flow-summary-strip">' +
-        summaryPill('Live', String(live)) +
-        summaryPill('Completed', String(completed)) +
-        summaryPill('Failed', String(failed)) +
-        summaryPill('Updated', updated) +
-      '</div>';
-  }
-
-  function summaryPill(label, value) {
-    return '<span class="summary-pill"><strong>' + escapeHtml(label) + '</strong> ' + escapeHtml(value) + '</span>';
   }
 
   function statusBannerHtml() {
     if (state.error) {
       return '<div class="flow-fail-banner"><strong>Error.</strong> ' + escapeHtml(state.error) + '</div>';
     }
-    if (state.loading) {
-      return '<div class="flow-now-banner">Loading live run state.</div>';
-    }
-    if (!state.runs.length) {
-      return '<div class="flow-now-banner">Waiting for benchmark runs.</div>';
-    }
     return '';
   }
 
-  function filterHtml(statuses) {
-    var options = ['<option value="all">All</option>'].concat(statuses.map(function (status) {
-      var selected = status === state.statusFilter ? ' selected' : '';
-      return '<option value="' + escapeHtml(status) + '"' + selected + '>' + escapeHtml(statusLabel(status)) + '</option>';
-    }));
-    return '' +
-      '<section class="panel filter-bar">' +
-        '<label class="filter-field">' +
-          '<span class="filter-label">Status</span>' +
-          '<select id="flow-status-filter" class="filter-select">' + options.join('') + '</select>' +
-        '</label>' +
-        '<label class="filter-field">' +
-          '<span class="filter-label">Search</span>' +
-          '<input id="flow-search" class="filter-input" type="search" placeholder="task, run_id, session_id..." value="' + escapeHtml(state.search) + '">' +
-        '</label>' +
-      '</section>';
-  }
-
-  function filteredRuns() {
-    return state.runs.filter(function (run) {
-      var status = displayStatus(run);
-      if (state.statusFilter !== 'all' && status !== state.statusFilter) return false;
-      if (state.search) {
-        var haystack = [
-          run.run_id,
-          run.session_id,
-          run.public_task_label,
-          run.status,
-          run.observer_status
-        ].join(' ').toLowerCase();
-        if (haystack.indexOf(state.search) === -1) return false;
+  function currentActiveRun() {
+    for (var i = 0; i < state.runs.length; i += 1) {
+      var run = state.runs[i];
+      if (run.status === 'active' && displayStatus(run) === 'active') {
+        return run;
       }
-      return true;
-    });
+    }
+    return null;
   }
 
   function runCardHtml(run) {
@@ -301,11 +223,6 @@
     }).join('') + '</div>';
   }
 
-  function emptyHtml() {
-    if (state.runs.length) return '<div class="empty-state"><p>No runs match the current filters.</p></div>';
-    return '<div class="empty-state"><p>Waiting for benchmark runs.</p></div>';
-  }
-
   function emptyConversationText(run) {
     var status = displayStatus(run);
     if (status === 'waiting') return 'Run created.';
@@ -323,11 +240,6 @@
     if (status === 'active') return 'Tool calls will appear as the agent works.';
     if (status === 'completed') return 'Archived tool calls are available in Human Review.';
     return statusLabel(status || 'pending');
-  }
-
-  function isLiveRun(run) {
-    if (run.is_live === true) return true;
-    return LIVE_STATUSES[run.status] && displayStatus(run) !== 'stale';
   }
 
   function displayStatus(run) {
@@ -354,15 +266,6 @@
       cancelled: 'Cancelled'
     };
     return labels[status] || titleCase(status || '');
-  }
-
-  function sortedUnique(values) {
-    var map = {};
-    values.forEach(function (value) {
-      if (value == null || value === '') return;
-      map[String(value)] = true;
-    });
-    return Object.keys(map).sort();
   }
 
   function titleCase(value) {

--- a/bench/server/web/static/js/flow-demo.js
+++ b/bench/server/web/static/js/flow-demo.js
@@ -218,9 +218,7 @@
     var status = displayStatus(run);
     var conversation = run.conversation || [];
     var logs = run.recent_tool_logs || [];
-    var href = run.status === 'completed' && run.session_id
-      ? '#/review/' + encodeURIComponent(run.session_id)
-      : '';
+    var href = runHref(run, status);
     var tag = href ? 'a' : 'article';
     var open = href ? ' href="' + href + '"' : '';
 
@@ -250,6 +248,16 @@
         '</div>' +
         previewHtml(run) +
       '</' + tag + '>';
+  }
+
+  function runHref(run, status) {
+    if (status === 'completed' && run.session_id) {
+      return '#/review/' + encodeURIComponent(run.session_id);
+    }
+    if (LIVE_STATUSES[status] && run.run_id) {
+      return '#/run/' + encodeURIComponent(run.run_id);
+    }
+    return '';
   }
 
   function previewHtml(run) {

--- a/bench/server/web/static/js/run-agent.js
+++ b/bench/server/web/static/js/run-agent.js
@@ -77,10 +77,7 @@
   // ── Main render ──
 
   window.QTB.renderMyAgentPage = function (app, state, payload) {
-    if (_runId) {
-      _renderMonitorPage(app);
-      return;
-    }
+    _cleanup();
 
     _renderPromptPage(app, {loading: true});
     _loadApiKeyStatus()
@@ -94,6 +91,25 @@
       });
   };
 
+  window.QTB.renderRunMonitorPage = function (app, runId) {
+    _cleanup();
+    _runId = String(runId || '').trim();
+    if (!_runId) {
+      app.innerHTML =
+        '<section class="error-state">' +
+          '<p class="eyebrow">Error</p>' +
+          '<h1>Run unavailable</h1>' +
+          '<p>Missing run id.</p>' +
+        '</section>';
+      return;
+    }
+    _renderMonitorPage(app);
+  };
+
+  window.addEventListener('hashchange', function () {
+    if (location.hash.indexOf('#/run/') !== 0) _cleanup();
+  });
+
   function _absoluteUrl(path) {
     if (/^https?:\/\//i.test(path)) return path;
     return window.location.origin + path;
@@ -106,7 +122,9 @@
   function _jsonResponse(response) {
     return response.json().then(function (payload) {
       if (!response.ok) {
-        throw new Error(payload.error || ('HTTP ' + response.status));
+        var error = new Error(payload.error || ('HTTP ' + response.status));
+        error.permanent = response.status === 404;
+        throw error;
       }
       return payload;
     });
@@ -281,7 +299,7 @@
   function _renderMonitorPage(app, createData) {
     var token = (createData && createData.token) || '';
     var mcp_url = (createData && createData.mcp_url) || '';
-    var label = (createData && createData.public_task_label) || '';
+    var label = (createData && createData.public_task_label) || _shortId(_runId);
     var launchCmd = (createData && createData.launch_command) || '';
 
     app.innerHTML =
@@ -318,7 +336,7 @@
               '<code class="run-connect-cmd">' + escapeHtml(launchCmd) + '</code>' +
               '<button class="btn btn-small run-copy-btn" data-copy="' + escapeHtml(launchCmd) + '">Copy</button>' +
             '</div>'
-          ) : '') +
+          ) : '<p class="detail-empty-note">Waiting for agent connection details.</p>') +
         '</div>' +
 
         // Live conversation + tools grid
@@ -358,7 +376,7 @@
       cancelBtn.addEventListener('click', function () {
         if (!_runId) return;
         cancelBtn.disabled = true;
-        _ownerFetch('/ui/runs/' + _runId + '/cancel', {method: 'POST'})
+        _ownerFetch('/ui/runs/' + encodeURIComponent(_runId) + '/cancel', {method: 'POST'})
           .then(function () {
             _cleanup();
             _updateStatus('cancelled');
@@ -375,37 +393,31 @@
 
   function _startStatusPoll() {
     if (_pollTimer) clearInterval(_pollTimer);
-    _pollTimer = setInterval(function () {
-      if (!_runId) return;
-      _ownerFetch('/ui/runs/' + _runId)
-        .then(function (r) {
-          if (r.status === 401) {
-            _stopPolling();
-            _showTokenLostMessage();
-            return null;
-          }
-          return r.json();
-        })
-        .then(function (data) {
-          if (data == null) return;
-          _updateStatus(data.status);
-          if (data.status === 'active') {
-            _startLivePoll();
+    _pollRunStatus();
+    _pollTimer = setInterval(_pollRunStatus, 3000);
+  }
+
+  function _pollRunStatus() {
+    if (!_runId) return;
+    _ownerFetch('/ui/runs/' + encodeURIComponent(_runId))
+      .then(_runJsonResponse)
+      .then(function (data) {
+        if (data == null) return;
+        _updateRunHeader(data);
+        _updateStatus(data.status);
+        if (data.status === 'active') {
+          _startLivePoll();
+          if (_pollTimer) {
             clearInterval(_pollTimer);
             _pollTimer = null;
           }
-          if (data.status === 'completed' || data.status === 'failed' || data.status === 'cancelled') {
-            _stopPolling();
-            if (data.status === 'completed' && data.session_id) {
-              var link = document.getElementById('myagent-results-link');
-              if (link) {
-                link.href = '#/review/' + data.session_id;
-                link.style.display = 'inline-block';
-              }
-            }
-          }
-        });
-    }, 3000);
+        }
+        if (data.status === 'completed' || data.status === 'failed' || data.status === 'cancelled') {
+          _stopPolling();
+          _showTerminalState(data);
+        }
+      })
+      .catch(_showRunLoadError);
   }
 
   function _startLivePoll() {
@@ -416,42 +428,32 @@
     if (liveGrid) liveGrid.style.display = 'grid';
 
     if (_livePollTimer) clearInterval(_livePollTimer);
-    _livePollTimer = setInterval(function () {
-      if (!_runId) return;
-      _ownerFetch('/ui/runs/' + _runId + '/live')
-        .then(function (r) {
-          if (r.status === 401) {
-            _stopPolling();
-            _showTokenLostMessage();
-            return null;
-          }
-          return r.json();
-        })
-        .then(function (data) {
-          if (data == null) return;
-          _updateStatus(data.run_status);
-          if (data.turn != null) {
-            var turnPill = document.getElementById('myagent-turn-pill');
-            if (turnPill) turnPill.textContent = 'Turn ' + data.turn;
-          }
-          _renderLiveData(data.conversation || [], data.recent_tool_logs || []);
+    _pollLiveData();
+    _livePollTimer = setInterval(_pollLiveData, 2000);
+  }
 
-          if (data.run_status === 'completed' || data.run_status === 'failed' || data.run_status === 'cancelled') {
-            _stopPolling();
-            // Show review link for completed runs
-            if (data.run_status === 'completed' && data.session_id) {
-              var link = document.getElementById('myagent-results-link');
-              if (link) {
-                link.href = '#/review/' + data.session_id;
-                link.style.display = 'inline-block';
-              }
-            }
-            // Hide cancel button on terminal state
-            var cancelBtn = document.getElementById('myagent-cancel-btn');
-            if (cancelBtn) cancelBtn.style.display = 'none';
-          }
-        });
-    }, 2000);
+  function _pollLiveData() {
+    if (!_runId) return;
+    _ownerFetch('/ui/runs/' + encodeURIComponent(_runId) + '/live')
+      .then(_runJsonResponse)
+      .then(function (data) {
+        if (data == null) return;
+        _updateStatus(data.run_status);
+        if (data.turn != null) {
+          var turnPill = document.getElementById('myagent-turn-pill');
+          if (turnPill) turnPill.textContent = 'Turn ' + data.turn;
+        }
+        _renderLiveData(data.conversation || [], data.recent_tool_logs || []);
+
+        if (data.run_status === 'completed' || data.run_status === 'failed' || data.run_status === 'cancelled') {
+          _stopPolling();
+          _showTerminalState({
+            status: data.run_status,
+            session_id: data.session_id
+          });
+        }
+      })
+      .catch(_showRunLoadError);
   }
 
   function _stopPolling() {
@@ -475,6 +477,50 @@
     }
   }
 
+  function _runJsonResponse(response) {
+    if (response.status === 401 || response.status === 403) {
+      _stopPolling();
+      _showTokenLostMessage();
+      return null;
+    }
+    return response.json().then(function (payload) {
+      if (!response.ok) {
+        throw new Error(payload.error || ('HTTP ' + response.status));
+      }
+      return payload;
+    });
+  }
+
+  function _updateRunHeader(data) {
+    var label = document.getElementById('myagent-label');
+    if (!label) return;
+    label.textContent = data.public_task_label || data.task_id || _shortId(data.run_id || _runId);
+  }
+
+  function _showTerminalState(data) {
+    if (data.status === 'completed' && data.session_id) {
+      var link = document.getElementById('myagent-results-link');
+      if (link) {
+        link.href = '#/review/' + encodeURIComponent(data.session_id);
+        link.style.display = 'inline-block';
+      }
+    }
+    var cancelBtn = document.getElementById('myagent-cancel-btn');
+    if (cancelBtn) cancelBtn.style.display = 'none';
+  }
+
+  function _showRunLoadError(error) {
+    if (!_runId) return;
+    if (error && error.permanent) _stopPolling();
+    var connectPanel = document.getElementById('myagent-connect-panel');
+    if (connectPanel) {
+      connectPanel.innerHTML =
+        '<h2>' + (error && error.permanent ? 'Run unavailable' : 'Connection retrying') + '</h2>' +
+        '<p class="detail-empty-note">' + escapeHtml(error && error.message ? error.message : String(error || 'Unable to load run.')) + '</p>';
+    }
+    _updateStatus(error && error.permanent ? 'failed' : 'retrying');
+  }
+
   function _updateStatus(status) {
     var pill = document.getElementById('myagent-status-pill');
     if (!pill) return;
@@ -482,6 +528,7 @@
       waiting: '● Waiting for agent',
       claimed: '● Agent connected',
       active: '● Running',
+      retrying: '● Retrying',
       completed: '✓ Completed',
       failed: '✗ Failed',
       cancelled: '— Cancelled'
@@ -611,6 +658,10 @@
     _lastConvLen = 0;
     _lastToolLen = 0;
     _lastSendLen = 0;
+  }
+
+  function _shortId(value) {
+    return String(value || '').slice(0, 8) || '-';
   }
 
 })();

--- a/bench/server/web/templates/index.html
+++ b/bench/server/web/templates/index.html
@@ -29,8 +29,8 @@
   <script src="/static/js/render.js?v=20260421a"></script>
   <script src="/static/js/chat.js?v=20260421a"></script>
   <script src="/static/js/tools.js?v=20260421a"></script>
-  <script src="/static/js/run-agent.js?v=20260501a"></script>
-  <script src="/static/js/flow-demo.js?v=20260430g"></script>
-  <script src="/static/js/app.js?v=20260501a"></script>
+  <script src="/static/js/run-agent.js?v=20260501b"></script>
+  <script src="/static/js/flow-demo.js?v=20260501b"></script>
+  <script src="/static/js/app.js?v=20260501b"></script>
 </body>
 </html>

--- a/bench/server/web/ui_app.py
+++ b/bench/server/web/ui_app.py
@@ -702,7 +702,7 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse({"error": "Run service not initialized"}, 503)
 
         run_id = request.path_params["run_id"]
-        user = auth.get_current_user(request) if auth.enabled else None
+        user = auth.get_current_user(request)
         try:
             run = _run_access_from_cookie(run_service, run_id, user)
         except ValueError:
@@ -724,7 +724,7 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse({"error": "Run service not initialized"}, 503)
 
         run_id = request.path_params["run_id"]
-        user = auth.get_current_user(request) if auth.enabled else None
+        user = auth.get_current_user(request)
         try:
             run = _run_access_from_cookie(run_service, run_id, user)
         except ValueError:
@@ -875,7 +875,7 @@ def ui_routes(manager) -> list[Route]:
             return JSONResponse({"error": "Run service not initialized"}, 503)
 
         run_id = request.path_params["run_id"]
-        user = auth.get_current_user(request) if auth.enabled else None
+        user = auth.get_current_user(request)
         try:
             run = _run_access_from_cookie(run_service, run_id, user)
         except ValueError:

--- a/bench/tests/test_run_control_token.py
+++ b/bench/tests/test_run_control_token.py
@@ -1,11 +1,13 @@
 """Tests for Step 4: control_token auth on /ui/runs/* endpoints."""
 
 import json
+import os
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
@@ -66,47 +68,51 @@ class ControlTokenTests(unittest.TestCase):
             self.assertTrue(body["control_token"].startswith("qtc_"))
             self.assertTrue(body["token"].startswith("qtb_"))
 
-    def test_get_run_without_control_token_returns_401(self):
+    def test_get_run_without_cookie_or_control_token_returns_401_when_auth_enabled(self):
         with tempfile.TemporaryDirectory() as tmp:
             _write_task(Path(tmp))
-            client, _ = _build_client(Path(tmp))
-            body = client.post("/ui/runs", json={"task": "D01"}).json()
-            r = client.get(f"/ui/runs/{body['run_id']}")
+            client, manager = _build_client(Path(tmp))
+            assignment, _, _ = manager._run_service.create_run("D01")
+            with patch.dict(os.environ, {"QTB_AUTH_MODE": "github"}):
+                r = client.get(f"/ui/runs/{assignment.run_id}")
             self.assertEqual(r.status_code, 401)
 
     def test_get_run_with_wrong_control_token_returns_401(self):
         with tempfile.TemporaryDirectory() as tmp:
             _write_task(Path(tmp))
-            client, _ = _build_client(Path(tmp))
-            body = client.post("/ui/runs", json={"task": "D01"}).json()
-            r = client.get(
-                f"/ui/runs/{body['run_id']}",
-                headers={"Authorization": "Bearer qtc_not_real"},
-            )
+            client, manager = _build_client(Path(tmp))
+            assignment, _, _ = manager._run_service.create_run("D01")
+            with patch.dict(os.environ, {"QTB_AUTH_MODE": "github"}):
+                r = client.get(
+                    f"/ui/runs/{assignment.run_id}",
+                    headers={"Authorization": "Bearer qtc_not_real"},
+                )
             self.assertEqual(r.status_code, 401)
 
     def test_get_run_with_correct_control_token_succeeds(self):
         with tempfile.TemporaryDirectory() as tmp:
             _write_task(Path(tmp))
-            client, _ = _build_client(Path(tmp))
-            body = client.post("/ui/runs", json={"task": "D01"}).json()
-            r = client.get(
-                f"/ui/runs/{body['run_id']}",
-                headers={"Authorization": f"Bearer {body['control_token']}"},
-            )
+            client, manager = _build_client(Path(tmp))
+            assignment, _, control_token = manager._run_service.create_run("D01")
+            with patch.dict(os.environ, {"QTB_AUTH_MODE": "github"}):
+                r = client.get(
+                    f"/ui/runs/{assignment.run_id}",
+                    headers={"Authorization": f"Bearer {control_token}"},
+                )
             self.assertEqual(r.status_code, 200)
-            self.assertEqual(r.json()["run_id"], body["run_id"])
+            self.assertEqual(r.json()["run_id"], assignment.run_id)
 
     def test_run_token_does_not_authorize_control_endpoint(self):
         with tempfile.TemporaryDirectory() as tmp:
             _write_task(Path(tmp))
-            client, _ = _build_client(Path(tmp))
-            body = client.post("/ui/runs", json={"task": "D01"}).json()
+            client, manager = _build_client(Path(tmp))
+            assignment, run_token, _ = manager._run_service.create_run("D01")
             # Use the run_token (qtb_) against a control endpoint — must fail.
-            r = client.get(
-                f"/ui/runs/{body['run_id']}",
-                headers={"Authorization": f"Bearer {body['token']}"},
-            )
+            with patch.dict(os.environ, {"QTB_AUTH_MODE": "github"}):
+                r = client.get(
+                    f"/ui/runs/{assignment.run_id}",
+                    headers={"Authorization": f"Bearer {run_token}"},
+                )
             self.assertEqual(r.status_code, 401)
 
     def test_live_observer_lists_active_run_from_public_endpoint(self):
@@ -148,6 +154,29 @@ class ControlTokenTests(unittest.TestCase):
                 "run_lean_backtest",
             )
 
+    def test_local_dev_can_open_live_run_detail_without_control_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_task(Path(tmp))
+            client, manager = _build_client(Path(tmp))
+            assignment, _, _ = manager._run_service.create_and_claim("D01")
+            manager._run_service.bind_session(assignment.run_id, "session-1")
+            manager._sessions["session-1"] = SimpleNamespace(
+                phase=SimpleNamespace(value="in_session"),
+                session=SimpleNamespace(
+                    conversation=[{"role": "user", "content": "opening"}],
+                    turn=1,
+                ),
+                proxy=SimpleNamespace(get_logs=lambda: []),
+            )
+
+            status = client.get(f"/ui/runs/{assignment.run_id}")
+            live = client.get(f"/ui/runs/{assignment.run_id}/live")
+
+            self.assertEqual(status.status_code, 200)
+            self.assertEqual(live.status_code, 200)
+            self.assertEqual(status.json()["run_id"], assignment.run_id)
+            self.assertEqual(live.json()["conversation"][0]["content"], "opening")
+
     def test_live_observer_marks_missing_active_session_stale(self):
         with tempfile.TemporaryDirectory() as tmp:
             _write_task(Path(tmp))
@@ -164,14 +193,16 @@ class ControlTokenTests(unittest.TestCase):
     def test_cancel_requires_control_token(self):
         with tempfile.TemporaryDirectory() as tmp:
             _write_task(Path(tmp))
-            client, _ = _build_client(Path(tmp))
-            body = client.post("/ui/runs", json={"task": "D01"}).json()
-            r = client.post(f"/ui/runs/{body['run_id']}/cancel")
+            client, manager = _build_client(Path(tmp))
+            assignment, _, control_token = manager._run_service.create_run("D01")
+            with patch.dict(os.environ, {"QTB_AUTH_MODE": "github"}):
+                r = client.post(f"/ui/runs/{assignment.run_id}/cancel")
             self.assertEqual(r.status_code, 401)
-            r = client.post(
-                f"/ui/runs/{body['run_id']}/cancel",
-                headers={"Authorization": f"Bearer {body['control_token']}"},
-            )
+            with patch.dict(os.environ, {"QTB_AUTH_MODE": "github"}):
+                r = client.post(
+                    f"/ui/runs/{assignment.run_id}/cancel",
+                    headers={"Authorization": f"Bearer {control_token}"},
+                )
             self.assertEqual(r.status_code, 200)
 
     def test_store_find_by_token_hash_distinguishes_types(self):

--- a/bench/tests/test_server_web_ui.py
+++ b/bench/tests/test_server_web_ui.py
@@ -872,10 +872,14 @@ class HttpAppSmokeTests(unittest.TestCase):
 
         index_response = client.get("/")
         script_response = client.get("/static/js/app.js")
+        flow_response = client.get("/static/js/flow-demo.js")
+        run_agent_response = client.get("/static/js/run-agent.js")
         render_response = client.get("/static/js/render.js")
 
         self.assertEqual(index_response.status_code, 200)
         self.assertEqual(script_response.status_code, 200)
+        self.assertEqual(flow_response.status_code, 200)
+        self.assertEqual(run_agent_response.status_code, 200)
         self.assertEqual(render_response.status_code, 200)
         review_response = client.get("/review")
         review_detail_response = client.get("/review/demo-bundle")
@@ -889,6 +893,10 @@ class HttpAppSmokeTests(unittest.TestCase):
         self.assertIn('href="#/review"', index_response.text)
         self.assertIn('data-route="review"', index_response.text)
         self.assertIn('data-route="run"', index_response.text)
+        self.assertIn("#/run/", flow_response.text)
+        self.assertIn("route.indexOf('/run/')", script_response.text)
+        self.assertIn("renderRunMonitorPage", run_agent_response.text)
+        self.assertIn("retrying", run_agent_response.text)
         self.assertIn("Isolated UI", index_response.text)
 
 


### PR DESCRIPTION
Closes #114

## Change
- Link Session Flow live run cards to #/run/{run_id}.
- Add SPA routing for per-run monitor pages.
- Reuse the existing run monitor replay for active conversation and tool detail.
- Keep monitor polling alive through transient fetch failures.
- Align local-dev per-run detail access with the existing local-dev live monitor.

## Verification
- node --check bench/server/web/static/js/flow-demo.js
- node --check bench/server/web/static/js/app.js
- node --check bench/server/web/static/js/run-agent.js
- pytest bench/tests/test_server_web_ui.py bench/tests/test_run_control_token.py bench/tests/test_run_owner_filtering.py -q
- git diff --check