### PR TITLE
Add client-scoped run control

### DIFF
--- a/bench/server/web/README.md
+++ b/bench/server/web/README.md
@@ -34,11 +34,17 @@ Current routes:
 - `GET /skills/quanttutorbench-rest-agent`
 - `GET /skills/quanttutorbench-rest-agent/raw`
 - `GET /client/tasks/catalog/labels`
+- `POST /client/runs/claim`
+- `POST /client/runs/start`
+- `GET /client/runs/active`
+- `POST /client/runs/{run_id}/cancel`
+- `POST /client/runs/{run_id}/trace`
 
 Run route scope:
 - `#/run` opens a copyable REST agent prompt directly.
 - The prompt surface generates a fresh REST API key through `/ui/api-key` and embeds a short Moltbook-style instruction, `/skill.md`, base URL, and key in a textarea.
-- External agents discover public labels through `/client/tasks/catalog/labels`, then create or claim runs through the REST skill workflow; hidden task metadata stays in the server/client execution context.
+- External agents discover public labels through `/client/tasks/catalog/labels`, create or claim runs through the REST skill workflow, list active owned runs through `/client/runs/active`, and cancel owned orphaned runs through `/client/runs/{run_id}/cancel`.
+- Hidden task metadata stays in the server/client execution context.
 - Session Flow owns run lifecycle browsing. Human Review owns archived session inspection.
 
 Task route scope:

--- a/bench/server/web/ui_app.py
+++ b/bench/server/web/ui_app.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from server.audit import record_event
 from server.auth import AuthService
 from server.quota import QuotaExceeded
+from server.run.models import TERMINAL_STATUSES
 from starlette.requests import Request
 from starlette.responses import (
     FileResponse,
@@ -142,6 +143,12 @@ def ui_routes(manager) -> list[Route]:
             return None
         except ValueError:
             raise
+
+    def _client_owner_id(user) -> str:
+        return str(user.user_id if user else "")
+
+    def _client_owns_run(run, user) -> bool:
+        return str(run.owner_user_id or "") == _client_owner_id(user)
 
     async def auth_login(request: Request):
         return await auth.login(request)
@@ -1018,6 +1025,66 @@ def ui_routes(manager) -> list[Route]:
             }
         )
 
+    async def client_list_active_runs(request: Request) -> JSONResponse:
+        """``GET /client/runs/active`` — list API-key-owned active runs."""
+        run_service = getattr(manager, "_run_service", None)
+        if run_service is None:
+            return JSONResponse({"error": "Run service not initialized"}, 503)
+
+        user, auth_err = auth.resolve_client_user(request)
+        if auth_err is not None:
+            return auth_err
+
+        runs = [
+            run
+            for run in run_service.list_runs(owner_user_id=_client_owner_id(user))
+            if run.status not in TERMINAL_STATUSES
+        ]
+        return JSONResponse(
+            {
+                "runs": [run.public_dict() for run in runs],
+                "count": len(runs),
+            }
+        )
+
+    async def client_cancel_run(request: Request) -> JSONResponse:
+        """``POST /client/runs/{run_id}/cancel`` — cancel an API-key-owned run."""
+        run_service = getattr(manager, "_run_service", None)
+        if run_service is None:
+            return JSONResponse({"error": "Run service not initialized"}, 503)
+
+        user, auth_err = auth.resolve_client_user(request)
+        if auth_err is not None:
+            return auth_err
+
+        run_id = request.path_params["run_id"]
+        run = run_service.get_run(run_id)
+        if run is None:
+            return JSONResponse({"error": "Run not found"}, 404)
+        if not _client_owns_run(run, user):
+            return JSONResponse({"error": "Run access denied"}, status_code=403)
+
+        try:
+            await manager.cancel_run(run_id)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, 400)
+        except Exception as exc:
+            logger.error("client_cancel_run %s failed: %s", run_id, exc, exc_info=True)
+            return JSONResponse({"error": f"Cancel failed: {exc}"}, 500)
+
+        run = run_service.get_run(run_id)
+        record_event(
+            manager.bench_root,
+            user,
+            "run.cancel",
+            request=request,
+            run_id=run_id,
+            session_id=run.session_id if run else "",
+            success=True,
+            payload={"source": "client"},
+        )
+        return JSONResponse(run.public_dict() if run else {"status": "cancelled"})
+
     async def client_upload_trace(request: Request) -> JSONResponse:
         """``POST /client/runs/{run_id}/trace`` — optional trace upload."""
         run_service = getattr(manager, "_run_service", None)
@@ -1116,5 +1183,7 @@ def ui_routes(manager) -> list[Route]:
         ),
         Route("/client/runs/claim", client_claim_run, methods=["POST"]),
         Route("/client/runs/start", client_start_run, methods=["POST"]),
+        Route("/client/runs/active", client_list_active_runs, methods=["GET"]),
+        Route("/client/runs/{run_id}/cancel", client_cancel_run, methods=["POST"]),
         Route("/client/runs/{run_id}/trace", client_upload_trace, methods=["POST"]),
     ]

--- a/bench/tests/api/test_rest_run_identity.py
+++ b/bench/tests/api/test_rest_run_identity.py
@@ -161,6 +161,104 @@ async def test_client_start_api_key_subject_to_user_quota(bench_root, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_client_active_runs_requires_api_key_when_auth_enabled(
+    bench_root, monkeypatch
+):
+    monkeypatch.setenv("QTB_AUTH_MODE", "github")
+    monkeypatch.delenv("QTB_CLIENT_API_KEYS", raising=False)
+    app = _make_app(bench_root)
+
+    resp = await _get_json(app, "/client/runs/active")
+
+    assert resp.status_code == 401
+    assert "client_api_key" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_client_active_runs_are_owner_scoped_and_token_safe(
+    bench_root, monkeypatch
+):
+    monkeypatch.setenv("QTB_AUTH_MODE", "github")
+    monkeypatch.setenv(
+        "QTB_CLIENT_API_KEYS",
+        "secret-alice=external:alice|alice,secret-bob=external:bob|bob",
+    )
+    app = _make_app(bench_root)
+    alice_headers = {"Authorization": "Bearer secret-alice"}
+    bob_headers = {"Authorization": "Bearer secret-bob"}
+
+    alice_run = await _post_json(
+        app, "/client/runs/start", {"task": "D01"}, alice_headers
+    )
+    bob_run = await _post_json(app, "/client/runs/start", {"task": "D02"}, bob_headers)
+    active = await _get_json(app, "/client/runs/active", alice_headers)
+
+    assert alice_run.status_code == 200
+    assert bob_run.status_code == 200
+    assert active.status_code == 200
+    payload = active.json()
+    assert payload["count"] == 1
+    assert [item["run_id"] for item in payload["runs"]] == [alice_run.json()["run_id"]]
+    assert {"token", "control_token", "task_id", "token_hash"}.isdisjoint(
+        payload["runs"][0]
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_cancel_run_is_owner_scoped_and_unblocks_quota(
+    bench_root, monkeypatch
+):
+    monkeypatch.setenv("QTB_AUTH_MODE", "github")
+    monkeypatch.setenv("QTB_MAX_ACTIVE_RUNS_PER_USER", "1")
+    monkeypatch.setenv(
+        "QTB_CLIENT_API_KEYS",
+        "secret-alice=external:alice|alice,secret-bob=external:bob|bob",
+    )
+    app = _make_app(bench_root)
+    alice_headers = {"Authorization": "Bearer secret-alice"}
+    bob_headers = {"Authorization": "Bearer secret-bob"}
+
+    first = await _post_json(app, "/client/runs/start", {"task": "D01"}, alice_headers)
+    blocked = await _post_json(
+        app, "/client/runs/start", {"task": "D02"}, alice_headers
+    )
+    run_id = first.json()["run_id"]
+    denied = await _post_json(app, f"/client/runs/{run_id}/cancel", {}, bob_headers)
+    cancelled = await _post_json(
+        app, f"/client/runs/{run_id}/cancel", {}, alice_headers
+    )
+    active = await _get_json(app, "/client/runs/active", alice_headers)
+    recovered = await _post_json(
+        app, "/client/runs/start", {"task": "D02"}, alice_headers
+    )
+
+    assert first.status_code == 200
+    assert blocked.status_code == 429
+    assert denied.status_code == 403
+    assert cancelled.status_code == 200
+    assert cancelled.json()["status"] == "cancelled"
+    assert active.status_code == 200
+    assert active.json()["runs"] == []
+    assert recovered.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_client_cancel_missing_run_returns_404(bench_root, monkeypatch):
+    monkeypatch.setenv("QTB_AUTH_MODE", "github")
+    monkeypatch.setenv("QTB_CLIENT_API_KEYS", "secret-alice=external:alice|alice")
+    app = _make_app(bench_root)
+
+    resp = await _post_json(
+        app,
+        "/client/runs/run_missing/cancel",
+        {},
+        headers={"Authorization": "Bearer secret-alice"},
+    )
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_rest_session_endpoints_require_matching_run_token(bench_root, monkeypatch):
     monkeypatch.setenv("QTB_AUTH_MODE", "github")
     monkeypatch.setenv("QTB_CLIENT_API_KEYS", "secret-alice=external:alice|alice")

--- a/docs/skills/quanttutorbench-rest-agent/SKILL.md
+++ b/docs/skills/quanttutorbench-rest-agent/SKILL.md
@@ -83,15 +83,19 @@ from the allowed lifecycle or task tool.
 ### REST
 
 Use the REST endpoints below when your runtime has a standard HTTP client.
-The run token authorizes `/session/*` requests and the control token authorizes
-`/ui/runs/{run_id}*` monitoring requests.
+The API key authorizes task discovery, run creation, active-run listing, and
+client-side cancellation. The run token authorizes `/session/*` requests. The
+control token authorizes `/ui/runs/{run_id}*` monitoring requests.
 
 ## Tokens
 
 The platform user generates a REST API key in the UI after GitHub OAuth login.
 Use it for task label discovery and run creation.
 
-- `api_key`: user API key for `/client/tasks/catalog/labels` and `/client/runs/start`; send as `Authorization: Bearer <api_key>`.
+- `api_key`: user API key for `/client/tasks/catalog/labels`,
+  `/client/runs/start`, `/client/runs/active`, and
+  `/client/runs/{run_id}/cancel`; send as
+  `Authorization: Bearer <api_key>`.
 - `token`: run token for `/session/*`; send as `Authorization: Bearer <token>`.
 - `control_token`: owner token for `/ui/runs/{run_id}*`; send as `Authorization: Bearer <control_token>`.
 
@@ -262,6 +266,39 @@ Every reply should reflect the latest student message. Repeated identical tutor
 text can trigger `agent_stuck`.
 
 ## Monitoring
+
+With an API key, list active runs created by the same API-key subject:
+
+```http
+GET /client/runs/active
+Authorization: Bearer <api_key>
+```
+
+The response contains token-safe run summaries:
+
+```json
+{
+  "runs": [
+    {
+      "run_id": "run_...",
+      "public_task_label": "D01",
+      "status": "claimed",
+      "session_id": null
+    }
+  ],
+  "count": 1
+}
+```
+
+Use this endpoint after an active-run quota response to find orphaned runs. To
+cancel a run owned by the same API-key subject:
+
+```http
+POST /client/runs/{run_id}/cancel
+Authorization: Bearer <api_key>
+```
+
+The returned run summary has `status: "cancelled"` when cancellation succeeds.
 
 When `control_token` is available:
 


### PR DESCRIPTION
Closes #120

## What changed
- Added `GET /client/runs/active` for API-key-owned nonterminal runs.
- Added `POST /client/runs/{run_id}/cancel` for owner-scoped client cancellation.
- Documented the new REST-agent recovery workflow.

## Verification
- `pytest bench/tests/api/test_rest_run_identity.py`
- `pytest bench/tests/test_run_control_token.py bench/tests/test_run_owner_filtering.py`
- `codex exec review --uncommitted`
