### PR TITLE
feat: REST closure — auto-eval on completion + retryable failures + lifecycle stability (#126)

### DIFF
--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -290,11 +290,13 @@ class BenchSessionManager:
                         async with state._request_lock:
                             if state.phase != SessionPhase.IN_SESSION:
                                 continue
+                            save_ok = False
                             try:
                                 if state.session is not None:
                                     state.session.force_complete("timeout")
                                 state.phase = SessionPhase.COMPLETED
                                 state._save_results()
+                                save_ok = True
                             except Exception:
                                 logger.warning(
                                     "Session %s save failed in sweep",
@@ -302,6 +304,8 @@ class BenchSessionManager:
                                     exc_info=True,
                                 )
                             state._destroy_container()
+                            if save_ok:
+                                state._trigger_auto_eval()
                             # Notify Run layer so run status tracks the
                             # force-completion. Swallow ValueError from
                             # mark_completed guards (e.g. run was cancelled

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -1085,6 +1085,176 @@ async def rest_register(request: Request) -> JSONResponse:
         return JSONResponse(result, status_code=code)
 
 
+_RETRYABLE_FAILURE = "infrastructure_failure"
+
+
+def _classify_session_failure(termination_reason: str | None) -> str:
+    """Map a session termination_reason to a retry-eligibility category.
+
+    Categories (per #126 P1):
+    - ``infrastructure_failure`` — retryable (NPC/student-sim crash, sandbox
+      crash; surfaces today as ``student_sim_error:*``).
+    - ``agent_gave_up`` — not retryable (``agent_stuck``, ``agent_abandoned``).
+    - ``max_turns_reached`` — not retryable (``max_turns``, ``timeout``;
+      session-level timeout is treated as exhaustion, not infra failure).
+    - ``terminal_success`` — not retryable (``objectives_met``).
+    - ``unknown`` — not retryable; defensive default.
+    """
+    if not termination_reason:
+        return "unknown"
+    if termination_reason.startswith("student_sim_error:"):
+        return _RETRYABLE_FAILURE
+    if termination_reason in ("agent_stuck", "agent_abandoned"):
+        return "agent_gave_up"
+    if termination_reason == "objectives_met":
+        return "terminal_success"
+    if termination_reason in ("max_turns", "timeout"):
+        return "max_turns_reached"
+    return "unknown"
+
+
+async def rest_retry_session(request: Request) -> JSONResponse:
+    """``POST /session/{sid}/retry`` — owner-scoped retry of a failed session.
+
+    Only sessions whose ``termination_reason`` classifies as
+    ``infrastructure_failure`` are retryable. The retry resets the
+    underlying RunAssignment back to CLAIMED, allocates a fresh session
+    under the same run, and returns the new session_id. The original
+    bundle remains on disk under its session_id as the failure receipt.
+    """
+    manager: BenchSessionManager = request.app.state.manager
+    sid = request.path_params["sid"]
+    try:
+        state = manager.get_or_restore_session(sid)
+    except Exception:
+        return JSONResponse({"error": "Session not found"}, 404)
+    if not state:
+        return JSONResponse({"error": "Session not found"}, 404)
+
+    auth_err = _authorize_rest_session_request(request, manager, state)
+    if auth_err is not None:
+        return auth_err
+
+    if state.phase != SessionPhase.COMPLETED:
+        return JSONResponse(
+            {
+                "error": "Session is not in a terminal state",
+                "current_phase": state.phase.value,
+            },
+            409,
+        )
+
+    if not state.run_id:
+        return JSONResponse(
+            {"error": "Session is not bound to a run"},
+            409,
+        )
+
+    run_state = state.get_run_results()
+    termination_reason = run_state.get("termination_reason")
+    category = _classify_session_failure(termination_reason)
+    if category != _RETRYABLE_FAILURE:
+        return JSONResponse(
+            {
+                "error": "Session is not retryable",
+                "category": category,
+                "termination_reason": termination_reason,
+            },
+            409,
+        )
+
+    # Snapshot the COMPLETED run so the retry can be undone if the new
+    # session fails to register — otherwise a transient sandbox failure
+    # would leave the run in FAILED with no session_id pointer back to
+    # the failure bundle, blocking any further retry attempt.
+    pre_reset_run = manager._run_service.get_run(state.run_id)
+    pre_reset_snapshot = (
+        {
+            "session_id": pre_reset_run.session_id,
+            "result_dir": pre_reset_run.result_dir,
+            "completed_at": pre_reset_run.completed_at,
+            "eval_status": pre_reset_run.eval_status,
+            "error": pre_reset_run.error,
+        }
+        if pre_reset_run is not None
+        else None
+    )
+
+    try:
+        run = manager._run_service.reset_for_retry(state.run_id)
+    except (ValueError, KeyError) as exc:
+        return JSONResponse({"error": str(exc)}, 409)
+
+    new_state = manager.create_rest_session()
+    new_state.run_id = run.run_id
+    new_state._run_task_id = run.task_id
+    new_state.owner_user_id = run.owner_user_id
+    new_state.owner_github_login = run.owner_github_login
+    new_state.owner_email = run.owner_email
+    new_state.visibility = run.visibility
+    new_state._on_completed = lambda result_dir: manager._run_service.mark_completed(
+        run.run_id, result_dir
+    )
+    # Preserve the original persona so the retry exercises the same
+    # student assignment; falling through to a random pick would change
+    # the scenario and make scores incomparable across attempts.
+    register_result = await asyncio.to_thread(
+        new_state.register, run.task_id, state.persona_id or None
+    )
+    if "session_id" not in register_result:
+        new_state.cleanup()
+        # Re-attach the original COMPLETED failure receipt so the run
+        # stays eligible for another retry.
+        if pre_reset_snapshot is not None:
+            try:
+                manager._run_service.restore_after_failed_retry(
+                    run.run_id, **pre_reset_snapshot
+                )
+            except Exception:
+                logger.warning(
+                    "Run %s restore_after_failed_retry failed",
+                    run.run_id,
+                    exc_info=True,
+                )
+        return JSONResponse(register_result, 500)
+
+    manager.register_rest_session(new_state)
+    manager._run_service.bind_session(run.run_id, new_state.session_id)
+
+    logger.info(
+        "[REST:%s] retry → new session=%s run=%s",
+        sid[:8],
+        new_state.session_id[:8],
+        run.run_id,
+    )
+    record_event(
+        manager.bench_root,
+        _audit_user_from_state(state),
+        "session.retry",
+        request=request,
+        run_id=run.run_id,
+        session_id=new_state.session_id,
+        task_id=run.task_id,
+        success=True,
+        payload={
+            "previous_session_id": sid,
+            "termination_reason": termination_reason,
+            "category": category,
+        },
+    )
+    return JSONResponse(
+        {
+            "status": "retry_started",
+            "session_id": new_state.session_id,
+            "previous_session_id": sid,
+            "run_id": run.run_id,
+            "category": category,
+            "termination_reason": termination_reason,
+            "next_action": f"POST /session/{new_state.session_id}/start",
+        }
+    )
+
+
 async def rest_start(request: Request) -> JSONResponse:
     """``POST /session/{sid}/start``"""
     manager: BenchSessionManager = request.app.state.manager
@@ -1933,6 +2103,7 @@ def create_app(
         ),
         Route("/session/{sid}/tool/{name}", rest_tool_call, methods=["POST"]),
         Route("/session/{sid}/send", rest_send, methods=["POST"]),
+        Route("/session/{sid}/retry", rest_retry_session, methods=["POST"]),
         Route("/session/{sid}/results", rest_results, methods=["GET"]),
         Route("/session/{sid}/scores", rest_scores, methods=["GET"]),
         # Operator-only evaluation surface: not reachable from MCP or

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -697,6 +697,7 @@ class SessionState:
                     self.session_id,
                     data.get("reason", "unknown"),
                 )
+            self._trigger_auto_eval()
             # Notify Run layer
             if self._on_completed:
                 try:
@@ -717,12 +718,57 @@ class SessionState:
     # Internal server-side evaluation trigger
     # ------------------------------------------------------------------
 
-    def request_evaluation(self) -> dict:
+    def _trigger_auto_eval(self) -> None:
+        """Enqueue a server-internal eval after a terminal transition.
+
+        Idempotent on the in-memory ``_eval_status`` guard and on the
+        ``auto:{session_id}`` key in the score store, so duplicate triggers
+        (e.g. an idle-sweep racing with handle_send_message) collapse onto
+        the same score record. Called by the public REST completion paths;
+        operators can still run additional evals via ``ops_evaluate`` with
+        a different idempotency key.
+        """
+        if self.phase != SessionPhase.COMPLETED or not self._result_dir:
+            return
+        with self._eval_lock:
+            if self._eval_status != "pending":
+                return
+        try:
+            # Pass auto params explicitly so a concurrent ops_evaluate
+            # mutation of _eval_mode / _eval_idempotency_key / eval_model
+            # cannot leak into score_1.
+            result = self.request_evaluation(
+                eval_mode="full",
+                eval_model=self.eval_model,
+                idempotency_key=f"auto:{self.session_id}",
+            )
+        except Exception as exc:
+            logger.warning(
+                "[auto-eval:%s] enqueue failed: %s", self.session_id[:8], exc
+            )
+            return
+        logger.info(
+            "[auto-eval:%s] status=%s score_id=%s",
+            self.session_id[:8],
+            result.get("status"),
+            result.get("score_id"),
+        )
+
+    def request_evaluation(
+        self,
+        *,
+        eval_mode: str | None = None,
+        eval_model: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> dict:
         """Start an internal evaluation run for a completed result bundle.
 
         Each non-concurrent call appends a new score_n evaluation run.
         Concurrent calls return the active running score instead of starting
-        a second run.
+        a second run. When ``eval_mode`` / ``eval_model`` / ``idempotency_key``
+        are passed explicitly the call ignores instance-state defaults — used
+        by ``_trigger_auto_eval`` so its parameters cannot be perturbed by a
+        racing operator request that mutated the instance fields.
         """
         if self._closed:
             return {
@@ -752,9 +798,17 @@ class SessionState:
             request = parse_eval_request(
                 {
                     "session_id": self.session_id,
-                    "eval_mode": self._eval_mode,
-                    "eval_model": self.eval_model,
-                    "idempotency_key": self._eval_idempotency_key,
+                    "eval_mode": (
+                        eval_mode if eval_mode is not None else self._eval_mode
+                    ),
+                    "eval_model": (
+                        eval_model if eval_model is not None else self.eval_model
+                    ),
+                    "idempotency_key": (
+                        idempotency_key
+                        if idempotency_key is not None
+                        else self._eval_idempotency_key
+                    ),
                 }
             )
             self._eval_mode = request.eval_mode

--- a/bench/server/run/service.py
+++ b/bench/server/run/service.py
@@ -287,6 +287,71 @@ class RunService:
         logger.info("Run cancelled: %s", run_id)
         return assignment
 
+    def reset_for_retry(self, run_id: str) -> RunAssignment:
+        """Reset a COMPLETED run back to CLAIMED so a fresh session can bind.
+
+        Used by the public retry endpoint when the prior session terminated
+        with an infrastructure-class failure. Clears the run-level pointers
+        to the failed session (session_id, result_dir, error, completed_at,
+        eval_status); the underlying bundle on disk is left untouched so the
+        failure receipt is preserved. ``claimed_at`` is refreshed so the
+        idle-claim sweeper does not retire the run between reset and the
+        follow-up bind_session.
+        """
+        assignment = self._get_or_raise(run_id)
+        if assignment.status != RunStatus.COMPLETED:
+            raise ValueError(
+                f"Run {run_id} is '{assignment.status.value}', "
+                f"only 'completed' runs can be reset for retry"
+            )
+        now = _now_iso()
+        assignment.status = RunStatus.CLAIMED
+        assignment.session_id = None
+        assignment.result_dir = None
+        assignment.error = None
+        assignment.completed_at = None
+        assignment.eval_status = "pending"
+        assignment.claimed_at = now
+        assignment.updated_at = now
+        self._store.save(assignment)
+        logger.info("Run reset for retry: %s", run_id)
+        return assignment
+
+    def restore_after_failed_retry(
+        self,
+        run_id: str,
+        *,
+        session_id: Optional[str],
+        result_dir: Optional[str],
+        completed_at: Optional[str],
+        eval_status: str,
+        error: Optional[str],
+    ) -> RunAssignment:
+        """Roll a CLAIMED retry back to its prior COMPLETED state.
+
+        Used by the retry endpoint when ``reset_for_retry`` succeeded but
+        the follow-up session register failed (e.g. transient sandbox
+        startup error). Re-attaches the original failure receipt so the
+        run remains pointing at the failed bundle and stays eligible for
+        another retry.
+        """
+        assignment = self._get_or_raise(run_id)
+        if assignment.status != RunStatus.CLAIMED:
+            raise ValueError(
+                f"Run {run_id} is '{assignment.status.value}', "
+                f"expected 'claimed' for retry rollback"
+            )
+        assignment.status = RunStatus.COMPLETED
+        assignment.session_id = session_id
+        assignment.result_dir = result_dir
+        assignment.completed_at = completed_at
+        assignment.eval_status = eval_status
+        assignment.error = error
+        assignment.updated_at = _now_iso()
+        self._store.save(assignment)
+        logger.info("Run %s restored after failed retry attempt", run_id)
+        return assignment
+
     def update_eval_status(self, run_id: str, eval_status: str) -> None:
         """Mirror SessionState._eval_status into RunAssignment."""
         assignment = self._store.get(run_id)

--- a/bench/tests/api/test_eval_flow.py
+++ b/bench/tests/api/test_eval_flow.py
@@ -45,6 +45,20 @@ def _wait_eval_done(state):
     raise AssertionError("evaluation did not finish")
 
 
+async def _complete_and_wait_for_auto_eval(app, client):
+    """Drive completion and block until the P0 auto-eval has settled.
+
+    Post-#126 P0 every terminal transition kicks off a server-internal
+    eval keyed ``auto:{session_id}``. Tests that want to drive operator
+    re-evaluation deterministically need the auto-eval to finish first
+    so the next ops_evaluate allocates a fresh ``score_n``.
+    """
+    sid = await _complete_session(client)
+    state = _get_state(app, sid)
+    _wait_eval_done(state)
+    return sid, state
+
+
 class TestPublicEvaluationBoundary:
     @pytest.mark.asyncio
     async def test_public_evaluate_route_absent_after_completion(self, client):
@@ -65,21 +79,23 @@ class TestPublicEvaluationBoundary:
 
 class TestOperatorEvaluation:
     @pytest.mark.asyncio
-    async def test_ops_evaluate_starts_score_run(self, app, client, mock_eval_pipeline):
-        sid = await _complete_session(client)
+    async def test_ops_evaluate_appends_score_run_after_auto_eval(
+        self, app, client, mock_eval_pipeline
+    ):
+        # Auto-eval (P0) takes score_1, operator gets score_2.
+        sid, state = await _complete_and_wait_for_auto_eval(app, client)
 
         resp = await client.post(f"/ops/session/{sid}/evaluate")
 
         assert resp.status_code == 200
         body = resp.json()
         assert body["status"] in ("running", "completed")
-        assert body["score_id"] == "score_1"
+        assert body["score_id"] == "score_2"
 
-        state = _get_state(app, sid)
         _wait_eval_done(state)
         with state._eval_lock:
             assert state._eval_status == "completed"
-            assert state._active_score_id == "score_1"
+            assert state._active_score_id == "score_2"
 
     @pytest.mark.asyncio
     async def test_ops_evaluate_denied_before_completion(self, client):
@@ -90,28 +106,26 @@ class TestOperatorEvaluation:
         assert resp.status_code == 409
 
     @pytest.mark.asyncio
-    async def test_ops_evaluate_appends_score_run(
+    async def test_ops_evaluate_appends_two_score_runs(
         self, app, client, mock_eval_pipeline
     ):
-        sid = await _complete_session(client)
-        state = _get_state(app, sid)
+        sid, state = await _complete_and_wait_for_auto_eval(app, client)
 
         first = await client.post(f"/ops/session/{sid}/evaluate")
-        assert first.json()["score_id"] == "score_1"
+        assert first.json()["score_id"] == "score_2"
         _wait_eval_done(state)
 
         second = await client.post(f"/ops/session/{sid}/evaluate")
         assert second.status_code == 200
-        assert second.json()["score_id"] == "score_2"
+        assert second.json()["score_id"] == "score_3"
 
 
 class TestOperatorEvalParameters:
     @pytest.mark.asyncio
     async def test_eval_mode_passed(self, app, client, mock_eval_pipeline):
-        sid = await _complete_session(client)
+        sid, state = await _complete_and_wait_for_auto_eval(app, client)
 
         await client.post(f"/ops/session/{sid}/evaluate?eval_mode=qp")
-        state = _get_state(app, sid)
         _wait_eval_done(state)
 
         assert state._eval_mode == "qp"
@@ -119,10 +133,9 @@ class TestOperatorEvalParameters:
 
     @pytest.mark.asyncio
     async def test_default_eval_mode_full(self, app, client, mock_eval_pipeline):
-        sid = await _complete_session(client)
+        sid, state = await _complete_and_wait_for_auto_eval(app, client)
 
         await client.post(f"/ops/session/{sid}/evaluate")
-        state = _get_state(app, sid)
         _wait_eval_done(state)
 
         assert mock_eval_pipeline.call_args.kwargs["eval_mode"] == "full"
@@ -130,23 +143,28 @@ class TestOperatorEvalParameters:
 
 class TestGetScores:
     @pytest.mark.asyncio
-    async def test_public_scores_pending_before_eval(self, client):
+    async def test_public_scores_show_auto_eval_after_completion(
+        self, app, client
+    ):
+        # Post-#126 P0 the auto-eval is already in flight by the time the
+        # client sees the completion turn — so /scores never lingers in
+        # 'pending'. It transitions through 'running' to 'completed' or
+        # 'failed' with no client trigger.
         sid = await _complete_session(client)
 
         resp = await client.get(f"/session/{sid}/scores")
 
         assert resp.status_code == 200
-        assert resp.json()["status"] == "pending"
+        body = resp.json()
+        assert body["status"] in ("running", "completed", "failed")
+        assert body["score_id"] == "score_1"
 
     @pytest.mark.asyncio
     async def test_public_scores_completed_without_private_cost(
         self, app, client, mock_eval_pipeline
     ):
-        sid = await _complete_session(client)
-        state = _get_state(app, sid)
+        sid, state = await _complete_and_wait_for_auto_eval(app, client)
 
-        await client.post(f"/ops/session/{sid}/evaluate")
-        _wait_eval_done(state)
         resp = await client.get(f"/session/{sid}/scores")
 
         assert resp.status_code == 200
@@ -163,25 +181,21 @@ class TestGetScores:
     async def test_ops_scores_include_private_cost(
         self, app, client, mock_eval_pipeline
     ):
-        sid = await _complete_session(client)
-        state = _get_state(app, sid)
+        sid, state = await _complete_and_wait_for_auto_eval(app, client)
 
-        await client.post(f"/ops/session/{sid}/evaluate")
-        _wait_eval_done(state)
         resp = await client.get(f"/ops/session/{sid}/scores")
 
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "completed"
         assert data["score_id"] == "score_1"
-        assert data["cost"]["eval_cost_usd"] == 0.006
+        assert data["cost"]["eval_cost_usd"] == 0.003
 
     @pytest.mark.asyncio
     async def test_scores_history_after_multiple_evals(
         self, app, client, mock_eval_pipeline
     ):
-        sid = await _complete_session(client)
-        state = _get_state(app, sid)
+        sid, state = await _complete_and_wait_for_auto_eval(app, client)
 
         await client.post(f"/ops/session/{sid}/evaluate")
         _wait_eval_done(state)
@@ -193,7 +207,11 @@ class TestGetScores:
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "history"
-        assert [s["score_id"] for s in data["scores"]] == ["score_1", "score_2"]
+        assert [s["score_id"] for s in data["scores"]] == [
+            "score_1",
+            "score_2",
+            "score_3",
+        ]
         assert all("cost" not in s for s in data["scores"])
 
 

--- a/bench/tests/api/test_session_completion_api.py
+++ b/bench/tests/api/test_session_completion_api.py
@@ -149,3 +149,72 @@ class TestPostCompletion:
         if resp.status_code == 200:
             data = resp.json()
             assert "conversation" in data or "error" not in data
+
+
+class TestAutoEvalOnCompletion:
+    """Issue #126 P0: terminal REST transition enqueues server-internal eval."""
+
+    @pytest.mark.asyncio
+    async def test_auto_eval_runs_on_max_turns_completion(
+        self, app, client, monkeypatch
+    ):
+        from server.api.session_api import SessionState
+
+        sid, _ = await register_and_start(client)
+        state = _get_session_state(app, sid)
+        state.session._max_turns = 1
+
+        seen: dict = {}
+        original = SessionState.request_evaluation
+
+        def _spy(
+            self,
+            *,
+            eval_mode=None,
+            eval_model=None,
+            idempotency_key=None,
+        ):
+            seen["sid"] = self.session_id
+            seen["key"] = idempotency_key
+            return original(
+                self,
+                eval_mode=eval_mode,
+                eval_model=eval_model,
+                idempotency_key=idempotency_key,
+            )
+
+        monkeypatch.setattr(SessionState, "request_evaluation", _spy)
+        # Stub the heavy background eval — we only need to verify the
+        # enqueue path, not the judge pipeline.
+        monkeypatch.setattr(SessionState, "_run_evaluation", lambda self, sid: None)
+
+        await send_message(client, sid, "Done.")
+
+        assert seen["sid"] == sid
+        assert seen["key"] == f"auto:{sid}"
+
+        from eval.storage.score_store import load_index
+
+        assert state._result_dir is not None
+        index = load_index(state._result_dir)
+        assert len(index["scores"]) == 1
+        assert index["scores"][0]["idempotency_key"] == f"auto:{sid}"
+
+    @pytest.mark.asyncio
+    async def test_auto_eval_visible_via_public_scores_endpoint(
+        self, app, client, monkeypatch
+    ):
+        from server.api.session_api import SessionState
+
+        sid, _ = await register_and_start(client)
+        state = _get_session_state(app, sid)
+        state.session._max_turns = 1
+        monkeypatch.setattr(SessionState, "_run_evaluation", lambda self, sid: None)
+
+        await send_message(client, sid, "Done.")
+
+        resp = await client.get(f"/session/{sid}/scores")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body.get("status") in ("running", "completed", "pending")
+        assert body.get("score_id") == "score_1"

--- a/bench/tests/api/test_session_concurrency.py
+++ b/bench/tests/api/test_session_concurrency.py
@@ -1,0 +1,68 @@
+"""Parallel-session sanity test for the P0 auto-eval path (issue #126 / P2).
+
+Drives 10 sessions to completion in parallel under one owner and verifies
+each one ends with a per-session score record keyed ``auto:{sid}`` and
+without leaking state across sessions. Heavy judge calls are stubbed via
+``_run_evaluation`` so the test stays in unit-test territory.
+"""
+
+import asyncio
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.api.session_api import SessionState
+from tests.helpers import register_and_start, send_message
+
+
+PARALLEL_COUNT = 10
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+def _get_state(app, sid):
+    state = app._manager.get_session(sid)
+    assert state is not None
+    return state
+
+
+@pytest.mark.asyncio
+async def test_ten_parallel_sessions_complete_with_auto_eval(
+    app, client, monkeypatch
+):
+    monkeypatch.setattr(SessionState, "_run_evaluation", lambda self, sid: None)
+
+    async def _drive_one():
+        sid, _ = await register_and_start(client)
+        state = _get_state(app, sid)
+        state.session._max_turns = 1
+        body = await send_message(client, sid, "Done.")
+        assert body["status"] == "completed"
+        return sid, state.run_id
+
+    results = await asyncio.gather(
+        *[_drive_one() for _ in range(PARALLEL_COUNT)]
+    )
+
+    sids = [sid for sid, _ in results]
+    run_ids = [run_id for _, run_id in results]
+    assert len(set(sids)) == PARALLEL_COUNT, "session_ids must be unique"
+    assert len(set(run_ids)) == PARALLEL_COUNT, "run_ids must be unique"
+
+    from eval.storage.score_store import load_index
+
+    for sid in sids:
+        state = _get_state(app, sid)
+        assert state._result_dir is not None
+        index = load_index(state._result_dir)
+        assert len(index["scores"]) == 1, f"expected 1 score for {sid}"
+        entry = index["scores"][0]
+        assert entry["score_id"] == "score_1"
+        assert entry["idempotency_key"] == f"auto:{sid}"

--- a/bench/tests/api/test_session_retry.py
+++ b/bench/tests/api/test_session_retry.py
@@ -1,0 +1,223 @@
+"""API tests for the failed-session retry endpoint (issue #126 / P1).
+
+POST /session/{sid}/retry is owner-scoped (run_token). Only sessions whose
+``termination_reason`` classifies as ``infrastructure_failure`` are
+retryable; everything else returns 409 with the category attached.
+"""
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.api.http_app import _classify_session_failure
+from tests.helpers import register_and_start, send_message
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+def _get_state(app, sid):
+    state = app._manager.get_session(sid)
+    assert state is not None
+    return state
+
+
+def _force_termination_reason(state, reason: str) -> None:
+    """Mutate the persisted run_state.json so retry classification reads
+    a chosen termination_reason without needing to drive the real failure
+    path. The retry endpoint reads from disk via state.get_run_results()."""
+    path = Path(state._result_dir) / "run_state.json"
+    rs = json.loads(path.read_text(encoding="utf-8"))
+    rs["termination_reason"] = reason
+    path.write_text(json.dumps(rs), encoding="utf-8")
+
+
+class TestClassifySessionFailure:
+    def test_student_sim_error_is_infrastructure(self):
+        assert (
+            _classify_session_failure("student_sim_error:network")
+            == "infrastructure_failure"
+        )
+        assert (
+            _classify_session_failure("student_sim_error:parse")
+            == "infrastructure_failure"
+        )
+
+    def test_agent_stuck_is_agent_gave_up(self):
+        assert _classify_session_failure("agent_stuck") == "agent_gave_up"
+        assert _classify_session_failure("agent_abandoned") == "agent_gave_up"
+
+    def test_terminal_categories(self):
+        assert _classify_session_failure("objectives_met") == "terminal_success"
+        assert _classify_session_failure("max_turns") == "max_turns_reached"
+        assert _classify_session_failure("timeout") == "max_turns_reached"
+
+    def test_unknown_categories(self):
+        assert _classify_session_failure(None) == "unknown"
+        assert _classify_session_failure("") == "unknown"
+        assert _classify_session_failure("something_else") == "unknown"
+
+
+class TestRetryEndpoint:
+    @pytest.mark.asyncio
+    async def test_unknown_session_returns_404(self, client):
+        resp = await client.post("/session/no-such-sid/retry")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_active_session_returns_409(self, client):
+        sid, _ = await register_and_start(client)
+        resp = await client.post(f"/session/{sid}/retry")
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body["current_phase"] == "in_session"
+
+    @pytest.mark.asyncio
+    async def test_agent_stuck_not_retryable(self, app, client):
+        sid, _ = await register_and_start(client)
+        msg = "Repeated message"
+        for _ in range(3):
+            await send_message(client, sid, msg)
+        # repeat detection → status="failed", reason="agent_stuck"
+        resp = await client.post(f"/session/{sid}/retry")
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body["category"] == "agent_gave_up"
+        assert body["termination_reason"] == "agent_stuck"
+
+    @pytest.mark.asyncio
+    async def test_max_turns_not_retryable(self, app, client):
+        sid, _ = await register_and_start(client)
+        state = _get_state(app, sid)
+        state.session._max_turns = 1
+        await send_message(client, sid, "Done.")
+        resp = await client.post(f"/session/{sid}/retry")
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body["category"] == "max_turns_reached"
+
+    @pytest.mark.asyncio
+    async def test_objectives_met_not_retryable(self, app, client):
+        # Synthesize objectives_met by patching the persisted reason.
+        sid, _ = await register_and_start(client)
+        state = _get_state(app, sid)
+        state.session._max_turns = 1
+        await send_message(client, sid, "Done.")
+        _force_termination_reason(state, "objectives_met")
+        resp = await client.post(f"/session/{sid}/retry")
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body["category"] == "terminal_success"
+
+    @pytest.mark.asyncio
+    async def test_infrastructure_failure_creates_new_session(self, app, client):
+        sid, _ = await register_and_start(client)
+        state = _get_state(app, sid)
+        original_run_id = state.run_id
+        assert original_run_id
+
+        state.session._max_turns = 1
+        await send_message(client, sid, "Done.")
+        # Patch persisted reason to simulate an NPC/sandbox crash.
+        _force_termination_reason(state, "student_sim_error:network")
+
+        resp = await client.post(f"/session/{sid}/retry")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "retry_started"
+        assert body["category"] == "infrastructure_failure"
+        assert body["previous_session_id"] == sid
+        assert body["run_id"] == original_run_id
+        new_sid = body["session_id"]
+        assert new_sid != sid
+
+        # Fresh session is bound to the same run, in REGISTERED phase.
+        new_state = _get_state(app, new_sid)
+        assert new_state.run_id == original_run_id
+        assert new_state.phase.value == "registered"
+
+        # Run-level binding now points at the new session.
+        run = app._manager._run_service.get_run(original_run_id)
+        assert run.session_id == new_sid
+        assert run.status.value == "active"
+
+    @pytest.mark.asyncio
+    async def test_retry_preserves_original_persona(self, app, client):
+        sid, _ = await register_and_start(client)
+        state = _get_state(app, sid)
+        original_persona = state.persona_id
+        assert original_persona
+
+        state.session._max_turns = 1
+        await send_message(client, sid, "Done.")
+        _force_termination_reason(state, "student_sim_error:network")
+
+        resp = await client.post(f"/session/{sid}/retry")
+        assert resp.status_code == 200
+        new_sid = resp.json()["session_id"]
+        new_state = _get_state(app, new_sid)
+        assert new_state.persona_id == original_persona
+
+    @pytest.mark.asyncio
+    async def test_failed_retry_register_restores_run(
+        self, app, client, monkeypatch
+    ):
+        from server.api.session_api import SessionState
+
+        sid, _ = await register_and_start(client)
+        state = _get_state(app, sid)
+        original_run_id = state.run_id
+        original_session_id = sid
+        state.session._max_turns = 1
+        await send_message(client, sid, "Done.")
+        original_result_dir = str(state._result_dir)
+        _force_termination_reason(state, "student_sim_error:network")
+
+        # Force the next register() to fail so the rollback path runs.
+        def _fail_register(self, task_id, persona_id=None):
+            return {"error": "Simulated sandbox boot failure"}
+
+        monkeypatch.setattr(SessionState, "register", _fail_register)
+
+        resp = await client.post(f"/session/{sid}/retry")
+        assert resp.status_code == 500
+
+        run = app._manager._run_service.get_run(original_run_id)
+        assert run.status.value == "completed"
+        assert run.session_id == original_session_id
+        assert run.result_dir == original_result_dir
+
+    @pytest.mark.asyncio
+    async def test_infrastructure_retry_then_complete_works(
+        self, app, client, monkeypatch
+    ):
+        # End-to-end: retry, start new session, send to completion.
+        from server.api.session_api import SessionState
+
+        monkeypatch.setattr(SessionState, "_run_evaluation", lambda self, sid: None)
+
+        sid, _ = await register_and_start(client)
+        state = _get_state(app, sid)
+        state.session._max_turns = 1
+        await send_message(client, sid, "Done.")
+        _force_termination_reason(state, "student_sim_error:network")
+
+        resp = await client.post(f"/session/{sid}/retry")
+        assert resp.status_code == 200
+        new_sid = resp.json()["session_id"]
+
+        start_resp = await client.post(f"/session/{new_sid}/start", json={})
+        assert start_resp.status_code == 200
+
+        new_state = _get_state(app, new_sid)
+        new_state.session._max_turns = 1
+        body = await send_message(client, new_sid, "Final.")
+        assert body["status"] == "completed"

--- a/bench/tests/conftest.py
+++ b/bench/tests/conftest.py
@@ -384,6 +384,7 @@ class FakeTCChecker:
         conversation,
         turn_evidence=None,
         turn_index=None,
+        tool_logs=None,
     ) -> bool:
         self._check_count += 1
         newly = []

--- a/bench/tests/test_run_state_transitions.py
+++ b/bench/tests/test_run_state_transitions.py
@@ -98,6 +98,120 @@ class CancelGuardTests(unittest.TestCase):
                 svc.cancel_run(a.run_id)
 
 
+class ResetForRetryTests(unittest.TestCase):
+    def test_reset_completed_clears_binding(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.mark_completed(a.run_id, "/tmp/r")
+            after = svc.reset_for_retry(a.run_id)
+            self.assertEqual(after.status, RunStatus.CLAIMED)
+            self.assertIsNone(after.session_id)
+            self.assertIsNone(after.result_dir)
+            self.assertIsNone(after.error)
+            self.assertIsNone(after.completed_at)
+            self.assertEqual(after.eval_status, "pending")
+
+    def test_reset_active_run_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")  # ACTIVE
+            with self.assertRaises(ValueError):
+                svc.reset_for_retry(a.run_id)
+
+    def test_reset_unknown_run_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            with self.assertRaises(ValueError):
+                svc.reset_for_retry("run_doesnotexist")
+
+    def test_reset_then_rebind_succeeds(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess1")
+            svc.mark_completed(a.run_id, "/tmp/r1")
+            svc.reset_for_retry(a.run_id)
+            after = svc.bind_session(a.run_id, "sess2")
+            self.assertEqual(after.status, RunStatus.ACTIVE)
+            self.assertEqual(after.session_id, "sess2")
+
+    def test_reset_refreshes_claimed_at(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess")
+            svc.mark_completed(a.run_id, "/tmp/r")
+            stale = svc.get_run(a.run_id).claimed_at
+            after = svc.reset_for_retry(a.run_id)
+            # claimed_at must move forward so the idle-claim sweeper
+            # does not retire the run mid-retry.
+            self.assertNotEqual(after.claimed_at, stale)
+            self.assertGreater(after.claimed_at, stale)
+
+
+class RestoreAfterFailedRetryTests(unittest.TestCase):
+    def test_restore_reattaches_completed_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess1")
+            svc.mark_completed(a.run_id, "/tmp/r1")
+            snapshot = svc.get_run(a.run_id)
+            snap_dict = {
+                "session_id": snapshot.session_id,
+                "result_dir": snapshot.result_dir,
+                "completed_at": snapshot.completed_at,
+                "eval_status": snapshot.eval_status,
+                "error": snapshot.error,
+            }
+            svc.reset_for_retry(a.run_id)  # now CLAIMED with cleared fields
+            restored = svc.restore_after_failed_retry(a.run_id, **snap_dict)
+            self.assertEqual(restored.status, RunStatus.COMPLETED)
+            self.assertEqual(restored.session_id, "sess1")
+            self.assertEqual(restored.result_dir, "/tmp/r1")
+            self.assertEqual(restored.completed_at, snapshot.completed_at)
+
+    def test_restore_then_retry_again(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess1")
+            svc.mark_completed(a.run_id, "/tmp/r1")
+            snap = svc.get_run(a.run_id)
+            snap_dict = {
+                "session_id": snap.session_id,
+                "result_dir": snap.result_dir,
+                "completed_at": snap.completed_at,
+                "eval_status": snap.eval_status,
+                "error": snap.error,
+            }
+            svc.reset_for_retry(a.run_id)
+            svc.restore_after_failed_retry(a.run_id, **snap_dict)
+            # A second retry attempt must still succeed since the run is
+            # back in COMPLETED with the failure receipt attached.
+            again = svc.reset_for_retry(a.run_id)
+            self.assertEqual(again.status, RunStatus.CLAIMED)
+            self.assertIsNone(again.session_id)
+
+    def test_restore_rejects_non_claimed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = _make_service(Path(tmp))
+            a, _, _ = svc.create_and_claim("D01")
+            svc.bind_session(a.run_id, "sess1")  # ACTIVE, not CLAIMED
+            with self.assertRaises(ValueError):
+                svc.restore_after_failed_retry(
+                    a.run_id,
+                    session_id="sess1",
+                    result_dir="/tmp/r1",
+                    completed_at="2026-01-01T00:00:00+00:00",
+                    eval_status="pending",
+                    error=None,
+                )
+
+
 class BindSessionRollbackTests(unittest.TestCase):
     def test_rollback_on_store_error_leaves_run_claimed(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/bench/tests/unit/test_session_auto_eval.py
+++ b/bench/tests/unit/test_session_auto_eval.py
@@ -1,0 +1,124 @@
+"""Unit tests for SessionState._trigger_auto_eval (issue #126 / P0).
+
+Auto-eval enqueues a server-internal eval after a terminal transition.
+It is idempotent on the in-memory ``_eval_status`` guard and on the
+``auto:{session_id}`` key in the score store, so duplicate triggers
+collapse onto the same score record.
+"""
+
+import pytest
+
+from server.api.protocol import SessionPhase
+
+
+@pytest.fixture
+def state(bench_root):
+    from server.api.session_api import SessionState
+
+    return SessionState(
+        session_id="auto-eval-test-001",
+        use_docker=False,
+        bench_root=bench_root,
+        eval_model="fake-model",
+    )
+
+
+class TestAutoEvalGuards:
+    def test_no_op_before_completed(self, state, monkeypatch):
+        calls = []
+        monkeypatch.setattr(state, "request_evaluation", lambda: calls.append(1))
+        state.phase = SessionPhase.IN_SESSION
+        state._result_dir = "/tmp/x"
+        state._trigger_auto_eval()
+        assert calls == []
+
+    def test_no_op_without_result_dir(self, state, monkeypatch):
+        calls = []
+        monkeypatch.setattr(state, "request_evaluation", lambda: calls.append(1))
+        state.phase = SessionPhase.COMPLETED
+        state._result_dir = None
+        state._trigger_auto_eval()
+        assert calls == []
+
+    def test_no_op_when_eval_already_started(self, state, monkeypatch, tmp_path):
+        calls = []
+        monkeypatch.setattr(
+            state, "request_evaluation", lambda: calls.append(1) or {}
+        )
+        state.phase = SessionPhase.COMPLETED
+        state._result_dir = tmp_path
+        state._eval_status = "running"
+        state._trigger_auto_eval()
+        assert calls == []
+
+
+class TestAutoEvalEnqueue:
+    def test_sets_auto_idempotency_key(self, state, monkeypatch, tmp_path):
+        seen = {}
+
+        def _fake_eval(*, eval_mode=None, eval_model=None, idempotency_key=None):
+            seen["key"] = idempotency_key
+            seen["mode"] = eval_mode
+            return {"status": "running", "score_id": "score_1"}
+
+        monkeypatch.setattr(state, "request_evaluation", _fake_eval)
+        state.phase = SessionPhase.COMPLETED
+        state._result_dir = tmp_path
+        state._trigger_auto_eval()
+        assert seen["key"] == f"auto:{state.session_id}"
+        assert seen["mode"] == "full"
+
+    def test_swallows_request_evaluation_exception(
+        self, state, monkeypatch, tmp_path, caplog
+    ):
+        def _boom(*, eval_mode=None, eval_model=None, idempotency_key=None):
+            raise RuntimeError("eval pipeline broken")
+
+        monkeypatch.setattr(state, "request_evaluation", _boom)
+        state.phase = SessionPhase.COMPLETED
+        state._result_dir = tmp_path
+        state._trigger_auto_eval()  # must not raise
+        assert "auto-eval" in caplog.text
+
+
+class TestAutoEvalIdempotency:
+    def test_second_trigger_after_running_is_noop(
+        self, state, monkeypatch, tmp_path
+    ):
+        calls = []
+
+        def _fake_eval(*, eval_mode=None, eval_model=None, idempotency_key=None):
+            calls.append(idempotency_key)
+            state._eval_status = "running"
+            return {"status": "running", "score_id": "score_1"}
+
+        monkeypatch.setattr(state, "request_evaluation", _fake_eval)
+        state.phase = SessionPhase.COMPLETED
+        state._result_dir = tmp_path
+
+        state._trigger_auto_eval()
+        state._trigger_auto_eval()
+        assert calls == [f"auto:{state.session_id}"]
+
+    def test_ignores_concurrent_operator_param_mutation(
+        self, state, monkeypatch, tmp_path
+    ):
+        """Operator mutation of _eval_mode / _eval_idempotency_key just before
+        auto-eval fires must not leak into score_1."""
+        seen = {}
+
+        def _fake_eval(*, eval_mode=None, eval_model=None, idempotency_key=None):
+            seen["mode"] = eval_mode
+            seen["key"] = idempotency_key
+            return {"status": "running", "score_id": "score_1"}
+
+        monkeypatch.setattr(state, "request_evaluation", _fake_eval)
+        state.phase = SessionPhase.COMPLETED
+        state._result_dir = tmp_path
+        # Simulate ops_evaluate that mutated the instance fields outside
+        # of _request_lock just before completion fired.
+        state._eval_mode = "qp"
+        state._eval_idempotency_key = "operator-key"
+        state._trigger_auto_eval()
+        assert seen["mode"] == "full"
+        assert seen["key"] == f"auto:{state.session_id}"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,11 +71,16 @@ Clients cannot trigger scoring:
 - no public `POST /session/{sid}/evaluate`
 - no scoring through `POST /session/{sid}/tool/{name}`
 
-Scoring is server/operator-owned:
+Scoring is server-owned. Two server-side triggers:
 
-- `POST /ops/session/{sid}/evaluate`
-- `GET /ops/session/{sid}/results`
-- `GET /ops/session/{sid}/scores`
+- **auto** — every terminal transition to `completed` (via `send_message`
+  or the idle-timeout sweep) enqueues one eval keyed
+  `auto:{session_id}`. The client then polls
+  `GET /session/{sid}/scores`.
+- **operator** — `POST /ops/session/{sid}/evaluate` (admin-token gated)
+  for re-evaluation, alternate `eval_mode`, or recovery on bundles whose
+  auto-eval failed. Operator reads stay at `GET /ops/session/{sid}/results`
+  and `GET /ops/session/{sid}/scores`.
 
 The `/ops/*` surface is gated by the admin-token mechanism in
 `server.web.ui_app`. Client read endpoints stay export-scoped and, when run
@@ -93,12 +98,17 @@ the client catalog.
 1. `register_session` loads task/persona and prepares runtime state.
 2. `start_session` returns the student opening and enters `in_session`.
 3. `send_message` advances the student simulator and tool trace.
-4. Terminal status persists a result bundle and enters `completed`.
+4. Terminal status persists a result bundle, enters `completed`, and
+   `_trigger_auto_eval()` enqueues a server-internal eval keyed
+   `auto:{session_id}`. The same trigger fires from the idle-timeout sweep
+   when a session crosses its deadline. The judge runs in a background
+   thread; clients poll `GET /session/{sid}/scores` for the result.
 5. `completed` is terminal for MCP/client tools.
 
 `restore_from_storage()` reconstructs enough completed-session state from
 `run_state.json` to read results, read scores, or run operator scoring without
-restarting the tutoring runtime.
+restarting the tutoring runtime. Restore does not re-trigger auto-eval; the
+score store is the source of truth for whether an eval has run.
 
 ## Canonical Storage
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,6 +110,15 @@ the client catalog.
 restarting the tutoring runtime. Restore does not re-trigger auto-eval; the
 score store is the source of truth for whether an eval has run.
 
+`POST /session/{sid}/retry` (run-token gated) lets the owning agent retry
+a session whose `termination_reason` classifies as
+`infrastructure_failure` (currently `student_sim_error:*`). The retry calls
+`RunService.reset_for_retry()` to rebind the same RunAssignment back to
+`claimed`, allocates a fresh session_id, and returns it. Other categories
+(`agent_gave_up`, `max_turns_reached`, `terminal_success`, `unknown`) are
+not retryable and return 409. The original failed bundle remains on disk
+under its session_id as the failure receipt.
+
 ## Canonical Storage
 
 Results are stored in-bundle:


### PR DESCRIPTION
## Summary

Closes #126. Phase 1.0a: external agents can now drive a session through the public REST surface, get its bundle automatically scored, and read scores back through `GET /session/{sid}/scores` — no operator intervention needed. Failed sessions caused by infrastructure (NPC/sandbox) issues can be retried under the same run via a new owner-scoped endpoint. Lifecycle stability gaps (test signature drift, concurrency confidence) are closed.

Three commits, each with its own slice:

- **P0 (8d11b430)** — `SessionState._trigger_auto_eval()` fires on every COMPLETED transition (`handle_send_message` + idle-timeout sweep). One eval per session_id via `auto:{session_id}` idempotency key. `request_evaluation()` accepts explicit `eval_mode` / `eval_model` / `idempotency_key` so auto-eval cannot inherit a racing operator's mutation. Sweep path gates `_trigger_auto_eval` on `_save_results()` success so partial bundles never get scored.
- **P1 (3c76bea9)** — `POST /session/{sid}/retry` (run-token gated). Reads `termination_reason`, classifies into `infrastructure_failure | agent_gave_up | max_turns_reached | terminal_success | unknown`. Only the first is retryable. `RunService.reset_for_retry()` rebinds the same run back to CLAIMED with refreshed `claimed_at`; `restore_after_failed_retry()` rolls the run back to its prior COMPLETED state if the new register fails so the failure receipt stays attached. Persona is preserved across retries.
- **P2 (fa4716a8)** — `FakeTCChecker.check()` gains the `tool_logs=` kwarg added to real `TCChecker` in #122 slice 5; the 4 dev-branch test failures unblock. New `tests/api/test_session_concurrency.py` drives 10 parallel sessions × 1 owner through the auto-eval path and asserts isolated score records.

`docs/architecture.md` Session Lifecycle + Permission Boundary now describe the auto-eval trigger and the retry endpoint.

## TBD resolutions (issue body, recorded before P0)

- TBD-1 (sync vs async) — async, since `request_evaluation()` is already a daemon thread and `/scores` already polls.
- TBD-2 (cost guard) — one auto-eval per session_id via `auto:{session_id}` idempotency key. Operators can still allocate additional `score_n` runs with different keys.
- TBD-3 (retry semantics) — fresh sandbox + fresh NPC seed + same persona; original bundle preserved on disk as the failure receipt.
- TBD-4 (concurrency SLO) — no per-owner cap for v1.0a; sanity-tested at 10 parallel × 1 owner.

## Codex review

Two rounds total, all findings accepted (P0 round: parameter snapshot + partial-bundle gate; P1 round: claimed_at refresh + persona preservation + restore-after-failed-retry).

## Test plan

- [x] `pytest bench/tests/unit/test_session_auto_eval.py` — 7/7
- [x] `pytest bench/tests/api/test_session_completion_api.py` — 10/10
- [x] `pytest bench/tests/api/test_session_retry.py` — 12/12
- [x] `pytest bench/tests/api/test_session_concurrency.py` — 1/1
- [x] `pytest bench/tests/api/test_eval_flow.py` — 14/14
- [x] `pytest bench/tests/test_run_state_transitions.py` — 16/16
- [x] `pytest bench/tests/unit/test_session_completion.py` — 24/24 (4 previously failing now pass)
- [x] Full suite: 323/326 passing on the branch (3 remaining failures are all pre-existing on origin/dev: 2 missing `nest_asyncio`, 1 `test_register_invalid_persona` 404 vs 400)

## Phase context

This was Phase 1.0a. Unblocks #125 (Bootstrap reference, Phase 1.0b) and the rest of Phase 1.0c.