### PR TITLE
fix(ui): restore LIVE_STATUSES declaration in flow-demo.js (prod hotfix)

### DIFF
--- a/bench/server/web/static/js/flow-demo.js
+++ b/bench/server/web/static/js/flow-demo.js
@@ -16,6 +16,7 @@
   };
 
   var POLL_MS = 2000;
+  var LIVE_STATUSES = {waiting: true, claimed: true, active: true};
 
   var _root = null;
   var _pollTimer = null;


### PR DESCRIPTION
## Summary

Hotfix for prod Session Flow page that started rendering blank after #128 (dev → master).

**Root cause**: the conflict resolution at 9f3aaca9 (when PR #119 was retargeted to dev) kept the reference to `LIVE_STATUSES` at line 155 of `flow-demo.js` but dropped the declaration. Production JS throws `ReferenceError: LIVE_STATUSES is not defined` whenever `currentLiveRun()` falls through to the non-active fallback branch. Result: `liveRun` resolves to null, page renders the empty `flow-demo-blank` section, the conversation + tools panels never appear.

User-visible symptoms reported:
1. Session Flow shows only a tiny/empty window (the bare page header)
2. Detail/conversation pane never renders

Both are downstream of the same crash.

**Fix**: one-line restore of the original declaration that matches master pre-merge (`a8e3c884`).

## Test plan

- [x] `node --check` clean on the modified file
- [x] `bench/tests/test_server_web_ui.py` — 9 pass / 1 pre-existing baseline failure (test_indexer_uses_latest_score_run, unrelated)
- [ ] After deploy: visit `https://benchmark-liard.vercel.app/` → Session Flow renders with conversation panel even when no active run is live
- [ ] DevTools console: no ReferenceError on flow-demo.js

## Follow-up (separate work)

The same conflict-resolution pass also dropped a few master-side helpers (`runHref`, `previewHtml`, `shortId`) that targeted the deleted card markup. Those were intentionally removed because dev's new `liveRunHtml` uses different markup. If any further functional regressions surface after this fix lands, will forward-port them onto the new markup case-by-case.

Same fix needs to be cherry-picked to `dev` after this lands so the two branches don't drift.