### PR TITLE
fix(ci): replace deploy fixed-sleep with /health polling; install pytest-timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements.txt pytest-timeout
       - run: pytest bench/tests/ -x --timeout=60
         continue-on-error: true
 
@@ -105,7 +105,21 @@ jobs:
             ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} << 'EOF'
             set -e
             sudo systemctl restart quanttutor
-            sleep 6
+            # Poll /health for up to 60s; new code's cold start can exceed 6s
+            # after Bundle v1 + audit sink + run service initialization (#122/#123).
+            for i in $(seq 1 30); do
+              if curl -sf -m 3 http://127.0.0.1:8000/health >/dev/null 2>&1; then
+                echo "health ok after ${i}*2s"
+                break
+              fi
+              if [ $i -eq 30 ]; then
+                echo "health probe timed out after 60s"
+                sudo systemctl status quanttutor --no-pager | head -20
+                tail -50 /var/log/quanttutor.log
+                exit 1
+              fi
+              sleep 2
+            done
             sudo systemctl is-active quanttutor
             # /health deep probe: docker daemon + LEAN image + disk (returns 503 on any failure)
             curl -sf http://127.0.0.1:8000/health >/dev/null


### PR DESCRIPTION
## Summary

Two CI fixes from the #128 deploy postmortem:

1. **`sleep 6` → /health polling**: Post-#122/#123 cold start (Bundle v1 + audit sink + run service init) exceeds 6s. systemd reports `active` immediately after fork but HTTP server hasn't bound 8000 yet → next `curl -sf` returns exit 7 → deploy reported failed even though prod is healthy. Replaced with a 30-iter × 2s poll loop, early-exit on first success, dumps `systemctl status` + log tail on timeout.

2. **Install `pytest-timeout`**: the existing `pytest --timeout=60` flag was failing at parse time because the plugin wasn't in `requirements.txt`. `continue-on-error: true` silently masked the issue (CI test step always finished with `success` but actually never ran tests). Adding `pytest-timeout` to the install line makes the flag work.

Note: kept `continue-on-error: true` on the test step. Removing it is a separate concern (test deps + actual test reliability) and out of scope for this hotfix.

## Test plan

- [x] yaml parses cleanly
- [ ] After merge: this PR's own deploy run completes without the false-alarm; CI test step now actually runs `pytest`
- [ ] On future cold-startup regressions, log lines `health ok after Nx2s` make the actual startup time visible