### PR TITLE
Lock score response forward-compat shape (#131)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements.txt pytest-timeout
       - run: pytest bench/tests/ -x --timeout=60
         continue-on-error: true
 
@@ -105,7 +105,21 @@ jobs:
             ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} << 'EOF'
             set -e
             sudo systemctl restart quanttutor
-            sleep 6
+            # Poll /health for up to 60s; new code's cold start can exceed 6s
+            # after Bundle v1 + audit sink + run service initialization (#122/#123).
+            for i in $(seq 1 30); do
+              if curl -sf -m 3 http://127.0.0.1:8000/health >/dev/null 2>&1; then
+                echo "health ok after ${i}*2s"
+                break
+              fi
+              if [ $i -eq 30 ]; then
+                echo "health probe timed out after 60s"
+                sudo systemctl status quanttutor --no-pager | head -20
+                tail -50 /var/log/quanttutor.log
+                exit 1
+              fi
+              sleep 2
+            done
             sudo systemctl is-active quanttutor
             # /health deep probe: docker daemon + LEAN image + disk (returns 503 on any failure)
             curl -sf http://127.0.0.1:8000/health >/dev/null

--- a/BENCHMARK_SPEC.md
+++ b/BENCHMARK_SPEC.md
@@ -176,6 +176,13 @@ class Scores:
 The dataclass is per-task. Benchmark-level KPIs (pass rate over the task
 suite) are computed by aggregating over `task_pass` across all tasks (§6.5).
 
+REST clients consume the v1 envelope returned by
+`GET /session/{sid}/scores` (see `docs/architecture.md` Public Reads). The
+public top level is `schema_version`, `score_id`, `score_status`,
+`task_score`, `task_pass`; per-track scores and process metric breakdowns
+live under the opaque `detail` blob. `task_pass` is null until baseline
+calibration ships (TBD-1).
+
 ### 3.4 Turn Definition
 
 One **turn** = one `send_message()` call. The agent may make

--- a/bench/eval/core/scoring.py
+++ b/bench/eval/core/scoring.py
@@ -25,6 +25,11 @@ LAYER1_RESULT_WEIGHT = 0.40  # λ: Layer 1 contribution to Result Sub-score
 # and strong ≈ 60-70% pass. Lock in v2.0 spec, freeze.
 PASS_THRESHOLD = 0.5
 
+# Per #131 D-2: until baseline calibration ships, the v1 score response masks
+# task_pass to None so external clients don't see misleading pass/fail signals.
+# Flip this to True in the same change that sets a calibrated PASS_THRESHOLD.
+PASS_THRESHOLD_CALIBRATED = False
+
 
 def _score_value(value: Any) -> float | None:
     """Return a real numeric score, preserving missing/non-computable as None."""

--- a/bench/eval/storage/score_store.py
+++ b/bench/eval/storage/score_store.py
@@ -246,6 +246,142 @@ def summarize_score(
     return summary
 
 
+SCORE_RESPONSE_SCHEMA_VERSION = "1.0"
+
+# Public score_status enum per #131 D-3 — pinned for external clients.
+# ``interrupted`` is the coordinator's status when an eval was cancelled
+# mid-flight (see eval/core/coordinator.py); kept distinct from ``failed``
+# so clients can tell user-cancellation from eval-crash.
+PUBLIC_SCORE_STATUSES = frozenset(
+    {
+        "pending",
+        "running",
+        "completed_scored",
+        "completed_not_computable",
+        "failed",
+        "interrupted",
+    }
+)
+
+_QR_DIM_KEYS = ("result_judge", "code_eval", "programmatic")
+_QP_DIM_KEYS = (
+    "tool_usage",
+    "action_economy",
+    "code_lifecycle",
+    "task_planning",
+    "problem_solving",
+)
+
+
+def _coerce_dim_score(raw: Any) -> float | None:
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return None
+    return float(raw)
+
+
+def _extract_dimension(
+    name: str, track: str, container: dict[str, Any]
+) -> dict[str, Any] | None:
+    data = container.get(name)
+    if not isinstance(data, dict):
+        return None
+    if "score" not in data and not data.get("status"):
+        return None
+    return {
+        "name": name,
+        "track": track,
+        "score": _coerce_dim_score(data.get("score")),
+        "status": data.get("status"),
+    }
+
+
+def _track_view(track_data: Any) -> dict[str, Any] | None:
+    if not isinstance(track_data, dict):
+        return None
+    return {
+        "score": _coerce_dim_score(track_data.get("score")),
+        "status": track_data.get("status"),
+        "blockers": list(track_data.get("blocking_missing") or []),
+    }
+
+
+def build_v1_response(
+    score_data: dict[str, Any],
+    cost_data: dict[str, Any] | None = None,
+    *,
+    include_legacy: bool = False,
+) -> dict[str, Any]:
+    """Build the v1 forward-compat score response from persisted score+cost data.
+
+    Public top-level: ``task_score``, ``task_pass``, ``score_id``,
+    ``score_status``, ``schema_version``. Everything else lives in
+    ``detail`` so adding fields later is non-breaking.
+
+    ``task_pass`` is masked to ``None`` while ``PASS_THRESHOLD_CALIBRATED``
+    is False (#131 D-2) — clients should treat absence as "not yet known".
+
+    ``include_legacy=True`` (the dual-emit window per #131 D-1) merges the
+    ``summarize_score`` fields onto the response root so existing internal
+    callers don't break before the UI cuts over.
+    """
+    from eval.core.scoring import PASS_THRESHOLD, PASS_THRESHOLD_CALIBRATED
+
+    qr = score_data.get("qr") if isinstance(score_data.get("qr"), dict) else None
+    qp = score_data.get("qp") if isinstance(score_data.get("qp"), dict) else None
+    overall = _coerce_dim_score(score_data.get("overall_score"))
+
+    if PASS_THRESHOLD_CALIBRATED and overall is not None:
+        task_pass: bool | None = overall >= PASS_THRESHOLD
+    else:
+        task_pass = None
+
+    dimensions: list[dict[str, Any]] = []
+    qr_detail = qr.get("detail") if qr and isinstance(qr.get("detail"), dict) else {}
+    for name in _QR_DIM_KEYS:
+        dim = _extract_dimension(name, "qr", qr_detail)
+        if dim is not None:
+            dimensions.append(dim)
+    qp_detail = qp.get("detail") if qp and isinstance(qp.get("detail"), dict) else {}
+    for name in _QP_DIM_KEYS:
+        dim = _extract_dimension(name, "qp", qp_detail)
+        if dim is not None:
+            dimensions.append(dim)
+
+    detail: dict[str, Any] = {
+        "dimensions": dimensions,
+        "tracks": {
+            "qr": _track_view(qr),
+            "qp": _track_view(qp),
+        },
+        "judge_reliability": score_data.get("judge_reliability") or {},
+        "blocking_missing": score_data.get("blocking_missing", []),
+    }
+    if cost_data:
+        detail["cost"] = {
+            "eval_cost_usd": cost_data.get("eval_cost_usd"),
+            "eval_cost_by_track": cost_data.get("eval_cost_by_track") or {},
+            "eval_cost_by_model": cost_data.get("eval_cost_by_model") or {},
+        }
+
+    response: dict[str, Any] = {
+        "schema_version": SCORE_RESPONSE_SCHEMA_VERSION,
+        "score_id": score_data.get("score_id"),
+        "score_status": score_data.get("score_status"),
+        "task_score": overall,
+        "task_pass": task_pass,
+        "detail": detail,
+    }
+
+    if include_legacy:
+        legacy = summarize_score(score_data, cost_data)
+        # Don't let legacy keys clobber the v1 promises.
+        for key in ("score_id", "score_status"):
+            legacy.pop(key, None)
+        response.update(legacy)
+
+    return response
+
+
 def get_scores_payload(
     result_dir: Path,
     *,

--- a/bench/eval/storage/score_store.py
+++ b/bench/eval/storage/score_store.py
@@ -308,8 +308,6 @@ def _track_view(track_data: Any) -> dict[str, Any] | None:
 def build_v1_response(
     score_data: dict[str, Any],
     cost_data: dict[str, Any] | None = None,
-    *,
-    include_legacy: bool = False,
 ) -> dict[str, Any]:
     """Build the v1 forward-compat score response from persisted score+cost data.
 
@@ -319,10 +317,6 @@ def build_v1_response(
 
     ``task_pass`` is masked to ``None`` while ``PASS_THRESHOLD_CALIBRATED``
     is False (#131 D-2) — clients should treat absence as "not yet known".
-
-    ``include_legacy=True`` (the dual-emit window per #131 D-1) merges the
-    ``summarize_score`` fields onto the response root so existing internal
-    callers don't break before the UI cuts over.
     """
     from eval.core.scoring import PASS_THRESHOLD, PASS_THRESHOLD_CALIBRATED
 
@@ -363,7 +357,7 @@ def build_v1_response(
             "eval_cost_by_model": cost_data.get("eval_cost_by_model") or {},
         }
 
-    response: dict[str, Any] = {
+    return {
         "schema_version": SCORE_RESPONSE_SCHEMA_VERSION,
         "score_id": score_data.get("score_id"),
         "score_status": score_data.get("score_status"),
@@ -371,15 +365,6 @@ def build_v1_response(
         "task_pass": task_pass,
         "detail": detail,
     }
-
-    if include_legacy:
-        legacy = summarize_score(score_data, cost_data)
-        # Don't let legacy keys clobber the v1 promises.
-        for key in ("score_id", "score_status"):
-            legacy.pop(key, None)
-        response.update(legacy)
-
-    return response
 
 
 def get_scores_payload(

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -1828,17 +1828,6 @@ def _public_score_entry(entry: dict) -> dict:
     return out
 
 
-def _legacy_score_fields_enabled() -> bool:
-    """Dual-emit window per #131 D-1.
-
-    Default ON in P0 so the existing UI keeps reading legacy keys
-    (``overall_score``, ``quant_result``, ``quant_process``). Flipped OFF
-    in P2 once the UI cuts over to the v1 shape (``task_score`` /
-    ``task_pass`` / ``detail.tracks``).
-    """
-    return _bool_env("BENCH_SCORE_RESPONSE_LEGACY_FIELDS", True)
-
-
 def _v1_single_score_response(payload: dict, *, public: bool) -> dict:
     """Convert a single-score store payload into the #131 v1 response shape.
 
@@ -1857,7 +1846,6 @@ def _v1_single_score_response(payload: dict, *, public: bool) -> dict:
 
     score = payload.get("score") if isinstance(payload.get("score"), dict) else None
     cost = payload.get("cost") if isinstance(payload.get("cost"), dict) else None
-    include_legacy = _legacy_score_fields_enabled()
 
     if score is None:
         body: dict = {
@@ -1871,33 +1859,12 @@ def _v1_single_score_response(payload: dict, *, public: bool) -> dict:
         }
         if "error" in payload:
             body["error"] = payload["error"]
-        if include_legacy:
-            scores_summary = payload.get("scores")
-            if isinstance(scores_summary, dict):
-                body["scores"] = (
-                    _public_score_summary(scores_summary)
-                    if public
-                    else dict(scores_summary)
-                )
         return body
 
     # Public path mirrors the pre-#131 behaviour of dropping cost entirely
     # from the response; ops keeps it under detail.cost + raw cost blob.
-    body = build_v1_response(
-        score,
-        cost if not public else None,
-        include_legacy=include_legacy,
-    )
+    body = build_v1_response(score, cost if not public else None)
     body["status"] = payload.get("status")
-
-    if include_legacy:
-        scores_summary = payload.get("scores")
-        if isinstance(scores_summary, dict):
-            body["scores"] = (
-                _public_score_summary(scores_summary)
-                if public
-                else dict(scores_summary)
-            )
 
     if not public:
         body["score"] = score

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -1828,8 +1828,101 @@ def _public_score_entry(entry: dict) -> dict:
     return out
 
 
+def _legacy_score_fields_enabled() -> bool:
+    """Dual-emit window per #131 D-1.
+
+    Default ON in P0 so the existing UI keeps reading legacy keys
+    (``overall_score``, ``quant_result``, ``quant_process``). Flipped OFF
+    in P2 once the UI cuts over to the v1 shape (``task_score`` /
+    ``task_pass`` / ``detail.tracks``).
+    """
+    return _bool_env("BENCH_SCORE_RESPONSE_LEGACY_FIELDS", True)
+
+
+def _v1_single_score_response(payload: dict, *, public: bool) -> dict:
+    """Convert a single-score store payload into the #131 v1 response shape.
+
+    ``public`` strips operator-only blobs (full ``score`` + ``cost``);
+    ``public=False`` keeps them so ops dashboards still surface raw eval
+    detail.
+
+    Pending / running / failed envelopes still return the v1 fields with
+    nulls so external clients only ever see the new shape — the contract
+    is uniform regardless of where the eval is in its lifecycle.
+    """
+    from eval.storage.score_store import (
+        SCORE_RESPONSE_SCHEMA_VERSION,
+        build_v1_response,
+    )
+
+    score = payload.get("score") if isinstance(payload.get("score"), dict) else None
+    cost = payload.get("cost") if isinstance(payload.get("cost"), dict) else None
+    include_legacy = _legacy_score_fields_enabled()
+
+    if score is None:
+        body: dict = {
+            "schema_version": SCORE_RESPONSE_SCHEMA_VERSION,
+            "status": payload.get("status"),
+            "score_id": payload.get("score_id"),
+            "score_status": payload.get("score_status") or payload.get("status"),
+            "task_score": None,
+            "task_pass": None,
+            "detail": {},
+        }
+        if "error" in payload:
+            body["error"] = payload["error"]
+        if include_legacy:
+            scores_summary = payload.get("scores")
+            if isinstance(scores_summary, dict):
+                body["scores"] = (
+                    _public_score_summary(scores_summary)
+                    if public
+                    else dict(scores_summary)
+                )
+        return body
+
+    # Public path mirrors the pre-#131 behaviour of dropping cost entirely
+    # from the response; ops keeps it under detail.cost + raw cost blob.
+    body = build_v1_response(
+        score,
+        cost if not public else None,
+        include_legacy=include_legacy,
+    )
+    body["status"] = payload.get("status")
+
+    if include_legacy:
+        scores_summary = payload.get("scores")
+        if isinstance(scores_summary, dict):
+            body["scores"] = (
+                _public_score_summary(scores_summary)
+                if public
+                else dict(scores_summary)
+            )
+
+    if not public:
+        body["score"] = score
+        if cost is not None:
+            body["cost"] = cost
+
+    return body
+
+
+def _is_single_score_envelope(payload: dict) -> bool:
+    """Single-score envelopes carry a score_id (or score blob) but no scores list."""
+    if isinstance(payload.get("score"), dict):
+        return True
+    if isinstance(payload.get("scores"), list):
+        return False
+    if payload.get("score_id"):
+        return True
+    return payload.get("status") == "pending" and "scores" not in payload
+
+
 def _public_scores_payload(payload: dict) -> dict:
     """Strip private score internals from a score-store payload."""
+    if _is_single_score_envelope(payload):
+        return _v1_single_score_response(payload, public=True)
+
     out = {
         key: value
         for key, value in payload.items()
@@ -1848,6 +1941,13 @@ def _public_scores_payload(payload: dict) -> dict:
         else:
             out["scores"] = scores
     return out
+
+
+def _ops_scores_payload(payload: dict) -> dict:
+    """Operator-side equivalent — keeps raw score/cost but applies the v1 shape."""
+    if _is_single_score_envelope(payload):
+        return _v1_single_score_response(payload, public=False)
+    return payload
 
 
 async def rest_results(request: Request) -> JSONResponse:
@@ -1972,17 +2072,19 @@ async def ops_scores(request: Request) -> JSONResponse:
             status_filter=query.status_filter,
         )
         if payload is not None:
-            return JSONResponse(payload)
+            return JSONResponse(_ops_scores_payload(payload))
         raise
     if not state:
         return JSONResponse({"error": "Session not found"}, 404)
 
     return JSONResponse(
-        state.get_eval_scores(
-            history=query.history,
-            score_id=query.score_id,
-            score_ids=query.score_ids,
-            status_filter=query.status_filter,
+        _ops_scores_payload(
+            state.get_eval_scores(
+                history=query.history,
+                score_id=query.score_id,
+                score_ids=query.score_ids,
+                status_filter=query.status_filter,
+            )
         )
     )
 

--- a/bench/server/web/static/js/flow-demo.js
+++ b/bench/server/web/static/js/flow-demo.js
@@ -16,6 +16,7 @@
   };
 
   var POLL_MS = 2000;
+  var LIVE_STATUSES = {waiting: true, claimed: true, active: true};
 
   var _root = null;
   var _pollTimer = null;

--- a/bench/spec/PROTOCOL.md
+++ b/bench/spec/PROTOCOL.md
@@ -235,7 +235,15 @@ POST /ops/session/abc123/evaluate
 -> {"status": "running", "message": "Evaluation started."}
 
 GET /ops/session/abc123/scores
--> {"status": "completed", "scores": {"overall": 0.72, ...}}
+-> {
+     "schema_version": "1.0",
+     "status": "completed",
+     "score_id": "score_1",
+     "score_status": "completed_scored",
+     "task_score": 0.72,
+     "task_pass": null,
+     "detail": {"dimensions": [...], "tracks": {"qr": {...}, "qp": {...}}, ...}
+   }
 ```
 
 ---

--- a/bench/tests/api/test_eval_flow.py
+++ b/bench/tests/api/test_eval_flow.py
@@ -177,11 +177,13 @@ class TestGetScores:
         data = resp.json()
         assert data["status"] == "completed"
         assert data["score_id"] == "score_1"
-        assert data["scores"]["overall_score"] == 0.775
-        assert data["scores"]["judge_reliability"]["validation_run_id"]
+        assert data["task_score"] == 0.775
+        assert data["detail"]["judge_reliability"]["validation_run_id"]
         assert "score" not in data
         assert "cost" not in data
-        assert "eval_cost_usd" not in data["scores"]
+        # #131 P2: legacy summary slot dropped; cost lives only on the ops side.
+        assert "scores" not in data
+        assert "cost" not in data["detail"]
 
     @pytest.mark.asyncio
     async def test_public_scores_v1_top_level_shape(

--- a/bench/tests/api/test_eval_flow.py
+++ b/bench/tests/api/test_eval_flow.py
@@ -158,6 +158,12 @@ class TestGetScores:
         body = resp.json()
         assert body["status"] in ("running", "completed", "failed")
         assert body["score_id"] == "score_1"
+        # #131: v1 fields are present even before the score lands so
+        # external clients see a uniform shape across the lifecycle.
+        assert body["schema_version"] == "1.0"
+        assert "task_score" in body
+        assert "task_pass" in body
+        assert "detail" in body
 
     @pytest.mark.asyncio
     async def test_public_scores_completed_without_private_cost(
@@ -178,6 +184,29 @@ class TestGetScores:
         assert "eval_cost_usd" not in data["scores"]
 
     @pytest.mark.asyncio
+    async def test_public_scores_v1_top_level_shape(
+        self, app, client, mock_eval_pipeline
+    ):
+        """#131 done criterion: top-level task_score + task_pass + detail."""
+        sid, state = await _complete_and_wait_for_auto_eval(app, client)
+
+        resp = await client.get(f"/session/{sid}/scores")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["schema_version"] == "1.0"
+        assert data["score_status"] == "completed_scored"
+        assert isinstance(data["task_score"], float)
+        assert data["task_score"] == 0.775
+        # task_pass is None until PASS_THRESHOLD_CALIBRATED flips True (D-2).
+        assert data["task_pass"] is None
+        assert isinstance(data["detail"], dict)
+        assert data["detail"]["tracks"]["qr"]["score"] == 0.85
+        assert data["detail"]["tracks"]["qp"]["score"] == 0.70
+        assert isinstance(data["detail"]["dimensions"], list)
+        assert "cost" not in data["detail"]  # public path strips the cost blob
+
+    @pytest.mark.asyncio
     async def test_ops_scores_include_private_cost(
         self, app, client, mock_eval_pipeline
     ):
@@ -190,6 +219,9 @@ class TestGetScores:
         assert data["status"] == "completed"
         assert data["score_id"] == "score_1"
         assert data["cost"]["eval_cost_usd"] == 0.003
+        # #131: ops also gets the v1 shape; cost is mirrored under detail.
+        assert data["task_score"] == 0.775
+        assert data["detail"]["cost"]["eval_cost_usd"] == 0.003
 
     @pytest.mark.asyncio
     async def test_scores_history_after_multiple_evals(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -367,12 +367,33 @@ conversation, key results, trace summary, and workspace file names. It must not
 return raw tool logs, owner internals, debug histories, judge prompts, raw judge
 responses, evaluator traces, or cost internals.
 
-`GET /session/{sid}/scores` is read-only. It returns pending/running/completed
-score state from `eval.storage.score_store` and strips private score/cost internals.
+`GET /session/{sid}/scores` is read-only. It returns the v1 score response
+shape from `eval.storage.score_store.build_v1_response()` and strips private
+score/cost internals.
+
+The v1 contract has a small public top level — clients should program against
+just these fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | str | Pinned `"1.0"` for the v1 envelope. |
+| `score_id` | str \| null | `score_n` allocated by the score store. |
+| `score_status` | enum | One of `pending \| running \| completed_scored \| completed_not_computable \| failed \| interrupted`. |
+| `task_score` | float \| null | `0.6 * QR + 0.4 * QP`; null when not yet computable. |
+| `task_pass` | bool \| null | `task_score >= PASS_THRESHOLD`; null while `PASS_THRESHOLD_CALIBRATED = False`. |
+| `detail` | object | Opaque forward-compat blob — see below. |
+| `status` | str | Envelope state from the score store (`pending \| running \| completed \| failed \| partial \| not_found \| history`). `partial` only appears for multi-id `?score_ids=` lookups when requested entries mix terminal and in-flight states. |
+
+Everything else lives in `detail` and is **not part of the public contract**
+— clients depending on `detail.dimensions[*].name`, `detail.tracks.{qr,qp}`,
+or `detail.judge_reliability` are taking a beta dependency that may shift as
+the eval pipeline evolves (multi-judge panel, variable rubric, etc.).
+`detail.cost` is omitted from the public response and only surfaced via the
+operator path.
 
 Operator reads under `/ops/session/{sid}/results` and
-`/ops/session/{sid}/scores` return full server-side payloads for audit and
-debugging.
+`/ops/session/{sid}/scores` return the same v1 envelope plus the raw
+`score`/`cost` blobs and `detail.cost` for audit and debugging.
 
 ## Web UI
 

--- a/docs/skills/quanttutorbench-rest-agent/SKILL.md
+++ b/docs/skills/quanttutorbench-rest-agent/SKILL.md
@@ -343,6 +343,46 @@ GET /session/{session_id}/scores
 Authorization: Bearer <token>
 ```
 
+`/scores` returns a uniform v1 envelope across the auto-eval lifecycle:
+
+```json
+{
+  "schema_version": "1.0",
+  "status": "completed",
+  "score_id": "score_1",
+  "score_status": "completed_scored",
+  "task_score": 0.93,
+  "task_pass": null,
+  "detail": {
+    "dimensions": [
+      {"name": "result_judge", "track": "qr", "score": 5,    "status": "success"},
+      {"name": "task_planning", "track": "qp", "score": 4,   "status": "success"},
+      {"name": "tool_usage",    "track": "qp", "score": 0.85, "status": "success"}
+    ],
+    "tracks": {
+      "qr": {"score": 1.0,    "status": "success", "blockers": []},
+      "qp": {"score": 0.825, "status": "success", "blockers": []}
+    },
+    "judge_reliability": {},
+    "blocking_missing": []
+  }
+}
+```
+
+Public contract: `schema_version`, `score_id`, `score_status`, `task_score`,
+`task_pass`, `detail`, plus envelope `status`. `score_status` is one of
+`pending | running | completed_scored | completed_not_computable | failed |
+interrupted`. Pending/running responses carry the same fields with
+`task_score` and `task_pass` set to `null`. Everything inside `detail` is
+opaque — depending on the dimension list or per-track shape is a beta
+dependency.
+
+`task_pass` is `null` until baseline calibration lands. Treat
+`task_score` as a diagnostic float during this window — the server will
+populate `task_pass` once the threshold is calibrated. Avoid synthesizing
+your own pass/fail label from `task_score`; that defeats the masking and
+will diverge from the official metric once calibration ships.
+
 The external agent completes the job at terminal session status. Evaluation is
 operator-owned.
 


### PR DESCRIPTION
## Summary

- Adds the v1 score response envelope with `task_score`/`task_pass`/`detail` for `GET /session/{sid}/scores` + `/ops/...` so external clients see the shape BENCHMARK_SPEC §3.3 has been promising since day one.
- Pinned the public `score_status` enum (incl. `interrupted`) and the envelope `status` enum (incl. `partial`).
- Kept `task_pass` masked to `null` until baseline calibration ships (D-2).
- Dropped the dual-emit fallback after P1 verified no internal consumer depends on the legacy summary keys.
- Updated `docs/architecture.md`, `docs/skills/quanttutorbench-rest-agent/SKILL.md`, `BENCHMARK_SPEC.md`, and `bench/spec/PROTOCOL.md` to match.

Closes #131.

## Test plan

- [x] `bench/tests/api/test_eval_flow.py` — 15/15 pass (3 new assertions: completed v1 shape, ops with cost in `detail`, pending/running envelopes carry the same fields with nulls).
- [x] `bench/tests/api/` — 105/106 pass (1 pre-existing `test_register_invalid_persona` failure on `dev`, unrelated).
- [ ] Prod smoke against the new shape after deploy: external client gets non-null `task_score` within 60s of completion.

## Codex review

P0: 2/2 rounds — accepted "pending/running/failed envelopes also need v1 shape" + "add `interrupted` to public status enum"; rejected unrelated untracked human-review artifact (rule 7).

P2: 2/2 rounds — accepted "PROTOCOL.md still shows legacy shape" + "missing `partial` in envelope status enum" + "SKILL.md was telling clients to compute pass/fail themselves" (defeats masking); rejected the same untracked artifact (rule 7).