### PR TITLE
fix(server): terminate session on student goodbye signal (#132)

### DIFF
--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -1097,7 +1097,8 @@ def _classify_session_failure(termination_reason: str | None) -> str:
     - ``agent_gave_up`` — not retryable (``agent_stuck``, ``agent_abandoned``).
     - ``max_turns_reached`` — not retryable (``max_turns``, ``timeout``;
       session-level timeout is treated as exhaustion, not infra failure).
-    - ``terminal_success`` — not retryable (``objectives_met``).
+    - ``terminal_success`` — not retryable (``objectives_met``,
+      ``student_satisfied``).
     - ``unknown`` — not retryable; defensive default.
     """
     if not termination_reason:
@@ -1106,7 +1107,7 @@ def _classify_session_failure(termination_reason: str | None) -> str:
         return _RETRYABLE_FAILURE
     if termination_reason in ("agent_stuck", "agent_abandoned"):
         return "agent_gave_up"
-    if termination_reason == "objectives_met":
+    if termination_reason in ("objectives_met", "student_satisfied"):
         return "terminal_success"
     if termination_reason in ("max_turns", "timeout"):
         return "max_turns_reached"

--- a/bench/server/core/session.py
+++ b/bench/server/core/session.py
@@ -15,7 +15,8 @@ Session status semantics
 ``send_message`` returns one of three ``status`` values:
 
 - ``"active"``    — session is still running; student reply included
-- ``"completed"`` — session ended normally (objectives_met / max_turns / timeout)
+- ``"completed"`` — session ended normally (objectives_met / student_satisfied
+                    / max_turns / timeout)
 - ``"failed"``    — session aborted due to an abnormal condition
                     (student_sim_error:* / agent_stuck)
 """
@@ -598,6 +599,19 @@ class TutoringSession:
             self._completion_reason = reason
             return self._result("", "failed", reason=reason, sim_error=sim_error)
         self._conversation.append({"role": "user", "content": reply, "ts": time.time()})
+
+        # ── Student-end signal (heuristic on the reply text) ──
+        # The student persona's own reply is treated as the session closing
+        # — no extra closing message is appended on top.
+        from server.core.student_sim import signaled_end_of_session
+
+        if signaled_end_of_session(reply):
+            self._done = True
+            self._completion_reason = "student_satisfied"
+            logger.info(
+                "Student signaled end-of-session at turn %d.", self._turn
+            )
+            return self._result(reply, "completed", reason="student_satisfied")
 
         return self._result(reply, "active")
 

--- a/bench/server/core/student_sim.py
+++ b/bench/server/core/student_sim.py
@@ -117,6 +117,69 @@ _JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
 
 
 # ---------------------------------------------------------------------------
+# Student end-of-session signal detection
+# ---------------------------------------------------------------------------
+
+# Phrases the student persona uses when satisfied and ready to end the session.
+# Conservative list — only clear closing signals. False negatives (one extra
+# turn) are cheaper than false positives (truncating a still-active session).
+_GOODBYE_PATTERNS = (
+    # "good to stop / end / wrap up / call it"
+    r"\bgood to (?:stop|end|wrap up|leave it|move on|call it)\b",
+    # "stop here for now", "stop here." — clause-final stop signal
+    r"\b(?:stop|wrap up|leave it|call it)(?:\s+here)?\s+for now\b",
+    r"\bstop here(?:\.|!|$)",
+    # "I'm done" — must end the clause or carry closing context
+    r"\b(?:I[' ]?m|I am)\s+done(?:\.|!|$)",
+    r"\b(?:I[' ]?m|I am)\s+done\s+(?:for now|here|with (?:this|that|today|the (?:topic|material|explanation)))",
+    # "I'm all set"
+    r"\b(?:I[' ]?m|I am)\s+all set\b",
+    # "I'm good" — only with closing context (avoids "I'm good at math")
+    r"\b(?:I[' ]?m|I am)\s+good\s+(?:to (?:stop|end|wrap up|go|leave|move on|call it)|for now|here|with (?:this|that))",
+    # "I think I'm done|all set|all good" — unambiguous closing
+    r"\bI think (?:I[' ]?m|I am|we[' ]?re|we are)\s+(?:done|all set|all good)\b",
+    # "I think I'm good|fine" — must be clause-final, with the optional
+    # closing-context phrase itself ending the clause. Avoids matching
+    # "I think I'm good with the rolling window..." or "fine with that part".
+    r"\bI think (?:I[' ]?m|I am|we[' ]?re|we are)\s+(?:good|fine)(?:\s+(?:for now|here|with (?:that|this)))?(?:\.|!|$)",
+    # "That's all (I needed)"
+    r"\bthat[' ]?s all (?:I needed|I had|for now|the help I needed|I was after)\b",
+    r"\bthanks,? that[' ]?s all\b",
+    r"\bthat[' ]?s (?:all|it),? thanks\b",
+    # "No more questions"
+    r"\bno (?:more|further|other) questions\b",
+    # "Call it a day", "let's wrap up"
+    r"\bcall it (?:a day|done|here)\b",
+    r"\blet[' ]?s (?:wrap|call) (?:up|it up|things up|it (?:done|a day))\b",
+    # Intent to apply independently — only with explicit "this/that/it" object
+    # and clause-final marker (avoids "let me try this on the data")
+    r"\b(?:I[' ]?ll|let me)\s+(?:go )?(?:try|run|test|apply|implement|practice|revisit|experiment with)\s+(?:this|that|it)(?:\s+(?:on my own|myself|now|out))?(?:\.|!|$)",
+)
+
+_GOODBYE_RE = re.compile("|".join(_GOODBYE_PATTERNS), re.IGNORECASE)
+
+
+def signaled_end_of_session(text: str) -> bool:
+    """Heuristic: did the student's reply signal session-end satisfaction?
+
+    Triggered by phrases the student persona uses to wind down — "I'm good
+    to stop here for now", "I'm done", "thanks, that's all", "no more
+    questions", "let me try this on my own". A trailing question mark
+    disqualifies the match (a student still asking is not actually done).
+
+    Conservative by design: false negatives are cheaper than false positives.
+    Returns False on empty input.
+    """
+    if not text or not text.strip():
+        return False
+    stripped = text.strip()
+    # Trailing question — student is still asking, not done.
+    if stripped.endswith("?"):
+        return False
+    return bool(_GOODBYE_RE.search(stripped))
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/bench/tests/api/test_session_completion_api.py
+++ b/bench/tests/api/test_session_completion_api.py
@@ -99,6 +99,60 @@ class TestRepeatDetectionViaAPI:
 
 
 # ---------------------------------------------------------------------------
+# Student-satisfied termination (issue #132)
+# ---------------------------------------------------------------------------
+
+
+class TestStudentSatisfiedViaAPI:
+    @pytest.mark.asyncio
+    async def test_student_goodbye_terminates_session(self, app, client, monkeypatch):
+        sid, _ = await register_and_start(client)
+        state = _get_session_state(app, sid)
+        # Force the next student reply to be the canonical D02 goodbye.
+        monkeypatch.setattr(
+            state.session._student_sim,
+            "generate_message",
+            lambda *a, **kw: "Got it, I'm good to stop here for now.",
+        )
+
+        body = await send_message(client, sid, "Anything else I can help with?")
+        assert body["status"] == "completed"
+        assert body["reason"] == "student_satisfied"
+
+    @pytest.mark.asyncio
+    async def test_subsequent_send_after_student_satisfied_denied(
+        self, app, client, monkeypatch
+    ):
+        sid, _ = await register_and_start(client)
+        state = _get_session_state(app, sid)
+        monkeypatch.setattr(
+            state.session._student_sim,
+            "generate_message",
+            lambda *a, **kw: "Thanks, that's all I needed!",
+        )
+
+        await send_message(client, sid, "Anything else?")
+        # Phase is COMPLETED — REST permission check returns 403.
+        resp = await client.post(f"/session/{sid}/send", json={"text": "hello?"})
+        assert resp.status_code == 403
+        assert resp.json().get("allowed") == []
+
+    @pytest.mark.asyncio
+    async def test_student_question_does_not_terminate(self, app, client, monkeypatch):
+        sid, _ = await register_and_start(client)
+        state = _get_session_state(app, sid)
+        # Mentions "stop" but is asking a question — must NOT terminate.
+        monkeypatch.setattr(
+            state.session._student_sim,
+            "generate_message",
+            lambda *a, **kw: "Before we stop, one quick question: what about edges?",
+        )
+
+        body = await send_message(client, sid, "Make sense so far?")
+        assert body["status"] == "active"
+
+
+# ---------------------------------------------------------------------------
 # Deadline timeout
 # ---------------------------------------------------------------------------
 

--- a/bench/tests/api/test_session_retry.py
+++ b/bench/tests/api/test_session_retry.py
@@ -57,6 +57,7 @@ class TestClassifySessionFailure:
 
     def test_terminal_categories(self):
         assert _classify_session_failure("objectives_met") == "terminal_success"
+        assert _classify_session_failure("student_satisfied") == "terminal_success"
         assert _classify_session_failure("max_turns") == "max_turns_reached"
         assert _classify_session_failure("timeout") == "max_turns_reached"
 

--- a/bench/tests/unit/test_student_sim_goodbye.py
+++ b/bench/tests/unit/test_student_sim_goodbye.py
@@ -1,0 +1,68 @@
+"""Unit tests for student-end heuristic (signaled_end_of_session).
+
+Pure-function coverage of the closing-signal regex set used by the session
+loop to terminate on student satisfaction (issue #132).
+"""
+
+import pytest
+
+from server.core.student_sim import signaled_end_of_session
+
+# Phrases the student persona uses when satisfied — these MUST terminate.
+# Includes the canonical D02 case ("I'm good to stop here for now") plus the
+# explicit examples from the issue body.
+_POSITIVE_PHRASES = [
+    "I'm good to stop here for now.",
+    "Thanks, I'm good to stop here for now!",
+    "Good to stop here, thanks for the help.",
+    "I think I'm good.",
+    "I think we're done here.",
+    "I'm done.",
+    "I'm done with this for now.",
+    "Thanks, that's all I needed!",
+    "That's all, thanks.",
+    "No more questions, thanks for the walkthrough.",
+    "OK, I'm all set!",
+    "Let's call it a day.",
+    "Let me try this on my own.",
+    "I'll go run this myself.",
+]
+
+# Phrases that mention "stop"/"done"/"good" in non-closing contexts — must
+# NOT terminate. Covers the two negatives called out in issue #132 plus a
+# few common false-positive shapes.
+_NEGATIVE_PHRASES = [
+    "Stop and let me think a moment — why does the rolling window matter?",
+    "Before we stop, one quick question: what about edge cases?",
+    "I'm good with the rolling window, but stuck on the resampling.",
+    # Codex P1 finding: "I think I'm good with X" must NOT terminate
+    "I think I'm good with the rolling window, but stuck on the resampling.",
+    "I think I'm fine with that part, but the resampling still confuses me.",
+    "I'm done loading the data. What's next?",
+    "Let me try this on the actual dataset and see what happens.",
+    "I'm good at math but new to pandas, so this is helpful.",
+]
+
+
+@pytest.mark.parametrize("text", _POSITIVE_PHRASES)
+def test_positive_phrases_terminate(text):
+    assert signaled_end_of_session(text), f"Expected terminate: {text!r}"
+
+
+@pytest.mark.parametrize("text", _NEGATIVE_PHRASES)
+def test_negative_phrases_do_not_terminate(text):
+    assert not signaled_end_of_session(text), f"Expected continue: {text!r}"
+
+
+def test_empty_input_returns_false():
+    assert not signaled_end_of_session("")
+    assert not signaled_end_of_session("   ")
+    assert not signaled_end_of_session(None)  # type: ignore[arg-type]
+
+
+def test_trailing_question_disqualifies_otherwise_matching_text():
+    # Without "?": terminates. With trailing "?": does not.
+    assert signaled_end_of_session("I think I'm good.")
+    assert not signaled_end_of_session(
+        "I think I'm good — but one more question, what about Y?"
+    )


### PR DESCRIPTION
## Summary

- `signaled_end_of_session()` heuristic detects student-persona closing signals (e.g. "I'm good to stop here for now"); on hit, the session returns `status="completed"`, `reason="student_satisfied"`.
- `/session/{sid}/retry` classifier now maps `student_satisfied` → `terminal_success` (was returning `unknown`).
- Auto-eval fires identically to `objectives_met` — no eval-pipeline change.

Closes #132

## Test plan

- [x] `bench/tests/unit/test_student_sim_goodbye.py` (24 cases)
- [x] `bench/tests/api/test_session_completion_api.py::TestStudentSatisfiedViaAPI` (3 cases)
- [x] `bench/tests/api/test_session_retry.py::TestClassifySessionFailure::test_terminal_categories` (extended)
- [x] Full regression: 314 passed (3 pre-existing master failures unrelated)
- [ ] Manual repro on D02 against preview deployment