### PR TITLE
fix(ui): /ui/runs/live no longer 500s on restored session tool logs (#135)

### DIFF
--- a/bench/server/web/ui_app.py
+++ b/bench/server/web/ui_app.py
@@ -16,7 +16,7 @@ import json
 import logging
 import math
 import os
-from dataclasses import asdict
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
 
 from server.audit import record_event
@@ -123,7 +123,14 @@ def _is_protocol_tool_log(log) -> bool:
 def _safe_tool_log_dict(log) -> dict:
     if isinstance(log, dict):
         return log
-    return asdict(log)
+    if is_dataclass(log):
+        return asdict(log)
+    # Restored sessions wrap tool logs as SimpleNamespace (see
+    # SessionState.restore_from_storage); asdict() rejects those, so fall
+    # back to __dict__ before giving up.
+    if hasattr(log, "__dict__"):
+        return dict(log.__dict__)
+    return {"raw": str(log)}
 
 
 # ---------------------------------------------------------------------------

--- a/bench/tests/unit/test_safe_tool_log_dict.py
+++ b/bench/tests/unit/test_safe_tool_log_dict.py
@@ -1,0 +1,57 @@
+"""Unit tests for _safe_tool_log_dict (issue #135).
+
+The /ui/runs/live snapshot iterates tool-log entries from
+session.proxy.get_logs(). For live sessions those are ToolCallLog
+dataclass instances; for restored completed sessions they are wrapped
+as SimpleNamespace by SessionState.restore_from_storage. The helper
+must serialise both shapes without raising.
+"""
+
+from types import SimpleNamespace
+
+from server.core.proxy import ToolCallLog
+from server.web.ui_app import _safe_tool_log_dict
+
+
+def test_dict_passes_through():
+    log = {"name": "shell_exec", "args": {"command": "ls"}, "success": True}
+    assert _safe_tool_log_dict(log) == log
+
+
+def test_dataclass_serialises_via_asdict():
+    log = ToolCallLog(
+        name="shell_exec",
+        args={"command": "ls"},
+        call_id="c1",
+        result="file.txt\n",
+        success=True,
+        turn_index=1,
+    )
+    out = _safe_tool_log_dict(log)
+    assert isinstance(out, dict)
+    assert out["name"] == "shell_exec"
+    assert out["args"] == {"command": "ls"}
+    assert out["success"] is True
+
+
+def test_simplenamespace_falls_back_to_dunder_dict():
+    # Restored sessions use SimpleNamespace(**log) for tool logs.
+    log = SimpleNamespace(
+        name="shell_exec",
+        args={"command": "ls"},
+        success=True,
+        turn_index=1,
+    )
+    out = _safe_tool_log_dict(log)
+    assert isinstance(out, dict)
+    assert out["name"] == "shell_exec"
+    assert out["args"] == {"command": "ls"}
+
+
+def test_unknown_object_returns_raw_marker():
+    class Opaque:
+        __slots__ = ()
+
+    out = _safe_tool_log_dict(Opaque())
+    assert isinstance(out, dict)
+    assert "raw" in out


### PR DESCRIPTION
## Summary

- \`_safe_tool_log_dict\` now branches on \`is_dataclass\` and falls back to \`__dict__\` for \`SimpleNamespace\`-wrapped tool logs from restored sessions, so the Session Flow polling endpoint stops 500ing.
- Single-file runtime change + 4-case unit test (dict / dataclass / SimpleNamespace / unknown).

Closes #135

## Test plan

- [x] \`bench/tests/unit/test_safe_tool_log_dict.py\` — 4 cases pass
- [x] Full regression (318 tests pass; 3 pre-existing master failures unrelated)
- [ ] Manual verify on benchmark-liard.vercel.app: open Session Flow as run owner, confirm 200 + populated conversation card for an active run while a previously-completed session also sits in \`manager._sessions\`