### PR TITLE
fix(server): student_satisfied catches curly apostrophes (#137)

### DIFF
--- a/bench/server/core/student_sim.py
+++ b/bench/server/core/student_sim.py
@@ -132,12 +132,15 @@ _GOODBYE_PATTERNS = (
     # "I'm done" — must end the clause or carry closing context
     r"\b(?:I[' ]?m|I am)\s+done(?:\.|!|$)",
     r"\b(?:I[' ]?m|I am)\s+done\s+(?:for now|here|with (?:this|that|today|the (?:topic|material|explanation)))",
-    # "I'm all set"
-    r"\b(?:I[' ]?m|I am)\s+all set\b",
+    # "I'm all set" — clause-final or explicit closing context.
+    # Avoids matching "I'm all set with the rolling window, but stuck on Y."
+    r"\b(?:I[' ]?m|I am)\s+all set(?:\s+(?:for now|now|here|with (?:that|this)))?(?:\.|!|$)",
     # "I'm good" — only with closing context (avoids "I'm good at math")
     r"\b(?:I[' ]?m|I am)\s+good\s+(?:to (?:stop|end|wrap up|go|leave|move on|call it)|for now|here|with (?:this|that))",
-    # "I think I'm done|all set|all good" — unambiguous closing
-    r"\bI think (?:I[' ]?m|I am|we[' ]?re|we are)\s+(?:done|all set|all good)\b",
+    # "I think I'm done|all set|all good" — clause-final or closing context.
+    # Avoids matching "I think I'm done loading the data, what's next?" or
+    # "I think I'm all good with the basics but unsure about Y."
+    r"\bI think (?:I[' ]?m|I am|we[' ]?re|we are)\s+(?:done|all set|all good)(?:\s+(?:for now|now|here|with (?:that|this)))?(?:\.|!|$)",
     # "I think I'm good|fine" — must be clause-final, with the optional
     # closing-context phrase itself ending the clause. Avoids matching
     # "I think I'm good with the rolling window..." or "fine with that part".
@@ -172,7 +175,11 @@ def signaled_end_of_session(text: str) -> bool:
     """
     if not text or not text.strip():
         return False
-    stripped = text.strip()
+    # The LLM-driven student persona emits Unicode curly apostrophes
+    # (U+2019) in contractions like "I'm". The goodbye patterns use the
+    # ASCII apostrophe, so normalize before matching to avoid false negatives.
+    normalized = text.replace("’", "'").replace("‘", "'").replace("ʼ", "'")
+    stripped = normalized.strip()
     # Trailing question — student is still asking, not done.
     if stripped.endswith("?"):
         return False

--- a/bench/tests/unit/test_student_sim_goodbye.py
+++ b/bench/tests/unit/test_student_sim_goodbye.py
@@ -38,6 +38,10 @@ _NEGATIVE_PHRASES = [
     # Codex P1 finding: "I think I'm good with X" must NOT terminate
     "I think I'm good with the rolling window, but stuck on the resampling.",
     "I think I'm fine with that part, but the resampling still confuses me.",
+    # Issue #137 Codex P2 finding: broad "all set" shouldn't match mid-clause
+    "I'm all set with the rolling window, but stuck on the resampling.",
+    "I think I'm all set with the basics but the slow window still confuses me.",
+    "I think I'm done loading the data, anything else I should check.",
     "I'm done loading the data. What's next?",
     "Let me try this on the actual dataset and see what happens.",
     "I'm good at math but new to pandas, so this is helpful.",
@@ -66,3 +70,21 @@ def test_trailing_question_disqualifies_otherwise_matching_text():
     assert not signaled_end_of_session(
         "I think I'm good — but one more question, what about Y?"
     )
+
+
+# Regression for #137: student persona emits curly apostrophes (U+2019)
+# in contractions; the regex must still terminate. Verified against the
+# real A02 transcript that timed out at 10 student turns instead of
+# terminating at the third clear goodbye.
+_CURLY_GOODBYES = [
+    "Thanks — I’m good for now. I was stressed at first.",
+    "Sounds good — thanks, I’m all set for now.",
+    "Thanks, I appreciate it — I’m done for now.",
+    "Thanks — I’m all set now.",
+    "I think I’m done now though, so I’m going to stop here.",
+]
+
+
+@pytest.mark.parametrize("text", _CURLY_GOODBYES)
+def test_curly_apostrophe_variants_terminate(text):
+    assert signaled_end_of_session(text), f"Expected terminate: {text!r}"


### PR DESCRIPTION
## Summary

- Normalize curly apostrophes (\`'\` → \`'\`) at the entry of \`signaled_end_of_session\` so phrases like "I'm good for now" match.
- Tighten broad \`I'm all set\` / \`I think I'm all set|all good|done\` branches to clause-final or closing context, addressing the Codex P2 finding that normalization exposes the same shape on more inputs.

Closes #137 — verified against the real A02 transcript (\`bf20fae70b6c\`) where 5 consecutive curly-quoted goodbye phrases failed to terminate the session.

## Test plan

- [x] 32 unit cases in \`test_student_sim_goodbye.py\` (adds curly-variant positives + mid-clause negatives)
- [x] Full regression: 326 pass
- [ ] Manual verify: drive an A02 session past 3 student goodbye turns; \`termination_reason\` recorded as \`student_satisfied\`, not \`timeout\`