### PR TITLE
feat(server): student persona emits task_end for termination (#139)

### DIFF
--- a/bench/experiments/student_sim_stability/pipeline/probes.py
+++ b/bench/experiments/student_sim_stability/pipeline/probes.py
@@ -284,7 +284,7 @@ def run_probes(
                 "source": "probe_tutor_script",
             }
         ]
-        message = sim.generate_message(conversation)
+        message, _ = sim.generate_message(conversation)
         expected_signals = (probe.get("expected_signals_by_persona") or {}).get(
             persona_id, []
         )

--- a/bench/experiments/student_sim_stability/pipeline/runner.py
+++ b/bench/experiments/student_sim_stability/pipeline/runner.py
@@ -217,7 +217,7 @@ def run_single_trial(
         )
 
         if turn_idx < n_turns - 1:
-            student_msg = sim.generate_message(conversation)
+            student_msg, _ = sim.generate_message(conversation)
             conversation.append(
                 {
                     "role": "user",

--- a/bench/server/core/session.py
+++ b/bench/server/core/session.py
@@ -562,7 +562,7 @@ class TutoringSession:
 
         # ── Generate student reply ──  (aligned: generate_next_user_input)
         try:
-            reply = self._student_sim.generate_message(
+            reply, task_end = self._student_sim.generate_message(
                 self._conversation,
                 runtime_guidance=self._build_student_runtime_guidance(
                     text,
@@ -600,16 +600,27 @@ class TutoringSession:
             return self._result("", "failed", reason=reason, sim_error=sim_error)
         self._conversation.append({"role": "user", "content": reply, "ts": time.time()})
 
-        # ── Student-end signal (heuristic on the reply text) ──
-        # The student persona's own reply is treated as the session closing
-        # — no extra closing message is appended on top.
+        # ── Student-end signal ──
+        # Primary: persona-emitted `task_end` flag (issue #139). The reply
+        # still flows to the agent first; the session closes after.
+        # Fallback: regex heuristic on the reply text (issues #132/#137) —
+        # cheap belt-and-suspenders for personas that don't emit the flag.
+        if task_end:
+            self._done = True
+            self._completion_reason = "student_satisfied"
+            logger.info(
+                "Student persona emitted task_end=true at turn %d.", self._turn
+            )
+            return self._result(reply, "completed", reason="student_satisfied")
+
         from server.core.student_sim import signaled_end_of_session
 
         if signaled_end_of_session(reply):
             self._done = True
             self._completion_reason = "student_satisfied"
             logger.info(
-                "Student signaled end-of-session at turn %d.", self._turn
+                "Student signaled end-of-session at turn %d (regex fallback).",
+                self._turn,
             )
             return self._result(reply, "completed", reason="student_satisfied")
 

--- a/bench/server/core/student_sim.py
+++ b/bench/server/core/student_sim.py
@@ -55,9 +55,16 @@ class StudentSimError(Exception):
 
 
 class SimulatedInput(BaseModel):
-    """Schema for structured student message output."""
+    """Schema for structured student message output.
+
+    ``task_end`` lets the persona itself signal that the conversation is
+    over. The session loop sends the reply to the agent and then closes —
+    no more turns. Defaults to ``False`` for backward compatibility with
+    older personas that have not been re-prompted yet.
+    """
 
     simulated_input: str
+    task_end: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -80,7 +87,19 @@ _NEXT_MESSAGE_PROMPT = textwrap.dedent(
     Conversation so far:
     {transcript}
 
-    Respond with a JSON object containing a single key `simulated_input`.
+    Respond with a JSON object with two keys:
+      - `simulated_input` (string): your next reply to the tutor.
+      - `task_end` (boolean): set to true ONLY when you would naturally
+        walk away from this conversation — your question is fully
+        answered, you have what you need, and the next thing you would
+        do is leave the chat. Set to false in every other case,
+        including when you are still asking, still confused, still
+        working through something, or just being polite.
+
+    When `task_end` is true, your `simulated_input` should read as a
+    natural goodbye / sign-off message — that is the last thing the
+    tutor will see before the session closes.
+
     JSON Output:
 """
 )
@@ -95,7 +114,9 @@ _REPAIR_PROMPT = textwrap.dedent(
     {bad_output}
     ---
     Return ONLY valid JSON in this exact shape, with no markdown, commentary, or extra keys:
-    {{"simulated_input": "..."}}
+    {{"simulated_input": "...", "task_end": false}}
+    Set `task_end` to true only if you would naturally end the chat now;
+    otherwise leave it false.
 """
 )
 
@@ -339,13 +360,19 @@ def _collect_images_from_ledger(
     return images
 
 
-def _parse_simulated_input_strict(raw: str) -> tuple[str, str]:
-    """Extract ``simulated_input`` from JSON output.
+def _parse_simulated_input_strict(raw: str) -> tuple[str, bool, str]:
+    """Extract ``simulated_input`` and ``task_end`` from JSON output.
 
-    Returns ``(text, parse_method)`` on success where ``parse_method`` is one of:
+    Returns ``(text, task_end, parse_method)`` on success where
+    ``parse_method`` is one of:
     - ``"json"``: extracted from ``simulated_input`` key
     - ``"json_single_value"``: extracted from the only string value in a JSON object
     - ``"fallback_text"``: accepted as natural-language student message
+
+    ``task_end`` defaults to ``False`` whenever the field is missing,
+    not a real Python bool, or the canonical key path is bypassed
+    (single-value / fallback-text). Bias to False so a malformed
+    response never accidentally terminates a still-active session.
 
     Raises ``ValueError`` if parsing fails.  Empty-output errors have the
     prefix ``"empty:"`` so callers can distinguish them from structural parse
@@ -360,7 +387,11 @@ def _parse_simulated_input_strict(raw: str) -> tuple[str, str]:
             data = json.loads(match.group())
             text = data.get("simulated_input")
             if text and text.strip():
-                return text.strip(), "json"
+                raw_end = data.get("task_end", False)
+                # Strict bool: only Python True terminates. Anything else
+                # (string "true", 1, missing) is treated as False.
+                task_end = raw_end is True
+                return text.strip(), task_end, "json"
             # simulated_input missing or empty — try single-value fallback
             # before giving up: if the object has exactly one string value and
             # it passes the usability check, accept it with a warning.
@@ -375,7 +406,7 @@ def _parse_simulated_input_strict(raw: str) -> tuple[str, str]:
                     "accepted single string value from JSON (key drift). raw=%r",
                     raw[:120],
                 )
-                return string_values[0].strip(), "json_single_value"
+                return string_values[0].strip(), False, "json_single_value"
         except (json.JSONDecodeError, TypeError):
             pass
         # JSON found but no usable value — not usable as-is
@@ -384,7 +415,7 @@ def _parse_simulated_input_strict(raw: str) -> tuple[str, str]:
     # No JSON — check if raw text is usable as a student message
     stripped = raw.strip()
     if _is_usable_student_message(stripped):
-        return stripped, "fallback_text"
+        return stripped, False, "fallback_text"
 
     raise ValueError(f"No JSON and text not usable as student message: {raw[:120]!r}")
 
@@ -462,8 +493,14 @@ class StudentSimulator:
             self._model = resolve_ewan_model(self._model)
         return self._model
 
-    def _generate_parsed(self, prompt: str, images: list[dict] | None = None) -> str:
+    def _generate_parsed(
+        self, prompt: str, images: list[dict] | None = None
+    ) -> tuple[str, bool]:
         """Generate text via model with retry, parse JSON output, track cost.
+
+        Returns ``(text, task_end)``.  ``task_end`` is the persona-emitted
+        end-of-session flag (defaults to ``False`` for any non-canonical
+        parse path or missing key).
 
         Retry strategy (budget: ``_MAX_GENERATE_ATTEMPTS``):
         - network error  → retry with original prompt (transient failure)
@@ -519,8 +556,12 @@ class StudentSimulator:
 
             # --- Parse layer ---
             try:
-                parsed, parse_method = _parse_simulated_input_strict(text)
-                attempt_record.update(error_type=None, parse_method=parse_method)
+                parsed, task_end, parse_method = _parse_simulated_input_strict(text)
+                attempt_record.update(
+                    error_type=None,
+                    parse_method=parse_method,
+                    task_end=task_end,
+                )
                 attempts.append(attempt_record)
                 if len(attempts) > 1:
                     logger.info(
@@ -528,7 +569,7 @@ class StudentSimulator:
                         attempt_idx + 1,
                         _MAX_GENERATE_ATTEMPTS,
                     )
-                return parsed
+                return parsed, task_end
             except ValueError as exc:
                 detail = str(exc)
                 # Distinguish empty output from structural parse failure so
@@ -570,7 +611,7 @@ class StudentSimulator:
         runtime_guidance: str = "",
         file_ledger: dict[str, dict] | None = None,
         workspace_path: str | None = None,
-    ) -> str:
+    ) -> tuple[str, bool]:
         """Generate the next student message given conversation history.
 
         Args:
@@ -581,7 +622,10 @@ class StudentSimulator:
                 student can see shared workspace files in temporal context.
 
         Returns:
-            The student's next message as a string.
+            ``(text, task_end)`` — the student's next message and the
+            persona-emitted end-of-session flag. ``task_end=True`` means
+            the session loop should send this reply to the agent and
+            then close (no further turns).
         """
         runtime_guidance_block = ""
         if runtime_guidance.strip():

--- a/bench/tests/api/test_session_completion_api.py
+++ b/bench/tests/api/test_session_completion_api.py
@@ -109,10 +109,11 @@ class TestStudentSatisfiedViaAPI:
         sid, _ = await register_and_start(client)
         state = _get_session_state(app, sid)
         # Force the next student reply to be the canonical D02 goodbye.
+        # task_end=False here exercises the regex fallback path.
         monkeypatch.setattr(
             state.session._student_sim,
             "generate_message",
-            lambda *a, **kw: "Got it, I'm good to stop here for now.",
+            lambda *a, **kw: ("Got it, I'm good to stop here for now.", False),
         )
 
         body = await send_message(client, sid, "Anything else I can help with?")
@@ -128,7 +129,7 @@ class TestStudentSatisfiedViaAPI:
         monkeypatch.setattr(
             state.session._student_sim,
             "generate_message",
-            lambda *a, **kw: "Thanks, that's all I needed!",
+            lambda *a, **kw: ("Thanks, that's all I needed!", False),
         )
 
         await send_message(client, sid, "Anything else?")
@@ -145,11 +146,36 @@ class TestStudentSatisfiedViaAPI:
         monkeypatch.setattr(
             state.session._student_sim,
             "generate_message",
-            lambda *a, **kw: "Before we stop, one quick question: what about edges?",
+            lambda *a, **kw: (
+                "Before we stop, one quick question: what about edges?",
+                False,
+            ),
         )
 
         body = await send_message(client, sid, "Make sense so far?")
         assert body["status"] == "active"
+
+    @pytest.mark.asyncio
+    async def test_task_end_flag_terminates_paraphrased_closure(
+        self, app, client, monkeypatch
+    ):
+        # Issue #139: paraphrased closure that the regex misses still
+        # terminates because the persona emits task_end=True.
+        sid, _ = await register_and_start(client)
+        state = _get_session_state(app, sid)
+        monkeypatch.setattr(
+            state.session._student_sim,
+            "generate_message",
+            lambda *a, **kw: (
+                "Perfect — that feels like the right stopping point for now. "
+                "I'll come back later for the rest.",
+                True,
+            ),
+        )
+
+        body = await send_message(client, sid, "Sounds good?")
+        assert body["status"] == "completed"
+        assert body["reason"] == "student_satisfied"
 
 
 # ---------------------------------------------------------------------------

--- a/bench/tests/unit/test_student_sim_task_end.py
+++ b/bench/tests/unit/test_student_sim_task_end.py
@@ -1,0 +1,96 @@
+"""Unit tests for the persona-emitted ``task_end`` flag (issue #139).
+
+The student-sim JSON output now carries a ``task_end`` boolean alongside
+``simulated_input``. The session loop terminates with
+``reason=student_satisfied`` when ``task_end`` is true. Parser must
+default to ``False`` when the field is missing, malformed, or the
+non-canonical fallback paths are taken.
+"""
+
+import json
+
+import pytest
+
+from server.core.student_sim import _parse_simulated_input_strict
+
+
+def _wrap(text: str, task_end=None) -> str:
+    payload: dict = {"simulated_input": text}
+    if task_end is not None:
+        payload["task_end"] = task_end
+    return json.dumps(payload)
+
+
+class TestTaskEndExtraction:
+    def test_explicit_true_extracted(self):
+        text, task_end, method = _parse_simulated_input_strict(
+            _wrap("That clears it up — I'll go try this myself.", True)
+        )
+        assert task_end is True
+        assert method == "json"
+        assert "try this myself" in text
+
+    def test_explicit_false_extracted(self):
+        text, task_end, method = _parse_simulated_input_strict(
+            _wrap("Wait — what about edge cases?", False)
+        )
+        assert task_end is False
+        assert method == "json"
+
+    def test_missing_field_defaults_to_false(self):
+        text, task_end, method = _parse_simulated_input_strict(
+            _wrap("Got it, makes sense.")
+        )
+        assert task_end is False
+        assert method == "json"
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["true", "false", "yes", 1, 0, None, [], {}],
+    )
+    def test_non_bool_values_default_to_false(self, bad_value):
+        # Strict bool: only Python ``True`` terminates. String "true",
+        # integer 1, lists, dicts — all coerce to False so that a
+        # malformed model output never accidentally truncates a session.
+        text, task_end, _ = _parse_simulated_input_strict(
+            _wrap("Reply text.", bad_value)
+        )
+        assert task_end is False
+
+
+class TestFallbackPathsForceFalse:
+    def test_single_value_fallback_forces_false(self):
+        # The model dropped the canonical key but the only string value
+        # is usable. The fallback path must not surface task_end=True
+        # because the field's intent is undefined here.
+        raw = json.dumps(
+            {"reply": "Sure, that helps. I'll think on it.", "task_end": True}
+        )
+        text, task_end, method = _parse_simulated_input_strict(raw)
+        assert method == "json_single_value"
+        assert task_end is False
+
+    def test_natural_language_fallback_forces_false(self):
+        # No JSON at all — student message accepted as raw text. No way
+        # to express task_end without the schema, so default False.
+        text, task_end, method = _parse_simulated_input_strict(
+            "Got it, that makes sense."
+        )
+        assert method == "fallback_text"
+        assert task_end is False
+
+
+class TestEmptyAndMalformed:
+    def test_empty_input_raises(self):
+        with pytest.raises(ValueError, match="empty:"):
+            _parse_simulated_input_strict("")
+
+    def test_whitespace_input_raises(self):
+        with pytest.raises(ValueError, match="empty:"):
+            _parse_simulated_input_strict("   \n\t  ")
+
+    def test_json_without_simulated_input_raises(self):
+        # Object has multiple non-string-or-empty values, no fallback.
+        raw = json.dumps({"reply_a": "", "reply_b": ""})
+        with pytest.raises(ValueError):
+            _parse_simulated_input_strict(raw)


### PR DESCRIPTION
## Summary

- Replace regex-only goodbye detection with a persona-emitted `task_end: bool` field in the student's existing JSON output schema. The model that writes the reply also decides whether the conversation is over — zero extra latency, zero extra cost, no regex treadmill.
- Session loop terminates with `reason=student_satisfied` when `task_end=True`; the reply still flows to the agent first. The existing regex (`signaled_end_of_session`) stays as a cheap belt-and-suspenders fallback.
- Background: A03 / D01 live sessions ran to `max_turns` despite 4+ clear paraphrased closures each ("right stopping point for now", "I'll come back later", "we can leave it there", "Got it"). The regex pattern set was demonstrably a treadmill — every test surfaced 3-4 fresh paraphrases. See #139 for the full audit.

## Test plan

- [x] `pytest tests/unit/test_student_sim_task_end.py tests/unit/test_student_sim_goodbye.py tests/api/test_session_completion_api.py` — 62/62 pass
- [x] `pytest tests/unit/ tests/api/` — 364 pass, 3 unrelated pre-existing failures on master (eval-architecture + persona-registration tests, none touching student_sim or session.py)
- [x] Strict bool coercion verified: only Python `True` terminates; string `"true"`, `1`, lists, dicts all coerce to `False` so malformed model output never accidentally truncates a session
- [x] Codex round 1 — 1 finding (P1: don't unpack `mcp_servers/student_sim.StudentSimulator`'s string return as a tuple), accepted and reverted
- [ ] Post-merge live verification: drive an A03 / D01 session and confirm `termination_reason=student_satisfied` at the first natural closure (vs. `max_turns` previously)

Closes #139