### PR TITLE
Deploy production via bench VPS runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,10 @@ on:
     branches: [master]
     paths:
       - 'bench/**'
+      - 'bench/requirements.txt'
       - 'requirements.txt'
       - 'pyproject.toml'
+      - 'deploy/**'
       - '.github/workflows/deploy.yml'
       - '!bench/data/**'
       - '!bench/reference/**'
@@ -18,6 +20,13 @@ concurrency:
   group: vps-deploy
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
+env:
+  DEPLOY_PATH: /home/bench/benchmark
+  SERVICE_NAME: quanttutor
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -27,17 +36,17 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-      - run: pip install -r requirements.txt pytest-timeout
+      - run: pip install -r requirements.txt -r bench/requirements.txt pytest-timeout
       - run: pytest bench/tests/ -x --timeout=60
         continue-on-error: true
 
   deploy:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, production, bench-vps]
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Detect changed paths
         id: changes
@@ -45,21 +54,22 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "docker=true" >> $GITHUB_OUTPUT
             echo "deps=true" >> $GITHUB_OUTPUT
+            echo "service=true" >> $GITHUB_OUTPUT
           else
-            FILES=$(git diff --name-only HEAD^ HEAD)
-            echo "$FILES" | grep -qE '^bench/docker/Dockerfile' && echo "docker=true" >> $GITHUB_OUTPUT || echo "docker=false" >> $GITHUB_OUTPUT
-            echo "$FILES" | grep -qE '^(requirements\.txt|pyproject\.toml)$' && echo "deps=true" >> $GITHUB_OUTPUT || echo "deps=false" >> $GITHUB_OUTPUT
+            BEFORE="${{ github.event.before }}"
+            if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              FILES=$(git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA")
+            else
+              FILES=$(git diff --name-only "$BEFORE" "$GITHUB_SHA")
+            fi
+            echo "$FILES" | grep -qE '^bench/docker/Dockerfile(\.lean)?$' && echo "docker=true" >> $GITHUB_OUTPUT || echo "docker=false" >> $GITHUB_OUTPUT
+            echo "$FILES" | grep -qE '^(requirements\.txt|bench/requirements\.txt|pyproject\.toml)$' && echo "deps=true" >> $GITHUB_OUTPUT || echo "deps=false" >> $GITHUB_OUTPUT
+            echo "$FILES" | grep -qE '^deploy/quanttutor\.service$' && echo "service=true" >> $GITHUB_OUTPUT || echo "service=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Setup SSH
+      - name: Sync code to deploy path
         run: |
-          mkdir -p ~/.ssh && chmod 700 ~/.ssh
-          echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H ${{ secrets.VPS_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
-
-      - name: Rsync code to VPS
-        run: |
+          mkdir -p "$DEPLOY_PATH"
           rsync -az --delete \
             --exclude='.git' \
             --exclude='.env' \
@@ -76,55 +86,62 @@ jobs:
             --exclude='node_modules' \
             --exclude='vercel-frontend/.vercel' \
             --exclude='vercel-frontend/dist' \
-            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=120" \
-            ./ ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:~/benchmark/
+            ./ "$DEPLOY_PATH/"
+
+      - name: Ensure Python runtime
+        id: runtime
+        run: |
+          if [ -x "$DEPLOY_PATH/.venv/bin/python" ]; then
+            echo "venv_created=false" >> "$GITHUB_OUTPUT"
+          else
+            python3 -m venv "$DEPLOY_PATH/.venv"
+            echo "venv_created=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Rebuild Docker images (if Dockerfile changed)
         if: steps.changes.outputs.docker == 'true'
         run: |
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=120 \
-            ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} << 'EOF'
-            set -e
-            cd ~/benchmark/bench
-            sudo docker build -t quant-tutor-env:v2.2 -f docker/Dockerfile docker/
-            sudo docker build -t quant-tutor-env:v2.2-lean -f docker/Dockerfile.lean .
-            sudo docker image prune -f
-            sudo docker builder prune -f
-          EOF
+          cd "$DEPLOY_PATH/bench"
+          docker build -t quant-tutor-env:v2.2 -f docker/Dockerfile docker/
+          docker build -t quant-tutor-env:v2.2-lean -f docker/Dockerfile.lean .
+          docker image prune -f
+          docker builder prune -f
 
       - name: Install Python deps (if requirements changed)
-        if: steps.changes.outputs.deps == 'true'
+        if: steps.changes.outputs.deps == 'true' || steps.runtime.outputs.venv_created == 'true'
         run: |
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=120 \
-            ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} \
-            '~/benchmark/.venv/bin/pip install -r ~/benchmark/requirements.txt'
+          "$DEPLOY_PATH/.venv/bin/pip" install --upgrade pip
+          "$DEPLOY_PATH/.venv/bin/pip" install \
+            -r "$DEPLOY_PATH/requirements.txt" \
+            -r "$DEPLOY_PATH/bench/requirements.txt"
+
+      - name: Install systemd unit (if service changed)
+        if: steps.changes.outputs.service == 'true'
+        run: |
+          sudo -n install -m 0644 "$DEPLOY_PATH/deploy/quanttutor.service" /etc/systemd/system/quanttutor.service
+          sudo -n systemctl daemon-reload
 
       - name: Restart service + smoke test
         run: |
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=120 \
-            ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} << 'EOF'
-            set -e
-            sudo systemctl restart quanttutor
-            # Poll /health for up to 60s; new code's cold start can exceed 6s
-            # after Bundle v1 + audit sink + run service initialization (#122/#123).
-            for i in $(seq 1 30); do
-              if curl -sf -m 3 http://127.0.0.1:8000/health >/dev/null 2>&1; then
-                echo "health ok after ${i}*2s"
-                break
-              fi
-              if [ $i -eq 30 ]; then
-                echo "health probe timed out after 60s"
-                sudo systemctl status quanttutor --no-pager | head -20
-                tail -50 /var/log/quanttutor.log
-                exit 1
-              fi
-              sleep 2
-            done
-            sudo systemctl is-active quanttutor
-            # /health deep probe: docker daemon + LEAN image + disk (returns 503 on any failure)
-            curl -sf http://127.0.0.1:8000/health >/dev/null
-            echo "--- disk ---"
-            df -h /home | tail -1
-            echo "--- tail log ---"
-            tail -5 /var/log/quanttutor.log
-          EOF
+          sudo -n systemctl restart "$SERVICE_NAME"
+          # Poll /health for up to 60s; cold starts can exceed 6s after
+          # Bundle v1 + audit sink + run service initialization (#122/#123).
+          for i in $(seq 1 30); do
+            if curl -sf -m 3 http://127.0.0.1:8000/health >/dev/null 2>&1; then
+              echo "health ok after ${i}*2s"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "health probe timed out after 60s"
+              sudo -n systemctl status "$SERVICE_NAME" --no-pager | head -20
+              sudo -n journalctl -u "$SERVICE_NAME" --no-pager -n 50
+              exit 1
+            fi
+            sleep 2
+          done
+          sudo -n systemctl is-active "$SERVICE_NAME"
+          curl -sf http://127.0.0.1:8000/health >/dev/null
+          echo "--- disk ---"
+          df -h /home | tail -1
+          echo "--- tail log ---"
+          sudo -n journalctl -u "$SERVICE_NAME" --no-pager -n 5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,22 @@ on:
       - '!bench/*MD/**'
       - '!bench/**.md'
   workflow_dispatch:
+    inputs:
+      rebuild_docker:
+        description: Rebuild Docker sandbox images
+        required: false
+        default: false
+        type: boolean
+      reinstall_deps:
+        description: Reinstall Python dependencies
+        required: false
+        default: false
+        type: boolean
+      reinstall_service:
+        description: Reinstall the systemd service file
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: vps-deploy
@@ -52,9 +68,9 @@ jobs:
         id: changes
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "docker=true" >> $GITHUB_OUTPUT
-            echo "deps=true" >> $GITHUB_OUTPUT
-            echo "service=true" >> $GITHUB_OUTPUT
+            echo "docker=${{ inputs.rebuild_docker }}" >> $GITHUB_OUTPUT
+            echo "deps=${{ inputs.reinstall_deps }}" >> $GITHUB_OUTPUT
+            echo "service=${{ inputs.reinstall_service }}" >> $GITHUB_OUTPUT
           else
             BEFORE="${{ github.event.before }}"
             if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then

--- a/bench/requirements.txt
+++ b/bench/requirements.txt
@@ -13,3 +13,11 @@ openai>=1.0.0
 docker>=7.0.0
 tabulate>=0.9.0
 huggingface_hub>=0.20.0
+
+# HTTP/MCP production server
+anyio>=4.0.0
+mcp>=1.27.0
+python-dotenv>=1.0.0
+sse-starlette>=3.0.0
+starlette>=0.37.0
+uvicorn>=0.29.0

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,35 @@
+# Production Deployment
+
+Production runs on the VPS as Linux user `bench`.
+
+Runtime layout:
+
+- deploy path: `/home/bench/benchmark`
+- service: `quanttutor`
+- app entrypoint: `cd /home/bench/benchmark/bench && ../.venv/bin/python -m server --host 127.0.0.1 --port 8000 --docker`
+- public SSH policy: `bench` SSH access stays governed by `/etc/security/access.conf`
+- GitHub deployment path: self-hosted runner on the VPS with labels `production,bench-vps`
+
+Initial VPS setup:
+
+```bash
+sudo usermod -aG docker bench
+sudo install -m 0644 /home/bench/benchmark/deploy/quanttutor.service /etc/systemd/system/quanttutor.service
+sudo systemctl daemon-reload
+sudo systemctl enable quanttutor
+```
+
+The GitHub runner service runs as `bench`. The deployment workflow syncs the
+checked-out repository into `/home/bench/benchmark`, installs Python
+dependencies into `/home/bench/benchmark/.venv`, rebuilds Docker images when
+the Dockerfiles change, restarts `quanttutor`, and checks `/health`.
+
+Required sudoers entry for workflow restarts:
+
+```sudoers
+Cmnd_Alias QTB_DEPLOY = /usr/bin/install -m 0644 /home/bench/benchmark/deploy/quanttutor.service /etc/systemd/system/quanttutor.service, /usr/bin/systemctl daemon-reload, /usr/bin/systemctl restart quanttutor, /usr/bin/systemctl is-active quanttutor, /usr/bin/systemctl status quanttutor --no-pager, /usr/bin/journalctl -u quanttutor --no-pager -n 50, /usr/bin/journalctl -u quanttutor --no-pager -n 5
+bench ALL=(root) NOPASSWD: QTB_DEPLOY
+```
+
+The workflow uses a self-hosted runner so GitHub Actions deployment traffic
+stays local to the VPS. This preserves the existing `bench` SSH IP allowlist.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -23,6 +23,9 @@ The GitHub runner service runs as `bench`. The deployment workflow syncs the
 checked-out repository into `/home/bench/benchmark`, installs Python
 dependencies into `/home/bench/benchmark/.venv`, rebuilds Docker images when
 the Dockerfiles change, restarts `quanttutor`, and checks `/health`.
+Manual workflow runs default to code sync, restart, and health check only.
+Use the workflow inputs to request Docker image rebuilds, dependency installs,
+or systemd unit reinstalls during manual maintenance runs.
 
 Required sudoers entry for workflow restarts:
 

--- a/deploy/quanttutor.service
+++ b/deploy/quanttutor.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=QuantTutorBench HTTP Server
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+User=bench
+Group=bench
+SupplementaryGroups=docker
+WorkingDirectory=/home/bench/benchmark/bench
+EnvironmentFile=-/home/bench/benchmark/.env
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/home/bench/benchmark/.venv/bin/python -m server --host 127.0.0.1 --port 8000 --docker
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,6 +59,27 @@ to the production service.
 The `BenchSessionManager` in `http_app.py` owns live sessions, the run store,
 quota checks, background tool jobs, cleanup, and restore-from-storage.
 
+## Production Deployment
+
+Production runs on the VPS under Linux user `bench` from
+`/home/bench/benchmark`. The systemd unit lives at
+`deploy/quanttutor.service` and starts:
+
+```bash
+cd /home/bench/benchmark/bench
+/home/bench/benchmark/.venv/bin/python -m server --host 127.0.0.1 --port 8000 --docker
+```
+
+GitHub Actions deploys through a self-hosted runner installed on the VPS with
+labels `production,bench-vps`. The workflow in `.github/workflows/deploy.yml`
+syncs the checkout into `/home/bench/benchmark`, maintains the virtualenv,
+rebuilds sandbox Docker images when Dockerfiles change, restarts `quanttutor`,
+and verifies `/health`.
+
+The `bench` SSH IP allowlist stays in `/etc/security/access.conf`. The
+self-hosted runner keeps deployment local to the VPS and preserves that SSH
+policy.
+
 ## Permission Boundary
 
 Clients can read public task labels, create or claim runs, register/start


### PR DESCRIPTION
Closes #147

## Changes
- Add a master-triggered production deploy workflow for the bench-vps self-hosted runner.
- Run production under the bench user at /home/bench/benchmark with systemd service quanttutor.
- Add deploy documentation covering layout, sudoers, and manual workflow inputs.
- Add server runtime dependencies to bench/requirements.txt.

## Verification
- workflow YAML parse ok
- git diff --check ok
- .venv/bin/python -m pytest bench/tests/test_health.py -q => 10 passed
- GitHub Actions deploy run 25310409305 succeeded on 2ed78f2d
- VPS /health returned HTTP 200; bench-vps runner is online and idle

## Notes
- Manual workflow dispatch defaults to sync, restart, and health check. Docker, dependency, and systemd maintenance steps are controlled by workflow inputs.
- Master pushes with deployment-relevant path changes trigger automatic deployment on bench-vps.