### PR TITLE
feat(server): add mid-session resume checkpoints

### DIFF
--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -18,6 +18,7 @@ import logging
 import os
 import shutil
 import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import AsyncIterator
@@ -110,6 +111,36 @@ def _bool_env(name: str, default: bool) -> bool:
     return default
 
 
+async def _run_manager_sync(manager, func, *args, **kwargs):
+    if not manager.use_docker:
+        return await _run_sync_worker(func, *args, **kwargs)
+    if kwargs:
+        return await anyio.to_thread.run_sync(lambda: func(*args, **kwargs))
+    return await anyio.to_thread.run_sync(func, *args)
+
+
+async def _run_sync_worker(func, *args, **kwargs):
+    done = threading.Event()
+    outcome: dict[str, object] = {}
+
+    def runner() -> None:
+        try:
+            outcome["value"] = func(*args, **kwargs)
+        except BaseException as exc:
+            outcome["error"] = exc
+        finally:
+            done.set()
+
+    thread = threading.Thread(target=runner, name="qtb-sync-worker", daemon=True)
+    thread.start()
+    while not done.is_set():
+        await anyio.sleep(0.01)
+    thread.join()
+    if "error" in outcome:
+        raise outcome["error"]  # type: ignore[misc]
+    return outcome.get("value")
+
+
 def _rest_session_token_required() -> bool:
     if os.environ.get("QTB_REQUIRE_SESSION_TOKEN", "").strip():
         return _bool_env("QTB_REQUIRE_SESSION_TOKEN", False)
@@ -162,6 +193,27 @@ def _authorize_rest_job_request(
     return None
 
 
+def _authorize_run_token_request(
+    request: Request, manager: "BenchSessionManager", run_id: str
+):
+    """Authorize a run-scoped API request with the run token."""
+    raw = extract_bearer_token(request)
+    if not raw:
+        return (
+            JSONResponse({"error": "Authorization: Bearer <token> required"}, 401),
+            None,
+        )
+    run = manager._run_service.resolve_token(raw, allow_expired_bound=True)
+    if run is None:
+        return (
+            JSONResponse({"error": "Invalid or expired token"}, status_code=401),
+            None,
+        )
+    if run.run_id != run_id:
+        return JSONResponse({"error": "Run token does not own this run"}, 403), None
+    return None, run
+
+
 class NoCacheStaticFiles(StaticFiles):
     """StaticFiles variant that forces browser revalidation for UI assets."""
 
@@ -199,6 +251,7 @@ class BenchSessionManager:
 
         self._sessions: dict[str, SessionState] = {}
         self._transports: dict[str, StreamableHTTPServerTransport] = {}
+        self._resume_locks: dict[str, asyncio.Lock] = {}
         self._task_group: anyio.abc.TaskGroup | None = None
 
         # Run layer
@@ -219,7 +272,7 @@ class BenchSessionManager:
         # Any pending/running jobs on disk at startup lost their worker when
         # the previous process died; fail them cleanly so clients polling a
         # stale job_id get a terminal state instead of timing out.
-        orphans = await asyncio.to_thread(self._job_store.mark_orphans_failed)
+        orphans = await anyio.to_thread.run_sync(self._job_store.mark_orphans_failed)
         if orphans:
             logger.warning(
                 "Startup: failed %d orphan tool job(s) from previous run", orphans
@@ -237,7 +290,7 @@ class BenchSessionManager:
                 )
                 for sid in list(self._sessions):
                     try:
-                        await self._cleanup_session(sid)
+                        await self._cleanup_session(sid, suspend_active=True)
                     except Exception as e:
                         logger.warning("Cleanup failed for session %s: %s", sid, e)
                 tg.cancel_scope.cancel()
@@ -296,6 +349,8 @@ class BenchSessionManager:
                                     state.session.force_complete("timeout")
                                 state.phase = SessionPhase.COMPLETED
                                 state._save_results()
+                                state._cleanup_resume_layers()
+                                state._remove_active_state()
                                 save_ok = True
                             except Exception:
                                 logger.warning(
@@ -484,7 +539,9 @@ class BenchSessionManager:
                     finally:
                         if session_id in self._sessions:
                             await self._cleanup_session(
-                                session_id, persist_partial=True
+                                session_id,
+                                persist_partial=True,
+                                suspend_active=True,
                             )
 
             try:
@@ -586,7 +643,11 @@ class BenchSessionManager:
                     )
                 finally:
                     if new_id in self._sessions:
-                        await self._cleanup_session(new_id, persist_partial=True)
+                        await self._cleanup_session(
+                            new_id,
+                            persist_partial=True,
+                            suspend_active=True,
+                        )
 
         try:
             await self._task_group.start(run_server)
@@ -629,10 +690,14 @@ class BenchSessionManager:
                 and session_id in self._sessions
             ):
                 logger.info(
-                    "Session %s MCP client disconnected — cleaning up partial state",
+                    "Session %s MCP client disconnected — suspending active state",
                     session_id[:8],
                 )
-                await self._cleanup_session(session_id, persist_partial=True)
+                await self._cleanup_session(
+                    session_id,
+                    persist_partial=True,
+                    suspend_active=True,
+                )
 
     # ------------------------------------------------------------------
     # Per-session MCP server factory
@@ -737,12 +802,12 @@ class BenchSessionManager:
         session_id: str,
         *,
         persist_partial: bool = False,
+        suspend_active: bool = False,
     ):
         """Remove session state and free resources.
 
-        If the session is bound to a Run that is still active (not in a
-        terminal state), mark the run as failed — the client disconnected
-        without completing the session.
+        Resumable ACTIVE runs are suspended with a run_state checkpoint and
+        container layer. Other unfinished run sessions are marked failed.
         """
         state = self._sessions.pop(session_id, None)
         transport = self._transports.pop(session_id, None)
@@ -758,8 +823,30 @@ class BenchSessionManager:
                 with contextlib.suppress(Exception):
                     await transport.terminate()
 
-            # Mark associated run as failed if session didn't complete normally.
-            if state.run_id and state.phase != SessionPhase.COMPLETED:
+            suspended = False
+            if (
+                suspend_active
+                and state.run_id
+                and state.phase in (SessionPhase.REGISTERED, SessionPhase.IN_SESSION)
+            ):
+                try:
+                    run = self._run_service.get_run(state.run_id)
+                    if run and run.status == RunStatus.ACTIVE:
+                        state.suspend_for_resume()
+                        suspended = True
+                        logger.info(
+                            "Run %s suspended for resume at session=%s",
+                            state.run_id,
+                            session_id[:8],
+                        )
+                except Exception as exc:
+                    logger.warning(
+                        "Run %s suspend for resume failed: %s",
+                        state.run_id,
+                        exc,
+                    )
+
+            if state.run_id and state.phase != SessionPhase.COMPLETED and not suspended:
                 try:
                     run = self._run_service.get_run(state.run_id)
                     if (
@@ -779,10 +866,11 @@ class BenchSessionManager:
                         "Failed to mark run %s as failed: %s", state.run_id, exc
                     )
 
-            try:
-                state.cleanup(persist_partial=persist_partial)
-            except Exception as e:
-                logger.warning("Session %s cleanup error: %s", session_id, e)
+            if not suspended:
+                try:
+                    state.cleanup(persist_partial=persist_partial)
+                except Exception as e:
+                    logger.warning("Session %s cleanup error: %s", session_id, e)
         logger.info("Session %s removed", session_id)
 
     # ------------------------------------------------------------------
@@ -854,6 +942,52 @@ class BenchSessionManager:
         )
         payload["session_id"] = session_id
         return payload
+
+    def active_run_state_path(self, run_id: str) -> Path:
+        return self.bench_root / "results" / "runs" / run_id / "run_state.json"
+
+    def get_run_replay_state(self, run) -> dict | None:
+        """Read run replay state from active storage or completed result_dir."""
+        active_path = self.active_run_state_path(run.run_id)
+        if active_path.exists():
+            try:
+                return json.loads(active_path.read_text(encoding="utf-8"))
+            except Exception:
+                logger.warning("Could not read active run_state: %s", active_path)
+        if run.result_dir:
+            state_path = Path(run.result_dir) / "run_state.json"
+            if state_path.exists():
+                try:
+                    return json.loads(state_path.read_text(encoding="utf-8"))
+                except Exception:
+                    logger.warning("Could not read completed run_state: %s", state_path)
+        return None
+
+    def resume_run(self, run) -> SessionState:
+        """Restore an ACTIVE run into memory from its active run_state file."""
+        if run.status != RunStatus.ACTIVE:
+            raise ValueError(
+                f"Run {run.run_id} is '{run.status.value}', expected 'active'"
+            )
+        if not run.session_id:
+            raise ValueError("Run has no session_id")
+        state = self.get_session(run.session_id)
+        if state is not None:
+            return state
+        state_path = self.active_run_state_path(run.run_id)
+        if not state_path.exists():
+            raise FileNotFoundError(str(state_path))
+        state = SessionState.restore_active_from_storage(
+            state_path=state_path,
+            bench_root=self.bench_root,
+            use_docker=self.use_docker,
+            eval_model=self.eval_model,
+        )
+        state._on_completed = lambda result_dir: self._run_service.mark_completed(
+            run.run_id, result_dir
+        )
+        self._sessions[state.session_id] = state
+        return state
 
     def list_sessions(self, task_id: str = "") -> list[dict]:
         results = []
@@ -979,16 +1113,16 @@ async def rest_health(request: Request) -> JSONResponse:
     checks: dict[str, dict] = {}
     if manager.use_docker:
         docker, image, disk = await asyncio.gather(
-            asyncio.to_thread(_health_check_docker),
-            asyncio.to_thread(_health_check_lean_image),
-            asyncio.to_thread(_health_check_disk),
+            anyio.to_thread.run_sync(_health_check_docker),
+            anyio.to_thread.run_sync(_health_check_lean_image),
+            anyio.to_thread.run_sync(_health_check_disk),
         )
         checks["docker"] = docker
         checks["lean_image"] = image
         checks["disk"] = disk
     else:
         checks["mode"] = {"ok": True, "docker": False}
-        checks["disk"] = await asyncio.to_thread(_health_check_disk)
+        checks["disk"] = await anyio.to_thread.run_sync(_health_check_disk)
     ok = all(c.get("ok") for c in checks.values())
     return JSONResponse(
         {"status": "ok" if ok else "down", "checks": checks},
@@ -1043,7 +1177,7 @@ async def rest_register(request: Request) -> JSONResponse:
     state._on_completed = lambda result_dir: manager._run_service.mark_completed(
         run.run_id, result_dir
     )
-    result = await asyncio.to_thread(state.register, task_id, persona_id)
+    result = await _run_manager_sync(manager, state.register, task_id, persona_id)
 
     if "session_id" in result:
         manager.register_rest_session(state)
@@ -1198,7 +1332,8 @@ async def rest_retry_session(request: Request) -> JSONResponse:
     # Preserve the original persona so the retry exercises the same
     # user assignment; falling through to a random pick would change
     # the scenario and make scores incomparable across attempts.
-    register_result = await asyncio.to_thread(
+    register_result = await _run_manager_sync(
+        manager,
         new_state.register, run.task_id, state.persona_id or None
     )
     if "session_id" not in register_result:
@@ -1277,7 +1412,7 @@ async def rest_start(request: Request) -> JSONResponse:
 
     async with state._request_lock:
         state._last_activity = time.time()
-        result = await asyncio.to_thread(state.start)
+        result = await _run_manager_sync(manager, state.start)
     logger.info("[REST:%s] session started", sid[:8])
     record_event(
         manager.bench_root,
@@ -1447,7 +1582,10 @@ async def rest_tool_call(request: Request) -> JSONResponse:
         )
 
     async with state._request_lock:
-        result = await asyncio.to_thread(state.call_domain_tool, name, **body)
+        result = await _run_manager_sync(
+            manager,
+            lambda: state.call_domain_tool(name, **body)
+        )
     result_preview = str(result)[:150]
     logger.debug("[REST:%s] %s -> %s...", sid[:8], name, result_preview)
     try:
@@ -1491,7 +1629,10 @@ async def _execute_tool_job(
         async with backtest_sem():
             store.update(job_id, status=JOB_STATUS_RUNNING, started_at=time.time())
             state._last_activity = time.time()
-            result = await asyncio.to_thread(state.call_domain_tool, name, **body)
+            result = await _run_manager_sync(
+                manager,
+                lambda: state.call_domain_tool(name, **body)
+            )
         try:
             parsed = json.loads(result)
         except (json.JSONDecodeError, TypeError):
@@ -1628,11 +1769,13 @@ async def rest_send(request: Request) -> JSONResponse:
     )
     async with state._request_lock:
         state._last_activity = time.time()
-        result = await asyncio.to_thread(
-            state.handle_send_message,
-            text,
-            attachments=attachments,
-            reasoning=reasoning,
+        result = await _run_manager_sync(
+            manager,
+            lambda: state.handle_send_message(
+                text,
+                attachments=attachments,
+                reasoning=reasoning,
+            )
         )
     data = json.loads(result)
     logger.info(
@@ -1706,7 +1849,7 @@ async def ops_evaluate(request: Request) -> JSONResponse:
 
     async with state._request_lock:
         state._last_activity = time.time()
-        result = await asyncio.to_thread(state.request_evaluation)
+        result = await _run_manager_sync(manager, state.request_evaluation)
     logger.info("[OPS:%s] evaluate: %s", sid[:8], result.get("status"))
     return JSONResponse(result)
 
@@ -2117,6 +2260,96 @@ async def rest_list(request: Request) -> JSONResponse:
     return JSONResponse({"sessions": sessions})
 
 
+async def api_run_resume(request: Request) -> JSONResponse:
+    """``POST /api/runs/{run_id}/resume`` — rehydrate an active run."""
+    manager: BenchSessionManager = request.app.state.manager
+    run_id = request.path_params["run_id"]
+    auth_err, run = _authorize_run_token_request(request, manager, run_id)
+    if auth_err is not None:
+        return auth_err
+
+    lock = manager._resume_locks.setdefault(run_id, asyncio.Lock())
+    async with lock:
+        try:
+            state = await _run_manager_sync(manager, manager.resume_run, run)
+        except FileNotFoundError:
+            return JSONResponse({"error": "No resumable state found"}, status_code=404)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=409)
+        except Exception as exc:
+            logger.error("Run %s resume failed: %s", run_id, exc, exc_info=True)
+            return JSONResponse({"error": f"Resume failed: {exc}"}, status_code=500)
+
+    base_url = str(request.base_url).rstrip("/")
+    return JSONResponse(
+        {
+            "run_id": run_id,
+            "session_id": state.session_id,
+            "run_status": run.status.value,
+            "phase": state.phase.value,
+            "mcp_url": f"{base_url}/mcp",
+            "endpoint": f"/session/{state.session_id}",
+            "send_endpoint": f"/session/{state.session_id}/send",
+            "latest_layer_tag": state._latest_layer_tag,
+        }
+    )
+
+
+async def api_run_replay(request: Request) -> JSONResponse:
+    """``GET /api/runs/{run_id}/replay`` — read-only conversation/tool replay."""
+    manager: BenchSessionManager = request.app.state.manager
+    run_id = request.path_params["run_id"]
+    auth_err, run = _authorize_run_token_request(request, manager, run_id)
+    if auth_err is not None:
+        return auth_err
+
+    state = manager.get_run_replay_state(run)
+    if state is None:
+        return JSONResponse({"error": "Replay state not found"}, status_code=404)
+    return JSONResponse(
+        {
+            "run_id": run_id,
+            "session_id": state.get("session_id"),
+            "phase": state.get("phase"),
+            "turn_count": state.get("turn_count", 0),
+            "conversation": state.get("conversation", []),
+            "tool_logs": state.get("tool_logs", []),
+        }
+    )
+
+
+async def api_run_state(request: Request) -> JSONResponse:
+    """``GET /api/runs/{run_id}/state`` — active resume metadata."""
+    manager: BenchSessionManager = request.app.state.manager
+    run_id = request.path_params["run_id"]
+    auth_err, run = _authorize_run_token_request(request, manager, run_id)
+    if auth_err is not None:
+        return auth_err
+
+    live = manager.get_session(run.session_id) if run.session_id else None
+    replay = manager.get_run_replay_state(run)
+    phase = live.phase.value if live is not None else None
+    turn_count = 0
+    latest_layer_tag = ""
+    if replay:
+        phase = phase or replay.get("phase")
+        turn_count = int(replay.get("turn_count") or 0)
+        latest_layer_tag = str(replay.get("latest_layer_tag") or "")
+    if live is not None:
+        turn_count = live._turn_count()
+        latest_layer_tag = live._latest_layer_tag
+    return JSONResponse(
+        {
+            "run_id": run_id,
+            "run_status": run.status.value,
+            "session_id": run.session_id,
+            "phase": phase,
+            "turn_count": turn_count,
+            "latest_layer_tag": latest_layer_tag,
+        }
+    )
+
+
 # ---------------------------------------------------------------------------
 # ASGI app factory
 # ---------------------------------------------------------------------------
@@ -2175,6 +2408,9 @@ def create_app(
         Route("/session/{sid}/retry", rest_retry_session, methods=["POST"]),
         Route("/session/{sid}/results", rest_results, methods=["GET"]),
         Route("/session/{sid}/scores", rest_scores, methods=["GET"]),
+        Route("/api/runs/{run_id}/resume", api_run_resume, methods=["POST"]),
+        Route("/api/runs/{run_id}/replay", api_run_replay, methods=["GET"]),
+        Route("/api/runs/{run_id}/state", api_run_state, methods=["GET"]),
         # Operator-only evaluation surface: not reachable from MCP or
         # client-facing /session tool dispatch.
         Route("/ops/session/{sid}/evaluate", ops_evaluate, methods=["POST"]),

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -23,11 +23,14 @@ import json
 import logging
 import os
 import random
+import shutil
 import threading
 import time
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
+import anyio
 from mcp.types import TextContent, Tool
 
 from server.config.llm_config import EVAL_DEFAULT_MODEL
@@ -49,6 +52,36 @@ from .protocol import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+async def _run_state_sync(use_docker: bool, func, *args, **kwargs):
+    if not use_docker:
+        return await _run_sync_worker(func, *args, **kwargs)
+    if kwargs:
+        return await anyio.to_thread.run_sync(lambda: func(*args, **kwargs))
+    return await anyio.to_thread.run_sync(func, *args)
+
+
+async def _run_sync_worker(func, *args, **kwargs):
+    done = threading.Event()
+    outcome: dict[str, object] = {}
+
+    def runner() -> None:
+        try:
+            outcome["value"] = func(*args, **kwargs)
+        except BaseException as exc:
+            outcome["error"] = exc
+        finally:
+            done.set()
+
+    thread = threading.Thread(target=runner, name="qtb-session-worker", daemon=True)
+    thread.start()
+    while not done.is_set():
+        await anyio.sleep(0.01)
+    thread.join()
+    if "error" in outcome:
+        raise outcome["error"]  # type: ignore[misc]
+    return outcome.get("value")
 
 
 def _stable_int_seed(*parts: object) -> int:
@@ -76,8 +109,17 @@ def _session_random_seed(
     return _stable_int_seed(task_id, session_id)
 
 
-def _resolve_persona_pin(task_id: str) -> Optional[str]:
+def _resolve_persona_pin(
+    task_id: str, persona_ids: Optional[list[str]] = None
+) -> Optional[str]:
     """Return an internal-only pinned persona override, if configured."""
+    allowed = set(persona_ids or [])
+
+    def _allowed(value: str) -> Optional[str]:
+        if allowed and value not in allowed:
+            return None
+        return value
+
     raw_json = os.environ.get("QTB_TEST_PERSONA_PIN_JSON", "").strip()
     if raw_json:
         try:
@@ -88,10 +130,10 @@ def _resolve_persona_pin(task_id: str) -> Optional[str]:
             if isinstance(mapping, dict):
                 desired = mapping.get(task_id) or mapping.get("*")
                 if desired:
-                    return str(desired)
+                    return _allowed(str(desired))
 
     desired = os.environ.get("QTB_TEST_PERSONA_PIN", "").strip()
-    return desired or None
+    return _allowed(desired) if desired else None
 
 
 def _task_is_lean(task) -> bool:
@@ -136,6 +178,27 @@ def _lean_template_context(task, *, user_code_dir: Optional[str | Path]) -> dict
         "sandbox_image": environment.sandbox_image if environment else "",
         "user_code_available": bool(user_code_dir),
     }
+
+
+def _int_env(name: str, default: int, *, minimum: int = 0) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(minimum, value)
+
+
+def _safe_tool_log_dict(log) -> dict:
+    if isinstance(log, dict):
+        return dict(log)
+    if is_dataclass(log):
+        return asdict(log)
+    if hasattr(log, "__dict__"):
+        return dict(log.__dict__)
+    return {"raw": str(log)}
 
 
 class SessionState:
@@ -197,6 +260,16 @@ class SessionState:
         self.owner_github_login: str = ""
         self.owner_email: str = ""
         self.visibility: str = "private"
+        self._latest_layer_tag: str = ""
+        self._snapshot_tags: list[str] = []
+        self._snapshot_interval: int = _int_env(
+            "QTB_RESUME_SNAPSHOT_INTERVAL", 5, minimum=1
+        )
+        self._snapshot_keep: int = _int_env(
+            "QTB_RESUME_SNAPSHOT_KEEP", 3, minimum=1
+        )
+        self._resume_layer_tag: str = ""
+        self._suppress_active_persist: bool = False
         # Callback invoked after successful register(). Used by http_app to
         # bind the session to a RunAssignment without injecting RunService
         # into SessionState.
@@ -308,6 +381,97 @@ class SessionState:
             session_id[:8],
             task_id,
             persona_id,
+        )
+        return state
+
+    @classmethod
+    def restore_active_from_storage(
+        cls,
+        *,
+        state_path: Path,
+        bench_root: Path,
+        use_docker: bool,
+        eval_model: str = EVAL_DEFAULT_MODEL,
+    ) -> "SessionState":
+        """Restore an ACTIVE session from results/runs/{run_id}/run_state.json."""
+        run_state = json.loads(Path(state_path).read_text(encoding="utf-8"))
+        session_id = str(run_state["session_id"])
+        task_id = str(run_state["task_id"])
+        persona_id = str(run_state["persona_id"])
+
+        state = cls(
+            session_id=session_id,
+            use_docker=use_docker,
+            bench_root=bench_root,
+            eval_model=eval_model,
+        )
+        state.run_id = str(run_state.get("run_id") or "")
+        state._run_task_id = task_id
+        state.owner_user_id = str(run_state.get("owner_user_id") or "")
+        state.owner_github_login = str(run_state.get("owner_github_login") or "")
+        state.owner_email = str(run_state.get("owner_email") or "")
+        state.visibility = str(run_state.get("visibility") or "private")
+        state._latest_layer_tag = str(run_state.get("latest_layer_tag") or "")
+        state._resume_layer_tag = state._latest_layer_tag
+        state._snapshot_tags = [
+            str(tag) for tag in run_state.get("snapshot_tags", []) if tag
+        ]
+        state._snapshot_interval = max(
+            1,
+            int(run_state.get("snapshot_interval") or state._snapshot_interval),
+        )
+        state._snapshot_keep = max(
+            1,
+            int(run_state.get("snapshot_keep") or state._snapshot_keep),
+        )
+
+        state._suppress_active_persist = True
+        try:
+            registered = state.register(task_id, persona_id)
+            if "error" in registered:
+                raise RuntimeError(str(registered.get("error")))
+        finally:
+            state._suppress_active_persist = False
+
+        snapshot_dir = Path(
+            run_state.get("workspace_snapshot_path")
+            or state_path.parent / "workspace_snapshot"
+        )
+        state._restore_active_workspace_snapshot(snapshot_dir)
+        if state.user_sim is not None:
+            state.user_sim.total_cost = float(run_state.get("simulator_cost") or 0.0)
+
+        if state.proxy is not None and hasattr(state.proxy, "restore_logs"):
+            state.proxy.restore_logs(run_state.get("tool_logs", []))
+
+        turn_count = int(run_state.get("turn_count") or 0)
+        if state.session is not None and hasattr(
+            state.session, "restore_runtime_state"
+        ):
+            state.session.restore_runtime_state(
+                conversation=run_state.get("conversation", []),
+                turn_count=turn_count,
+                session_status=str(run_state.get("session_status") or "active"),
+                completion_reason=run_state.get("termination_reason"),
+                file_ledger=run_state.get("file_ledger") or {},
+                artifact_debug_history=run_state.get("artifact_debug_history") or [],
+            )
+        if state.proxy is not None and hasattr(state.proxy, "set_turn"):
+            state.proxy.set_turn(turn_count)
+
+        phase = str(run_state.get("phase") or SessionPhase.IN_SESSION.value)
+        try:
+            state.phase = SessionPhase(phase)
+        except ValueError:
+            state.phase = SessionPhase.IN_SESSION
+        state._start_time = time.time() - float(run_state.get("duration_seconds") or 0)
+        state._closed = False
+        state._persist_active_state()
+        logger.info(
+            "Restored active session %s from %s using layer=%s",
+            session_id[:8],
+            state_path,
+            state._latest_layer_tag or "none",
         )
         return state
 
@@ -471,19 +635,22 @@ class SessionState:
                 )
                 self.staged_temp_dirs.extend(sample_temp_dirs)
 
+            base_sandbox_img = (
+                task.environment.sandbox_image if task.environment else None
+            )
             self.container = self.container_manager.create_container(
                 task_id=f"{task_id}_{self.session_id[:8]}",
                 data_dir=staged_data_dir,
                 docs_dir=staged_docs_dir,
                 user_code_dir=user_code_dir,
-                sandbox_image=(
-                    task.environment.sandbox_image if task.environment else None
-                ),
+                sandbox_image=(self._resume_layer_tag or base_sandbox_img),
                 network_enabled=(
                     task.environment.network_enabled if task.environment else False
                 ),
                 lean_data_dir=paths.lean_data,
                 custom_data_dir=paths.custom_data,
+                restore_workspace_snapshot=bool(self._resume_layer_tag),
+                resource_image=base_sandbox_img,
             )
 
             local_tool_env = self._build_tool_env(
@@ -582,6 +749,7 @@ class SessionState:
                         exc,
                     )
 
+            self._persist_active_state()
             return {
                 "session_id": self.session_id,
                 "current_phase": self.phase.value,
@@ -619,6 +787,7 @@ class SessionState:
         ]
         data["current_phase"] = self.phase.value
         data["next_allowed"] = next_allowed_for_phase(self.phase)
+        self._persist_active_state()
         return data
 
     # ------------------------------------------------------------------
@@ -661,6 +830,8 @@ class SessionState:
         if session_status in ("completed", "failed"):
             self.phase = SessionPhase.COMPLETED
             self._save_results()
+            self._cleanup_resume_layers()
+            self._remove_active_state()
             self._destroy_container()
             if session_status == "failed":
                 logger.error(
@@ -689,6 +860,8 @@ class SessionState:
                     )
         data.setdefault("current_phase", self.phase.value)
         data.setdefault("next_allowed", next_allowed_for_phase(self.phase))
+        if self.phase != SessionPhase.COMPLETED:
+            self._persist_active_state()
         return json.dumps(data)
 
     # ------------------------------------------------------------------
@@ -846,7 +1019,9 @@ class SessionState:
         """Route a domain tool call through the proxy."""
         if self._closed:
             return json.dumps({"success": False, "output": "Error: Session is closed"})
-        return self.proxy.call_tool(name, **kwargs)
+        result = self.proxy.call_tool(name, **kwargs)
+        self._persist_active_state()
+        return result
 
     # ------------------------------------------------------------------
     # Tool visibility per phase (for MCP list_tools)
@@ -1025,13 +1200,15 @@ class SessionState:
                         ),
                     )
                 ]
-            result = await asyncio.to_thread(self.register, task_id, persona_id)
+            result = await _run_state_sync(
+                self.use_docker, self.register, task_id, persona_id
+            )
             if "session_id" in result:
                 await self._notify_tools_changed()
             return [TextContent(type="text", text=json.dumps(result))]
 
         if name == "start_session":
-            result = await asyncio.to_thread(self.start)
+            result = await _run_state_sync(self.use_docker, self.start)
             await self._notify_tools_changed()
             return [TextContent(type="text", text=json.dumps(result))]
 
@@ -1069,11 +1246,13 @@ class SessionState:
                 "yes" if reasoning else "no",
                 text[:100],
             )
-            result = await asyncio.to_thread(
-                self.handle_send_message,
-                text,
-                attachments=attachments,
-                reasoning=reasoning,
+            result = await _run_state_sync(
+                self.use_docker,
+                lambda: self.handle_send_message(
+                    text,
+                    attachments=attachments,
+                    reasoning=reasoning,
+                )
             )
             # Log user reply
             try:
@@ -1093,11 +1272,15 @@ class SessionState:
         # Domain tool — route through proxy
         if name in HEAVY_TOOLS:
             async with backtest_sem():
-                result = await asyncio.to_thread(
-                    self.call_domain_tool, name, **arguments
+                result = await _run_state_sync(
+                    self.use_docker,
+                    lambda: self.call_domain_tool(name, **arguments)
                 )
         else:
-            result = await asyncio.to_thread(self.call_domain_tool, name, **arguments)
+            result = await _run_state_sync(
+                self.use_docker,
+                lambda: self.call_domain_tool(name, **arguments)
+            )
         result_preview = str(result)[:150]
         logger.debug("[%s] %s -> %s...", self.session_id[:8], name, result_preview)
         return [TextContent(type="text", text=str(result))]
@@ -1105,6 +1288,214 @@ class SessionState:
     # ------------------------------------------------------------------
     # Result saving
     # ------------------------------------------------------------------
+
+    def _active_run_state_path(self) -> Path | None:
+        if not self.run_id:
+            return None
+        return self.bench_root / "results" / "runs" / self.run_id / "run_state.json"
+
+    def _active_workspace_snapshot_path(self) -> Path | None:
+        state_path = self._active_run_state_path()
+        if state_path is None:
+            return None
+        return state_path.parent / "workspace_snapshot"
+
+    def _turn_count(self) -> int:
+        return int(getattr(self.session, "turn", 0) or 0) if self.session else 0
+
+    def _copy_active_workspace_snapshot(self) -> Path | None:
+        if self.container is None:
+            return None
+        source = Path(self.container.workspace_path)
+        if not source.is_dir():
+            return None
+        dest = self._active_workspace_snapshot_path()
+        if dest is None:
+            return None
+        tmp = dest.with_name(f".{dest.name}.tmp")
+        shutil.rmtree(tmp, ignore_errors=True)
+        shutil.copytree(source, tmp, symlinks=True)
+        shutil.rmtree(dest, ignore_errors=True)
+        os.replace(tmp, dest)
+        return dest
+
+    def _restore_active_workspace_snapshot(self, snapshot_dir: Path) -> None:
+        if self.container is None or not snapshot_dir.is_dir():
+            return
+        dest = Path(self.container.workspace_path)
+        dest.mkdir(parents=True, exist_ok=True)
+        for child in dest.iterdir():
+            if child.is_dir() and not child.is_symlink():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+        for child in snapshot_dir.iterdir():
+            target = dest / child.name
+            if child.is_dir() and not child.is_symlink():
+                shutil.copytree(child, target, symlinks=True)
+            else:
+                shutil.copy2(child, target, follow_symlinks=False)
+
+    def _maybe_commit_resume_snapshot(self, *, force: bool = False) -> None:
+        if not self.run_id or not self.container_manager or not self.container:
+            return
+        turn_count = self._turn_count()
+        if not force and (turn_count <= 0 or turn_count % self._snapshot_interval != 0):
+            return
+        if not force and self._latest_layer_tag.endswith(f"-{turn_count}"):
+            return
+        if not hasattr(self.container_manager, "commit_resume_snapshot"):
+            return
+        try:
+            tag = self.container_manager.commit_resume_snapshot(
+                self.container.container_id,
+                run_id=self.run_id,
+                turn_count=turn_count,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Session %s resume snapshot failed at turn %s: %s",
+                self.session_id,
+                turn_count,
+                exc,
+            )
+            return
+        if not tag:
+            return
+        self._latest_layer_tag = tag
+        if tag in self._snapshot_tags:
+            self._snapshot_tags.remove(tag)
+        self._snapshot_tags.append(tag)
+        while len(self._snapshot_tags) > self._snapshot_keep:
+            old = self._snapshot_tags.pop(0)
+            try:
+                self.container_manager.remove_image(old)
+            except Exception as exc:
+                logger.debug("Could not remove old resume layer %s: %s", old, exc)
+
+    def _cleanup_resume_layers(self) -> None:
+        tags = list(
+            dict.fromkeys([*self._snapshot_tags, self._latest_layer_tag])
+        )
+        tags = [tag for tag in tags if tag]
+        if not tags:
+            self._latest_layer_tag = ""
+            return
+        manager = self.container_manager
+        if manager is None:
+            try:
+                from server.core.container import ContainerManager
+
+                manager = ContainerManager(use_docker=self.use_docker)
+            except Exception:
+                manager = None
+        if manager is None or not hasattr(manager, "remove_image"):
+            return
+        for tag in tags:
+            try:
+                manager.remove_image(tag)
+            except Exception as exc:
+                logger.debug("Could not remove resume layer %s: %s", tag, exc)
+        self._snapshot_tags = []
+        self._latest_layer_tag = ""
+
+    def _remove_active_state(self) -> None:
+        state_path = self._active_run_state_path()
+        if state_path is None:
+            return
+        try:
+            state_path.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.debug("Could not remove active run_state %s: %s", state_path, exc)
+        snapshot_path = self._active_workspace_snapshot_path()
+        if snapshot_path is not None:
+            shutil.rmtree(snapshot_path, ignore_errors=True)
+
+    def _active_run_payload(self) -> dict:
+        conversation = self.session.conversation if self.session else []
+        tool_logs = (
+            [_safe_tool_log_dict(log) for log in self.proxy.get_logs()]
+            if self.proxy
+            else []
+        )
+        distractor_names = (
+            self.proxy.get_distractor_names() if self.proxy is not None else []
+        )
+        try:
+            from eval.tool_filters import NON_SUBSTANTIVE_TOOLS
+
+            step_count = sum(
+                1 for log in tool_logs if log.get("name") not in NON_SUBSTANTIVE_TOOLS
+            )
+        except Exception:
+            step_count = len(tool_logs)
+        duration = time.time() - self._start_time if self._start_time else 0.0
+        session_status = (
+            self.session.session_status if self.session else self.phase.value
+        )
+        termination_reason = self.session.completion_reason if self.session else None
+        return {
+            "active_state_version": 1,
+            "run_id": self.run_id or "",
+            "public_task_label": self.task_id.split("_")[0] if self.task_id else "",
+            "owner_user_id": self.owner_user_id,
+            "owner_github_login": self.owner_github_login,
+            "owner_email": self.owner_email,
+            "visibility": self.visibility,
+            "task_id": self.task_id,
+            "session_id": self._storage_session_id(),
+            "persona_id": self.persona_id,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "phase": self.phase.value,
+            "session_status": session_status,
+            "termination_reason": termination_reason,
+            "turn_count": self._turn_count(),
+            "conversation": conversation,
+            "tool_logs": tool_logs,
+            "distractor_names": distractor_names,
+            "file_ledger": self.session.file_ledger if self.session else {},
+            "artifact_debug_history": (
+                self.session.artifact_debug_history if self.session else []
+            ),
+            "simulator_cost": self.user_sim.total_cost if self.user_sim else 0.0,
+            "duration_seconds": duration,
+            "step_count": step_count,
+            "latest_layer_tag": self._latest_layer_tag,
+            "snapshot_tags": list(self._snapshot_tags),
+            "snapshot_interval": self._snapshot_interval,
+            "snapshot_keep": self._snapshot_keep,
+            "workspace_snapshot_path": (
+                str(path)
+                if (path := self._active_workspace_snapshot_path()) and path.exists()
+                else ""
+            ),
+        }
+
+    def _persist_active_state(self, *, force_snapshot: bool = False) -> Path | None:
+        if self._suppress_active_persist:
+            return None
+        state_path = self._active_run_state_path()
+        if state_path is None:
+            return None
+        if force_snapshot:
+            self._maybe_commit_resume_snapshot(force=True)
+            self._copy_active_workspace_snapshot()
+        else:
+            self._maybe_commit_resume_snapshot(force=False)
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = state_path.with_name(f".{state_path.name}.tmp")
+        tmp_path.write_text(
+            json.dumps(self._active_run_payload(), indent=2, default=str),
+            encoding="utf-8",
+        )
+        os.replace(tmp_path, state_path)
+        return state_path
+
+    def suspend_for_resume(self) -> None:
+        """Persist an active checkpoint, snapshot the container, and release it."""
+        self._persist_active_state(force_snapshot=True)
+        self._destroy_container()
+        self._closed = True
 
     def _storage_session_id(self) -> str:
         """Session ID for result storage.
@@ -1339,6 +1730,8 @@ class SessionState:
                     self.session_id,
                 )
                 self._save_results()
+                self._cleanup_resume_layers()
+                self._remove_active_state()
             except Exception as exc:
                 logger.warning(
                     "Session %s: save before cleanup failed: %s",

--- a/bench/server/core/container.py
+++ b/bench/server/core/container.py
@@ -60,6 +60,7 @@ class ContainerManager:
         "lean": ("1g", "2"),
         "_default": ("768m", "1"),
     }
+    _RESUME_WORKSPACE_DIR = "/opt/bench/resume_workspace"
 
     def __init__(
         self, docker_image: str = "quant-tutor-env:v2.2", use_docker: bool = True
@@ -97,6 +98,8 @@ class ContainerManager:
         network_enabled: bool = False,
         lean_data_dir: Optional[str] = None,
         custom_data_dir: Optional[str] = None,
+        restore_workspace_snapshot: bool = False,
+        resource_image: Optional[str] = None,
     ) -> ContainerInfo:
         """Create a sandboxed Docker container (or local workspace fallback).
 
@@ -131,7 +134,7 @@ class ContainerManager:
 
             network_flag = "--network bridge" if network_enabled else "--network none"
             network_mode = "bridge" if network_enabled else "none"
-            mem_limit, cpu_limit = self._resolve_resources(image)
+            mem_limit, cpu_limit = self._resolve_resources(resource_image or image)
             cmd = (
                 f"docker run -d --name qtb_{task_id}_{int(time.time())} "
                 f"{network_flag} --cpus {cpu_limit} --memory {mem_limit} "
@@ -266,6 +269,34 @@ class ContainerManager:
                     ],
                     capture_output=True,
                 )
+
+            if restore_workspace_snapshot:
+                restored = subprocess.run(
+                    [
+                        "docker",
+                        "exec",
+                        "--user",
+                        "root",
+                        container_id,
+                        "bash",
+                        "-lc",
+                        (
+                            "set -e; "
+                            f"test -d {self._RESUME_WORKSPACE_DIR}; "
+                            "find /workspace -mindepth 1 -maxdepth 1 "
+                            "-exec rm -rf {} +; "
+                            f"cp -a {self._RESUME_WORKSPACE_DIR}/. /workspace/; "
+                            "chown -R sandbox:sandbox /workspace 2>/dev/null || true"
+                        ),
+                    ],
+                    capture_output=True,
+                    text=True,
+                )
+                if restored.returncode != 0:
+                    raise RuntimeError(
+                        "docker workspace restore failed: "
+                        f"{restored.stderr.strip() or restored.stdout.strip()}"
+                    )
         else:
             container_id = f"local_{task_id}_{int(time.time())}"
             # Local fallback cannot enforce isolation; use host networking semantics.
@@ -276,7 +307,11 @@ class ContainerManager:
         # run_backtest call only does an incremental build (~13s vs ~190s).
         # Write a dummy Algorithm.cs to trigger a real recompile of the
         # Algorithm.CSharp project; without this the warmup is a no-op.
-        if self.use_docker and "lean" in image.lower():
+        if (
+            self.use_docker
+            and "lean" in (resource_image or image).lower()
+            and not restore_workspace_snapshot
+        ):
             subprocess.run(
                 [
                     "docker",
@@ -510,3 +545,52 @@ class ContainerManager:
         if workspace and os.path.exists(workspace):
             shutil.rmtree(workspace, ignore_errors=True)
         self._containers.pop(container_id, None)
+
+    def commit_resume_snapshot(
+        self,
+        container_id: str,
+        *,
+        run_id: str,
+        turn_count: int,
+    ) -> str | None:
+        """Commit a resumable image layer containing a copy of /workspace."""
+        if not self.use_docker or container_id.startswith("local_"):
+            return None
+        safe_run_id = "".join(
+            ch if ch.isalnum() or ch in ("_", "-") else "-" for ch in run_id.lower()
+        )
+        tag = f"bench-resume:{safe_run_id}-{int(turn_count or 0)}"
+        copy_cmd = (
+            f"rm -rf {self._RESUME_WORKSPACE_DIR} && "
+            f"mkdir -p {self._RESUME_WORKSPACE_DIR} && "
+            f"cp -a /workspace/. {self._RESUME_WORKSPACE_DIR}/"
+        )
+        copied = subprocess.run(
+            ["docker", "exec", "--user", "root", container_id, "bash", "-lc", copy_cmd],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if copied.returncode != 0:
+            raise RuntimeError(
+                "docker exec workspace snapshot failed: "
+                f"{copied.stderr.strip() or copied.stdout.strip()}"
+            )
+        committed = subprocess.run(
+            ["docker", "commit", container_id, tag],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        if committed.returncode != 0:
+            raise RuntimeError(
+                "docker commit failed: "
+                f"{committed.stderr.strip() or committed.stdout.strip()}"
+            )
+        return tag
+
+    def remove_image(self, image_tag: str) -> None:
+        """Remove a Docker image tag created for active-run resume."""
+        if not self.use_docker or not image_tag:
+            return
+        subprocess.run(["docker", "rmi", "-f", image_tag], capture_output=True)

--- a/bench/server/core/proxy.py
+++ b/bench/server/core/proxy.py
@@ -305,6 +305,20 @@ class MCPProxy:
         """Get all recorded tool call logs."""
         return list(self._logs)
 
+    def restore_logs(self, logs: list[dict]) -> None:
+        """Restore proxy logs from a persisted run_state snapshot."""
+        restored: list[ToolCallLog] = []
+        fields = set(ToolCallLog.__dataclass_fields__)
+        for item in logs:
+            if isinstance(item, ToolCallLog):
+                restored.append(item)
+            elif isinstance(item, dict):
+                payload = {key: item.get(key) for key in fields if key in item}
+                restored.append(ToolCallLog(**payload))
+        self._logs = restored
+        if restored:
+            self._current_turn = max(int(log.turn_index or 0) for log in restored)
+
     def get_distractor_names(self) -> list[str]:
         """Get names of all registered distractor tools."""
         return list(self._distractors.keys())

--- a/bench/server/core/session.py
+++ b/bench/server/core/session.py
@@ -630,6 +630,43 @@ class TutoringSession:
     def artifact_debug_history(self) -> list[dict]:
         return list(self._artifact_debug_history)
 
+    def restore_runtime_state(
+        self,
+        *,
+        conversation: list[dict],
+        turn_count: int,
+        session_status: str = "active",
+        completion_reason: str | None = None,
+        file_ledger: dict | None = None,
+        artifact_debug_history: list[dict] | None = None,
+    ) -> None:
+        """Restore in-memory turn state from an active run_state snapshot."""
+        self._conversation = [
+            dict(item) for item in conversation if isinstance(item, dict)
+        ]
+        self._turn = max(0, int(turn_count or 0))
+        self._session_info_called = bool(self._conversation)
+        self._done = session_status in ("completed", "failed")
+        self._completion_reason = completion_reason
+        self._file_ledger = dict(file_ledger or {})
+        self._artifact_debug_history = list(artifact_debug_history or [])
+
+        assistant_messages = [
+            str(item.get("content") or "")
+            for item in self._conversation
+            if item.get("role") == "assistant"
+        ]
+        self._last_agent_msg = assistant_messages[-1] if assistant_messages else ""
+        self._repeat_count = 0
+        if self._last_agent_msg:
+            for content in reversed(assistant_messages[:-1]):
+                if content != self._last_agent_msg:
+                    break
+                self._repeat_count += 1
+
+        if self._proxy is not None:
+            self._proxy.set_turn(self._turn)
+
     def force_complete(
         self,
         reason: str,

--- a/bench/tests/api/test_run_resume.py
+++ b/bench/tests/api/test_run_resume.py
@@ -1,0 +1,129 @@
+"""API coverage for active run replay and resume."""
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from tests.helpers import (
+    DEFAULT_PERSONA_ID,
+    DEFAULT_TASK_ID,
+    DEFAULT_TASK_LABEL,
+    create_run,
+)
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+async def _register_start_send(client, token: str) -> str:
+    resp = await client.post(
+        "/session/register",
+        json={"persona_id": DEFAULT_PERSONA_ID},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    sid = resp.json()["session_id"]
+
+    resp = await client.post(f"/session/{sid}/start", json={})
+    assert resp.status_code == 200, resp.text
+
+    resp = await client.post(
+        f"/session/{sid}/send",
+        json={"text": "Let me inspect the moving average bug."},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "active"
+    return sid
+
+
+@pytest.mark.asyncio
+async def test_active_run_state_and_replay_endpoint(client, bench_root):
+    run_id, token = await create_run(client, task=DEFAULT_TASK_LABEL)
+    sid = await _register_start_send(client, token)
+
+    state_path = Path(bench_root) / "results" / "runs" / run_id / "run_state.json"
+    assert state_path.exists()
+    active_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert active_state["run_id"] == run_id
+    assert active_state["session_id"] == sid
+    assert active_state["task_id"] == DEFAULT_TASK_ID
+    assert active_state["phase"] == "in_session"
+    assert active_state["turn_count"] == 1
+    assert active_state["conversation"]
+    assert any(log["name"] == "send_message" for log in active_state["tool_logs"])
+
+    replay = await client.get(
+        f"/api/runs/{run_id}/replay",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert replay.status_code == 200, replay.text
+    replay_body = replay.json()
+    assert replay_body["session_id"] == sid
+    assert replay_body["turn_count"] == 1
+    assert replay_body["conversation"] == active_state["conversation"]
+
+    state = await client.get(
+        f"/api/runs/{run_id}/state",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert state.status_code == 200, state.text
+    state_body = state.json()
+    assert state_body["run_status"] == "active"
+    assert state_body["phase"] == "in_session"
+    assert state_body["turn_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_resume_suspended_active_run_continues_send(client, app):
+    run_id, token = await create_run(client, task=DEFAULT_TASK_LABEL)
+    sid = await _register_start_send(client, token)
+
+    manager = app._manager
+    active_state = manager.get_session(sid)
+    assert active_state is not None
+    workspace_file = Path(active_state.container.workspace_path) / "resume_note.txt"
+    workspace_file.write_text("preserve this workspace file", encoding="utf-8")
+
+    await manager._cleanup_session(sid, suspend_active=True)
+    assert manager.get_session(sid) is None
+    assert manager._run_service.get_run(run_id).status.value == "active"
+
+    state_path = (
+        Path(manager.bench_root) / "results" / "runs" / run_id / "run_state.json"
+    )
+    saved_state = json.loads(state_path.read_text(encoding="utf-8"))
+    saved_state["simulator_cost"] = 1.25
+    state_path.write_text(json.dumps(saved_state), encoding="utf-8")
+
+    resumed = await client.post(
+        f"/api/runs/{run_id}/resume",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resumed.status_code == 200, resumed.text
+    body = resumed.json()
+    assert body["session_id"] == sid
+    assert body["phase"] == "in_session"
+    resumed_state = manager.get_session(sid)
+    assert resumed_state is not None
+    resumed_workspace_file = (
+        Path(resumed_state.container.workspace_path) / "resume_note.txt"
+    )
+    assert resumed_workspace_file.read_text(encoding="utf-8") == (
+        "preserve this workspace file"
+    )
+    assert resumed_state.user_sim.total_cost == 1.25
+
+    continued = await client.post(
+        f"/session/{sid}/send",
+        json={"text": "I found the rolling window issue."},
+    )
+    assert continued.status_code == 200, continued.text
+    assert continued.json()["status"] in ("active", "completed")

--- a/bench/tests/api/test_session_lifecycle.py
+++ b/bench/tests/api/test_session_lifecycle.py
@@ -61,8 +61,8 @@ class TestRegister:
         )
         # Registration itself may succeed or fail depending on task config
         # But the persona validation happens inside register()
-        assert resp.status_code in (200, 400)
-        if resp.status_code == 400:
+        assert resp.status_code in (200, 400, 404)
+        if resp.status_code in (400, 404):
             assert "error" in resp.json()
 
 
@@ -181,10 +181,10 @@ class TestSessionStatus:
         assert run_state["session_status"] in ("completed", "failed")
 
     @pytest.mark.asyncio
-    async def test_mcp_disconnect_persists_review_bundle(
+    async def test_mcp_disconnect_suspends_resumable_run(
         self, client, app, bench_root, monkeypatch
     ):
-        """MCP stream disconnect should leave a reviewable partial bundle."""
+        """MCP stream disconnect should leave active state for run resume."""
         import json
 
         import anyio
@@ -290,9 +290,10 @@ class TestSessionStatus:
                 await manager.handle_mcp_request(scope, receive, send)
                 for _ in range(50):
                     run = manager._run_service.get_run(run_id)
-                    if run and run.session_id and manager.find_archived_result_dir(
-                        run.session_id
-                    ):
+                    run_state_path = (
+                        bench_root / "results" / "runs" / run_id / "run_state.json"
+                    )
+                    if run and run.session_id and run_state_path.exists():
                         break
                     await anyio.sleep(0.01)
             finally:
@@ -307,21 +308,23 @@ class TestSessionStatus:
         run = manager._run_service.get_run(run_id)
         assert run is not None
         assert run.session_id
-        assert run.status == RunStatus.FAILED
-        assert run.error == "Client disconnected"
+        assert run.status == RunStatus.ACTIVE
+        assert run.error is None
 
-        task_root = bench_root / "results" / "server" / DEFAULT_TASK_ID
-        matches = list(task_root.rglob(f"*_{run.session_id[:12]}"))
-        assert matches, f"bundle was not persisted under {task_root}"
+        run_state_path = bench_root / "results" / "runs" / run_id / "run_state.json"
+        assert run_state_path.exists()
+        run_state = json.loads(run_state_path.read_text(encoding="utf-8"))
+        assert run_state["run_id"] == run_id
+        assert run_state["session_id"] == run.session_id
+        assert run_state["phase"] == "in_session"
+        assert run_state["turn_count"] == 1
 
-        bundle = matches[0]
-        assert (bundle / ".session_id").read_text(encoding="utf-8") == run.session_id
-        run_state = json.loads((bundle / "run_state.json").read_text())
-        assert run_state["termination_reason"] == "agent_abandoned"
-
-        review_resp = await client.get(f"/ui/review/bundles/{run.session_id}")
-        assert review_resp.status_code == 200, review_resp.text
-        assert review_resp.json()["bundle_id"] == run.session_id
+        resume_resp = await client.post(
+            f"/api/runs/{run_id}/resume",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resume_resp.status_code == 200, resume_resp.text
+        assert resume_resp.json()["session_id"] == run.session_id
 
     @pytest.mark.asyncio
     async def test_list_sessions(self, client):

--- a/bench/tests/test_mcp_disconnect_cleanup.py
+++ b/bench/tests/test_mcp_disconnect_cleanup.py
@@ -62,8 +62,10 @@ async def test_mcp_http_disconnect_persists_partial_cleanup(tmp_path):
     manager._sessions["session-1"] = object()
     calls = []
 
-    async def fake_cleanup(session_id, *, persist_partial=False):
-        calls.append((session_id, persist_partial))
+    async def fake_cleanup(
+        session_id, *, persist_partial=False, suspend_active=False
+    ):
+        calls.append((session_id, persist_partial, suspend_active))
         manager._sessions.pop(session_id, None)
 
     manager._cleanup_session = fake_cleanup
@@ -82,7 +84,7 @@ async def test_mcp_http_disconnect_persists_partial_cleanup(tmp_path):
         send,
     )
 
-    assert calls == [("session-1", True)]
+    assert calls == [("session-1", True, True)]
 
 
 @pytest.mark.asyncio
@@ -91,8 +93,10 @@ async def test_mcp_get_disconnect_keeps_session_open(tmp_path):
     manager._sessions["session-1"] = object()
     calls = []
 
-    async def fake_cleanup(session_id, *, persist_partial=False):
-        calls.append((session_id, persist_partial))
+    async def fake_cleanup(
+        session_id, *, persist_partial=False, suspend_active=False
+    ):
+        calls.append((session_id, persist_partial, suspend_active))
 
     manager._cleanup_session = fake_cleanup
 
@@ -120,8 +124,10 @@ async def test_mcp_http_disconnect_cleanup_runs_when_transport_raises(tmp_path):
     manager._sessions["session-1"] = object()
     calls = []
 
-    async def fake_cleanup(session_id, *, persist_partial=False):
-        calls.append((session_id, persist_partial))
+    async def fake_cleanup(
+        session_id, *, persist_partial=False, suspend_active=False
+    ):
+        calls.append((session_id, persist_partial, suspend_active))
         manager._sessions.pop(session_id, None)
 
     manager._cleanup_session = fake_cleanup
@@ -141,7 +147,7 @@ async def test_mcp_http_disconnect_cleanup_runs_when_transport_raises(tmp_path):
             send,
         )
 
-    assert calls == [("session-1", True)]
+    assert calls == [("session-1", True, True)]
 
 
 @pytest.mark.asyncio
@@ -150,8 +156,10 @@ async def test_mcp_regular_request_keeps_session_open(tmp_path):
     manager._sessions["session-1"] = object()
     calls = []
 
-    async def fake_cleanup(session_id, *, persist_partial=False):
-        calls.append((session_id, persist_partial))
+    async def fake_cleanup(
+        session_id, *, persist_partial=False, suspend_active=False
+    ):
+        calls.append((session_id, persist_partial, suspend_active))
 
     manager._cleanup_session = fake_cleanup
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,7 @@ to the production service.
 
 - MCP at `/mcp`
 - client REST under `/session/*`
+- run resume/replay REST under `/api/runs/*`
 - operator REST under `/ops/*`
 - UI/client run routes from `bench/server/web/ui_app.py`
 
@@ -119,17 +120,35 @@ the client catalog.
 1. `register_session` loads task/persona and prepares runtime state.
 2. `start_session` returns the user opening and enters `in_session`.
 3. `send_message` advances the user simulator and tool trace.
-4. Terminal status persists a result bundle, enters `completed`, and
+4. Active sessions persist incremental `run_state.json` checkpoints under
+   `results/runs/{run_id}/run_state.json`. In Docker mode the server commits
+   resumable image layers as `bench-resume:{run_id}-{turn}` every
+   `QTB_RESUME_SNAPSHOT_INTERVAL` turns (default 5) and keeps
+   `QTB_RESUME_SNAPSHOT_KEEP` recent layers (default 3). The commit path copies
+   `/workspace` into a container-internal resume directory before `docker commit`
+   because `/workspace` is a bind mount. Suspend also writes a host-side
+   `workspace_snapshot/` beside the active checkpoint so local mode and failed
+   Docker snapshots still preserve workspace files.
+5. Terminal status persists a result bundle, enters `completed`, and
    `_trigger_auto_eval()` enqueues a server-internal eval keyed
    `auto:{session_id}`. The same trigger fires from the idle-timeout sweep
    when a session crosses its deadline. The judge runs in a background
    thread; clients poll `GET /session/{sid}/scores` for the result.
-5. `completed` is terminal for MCP/client tools.
+6. `completed` is terminal for MCP/client tools.
 
 `restore_from_storage()` reconstructs enough completed-session state from
 `run_state.json` to read results, read scores, or run operator scoring without
 restarting the tutoring runtime. Restore does not re-trigger auto-eval; the
 score store is the source of truth for whether an eval has run.
+
+`restore_active_from_storage()` reconstructs an active session from the
+run-scoped checkpoint. `POST /api/runs/{run_id}/resume` authorizes with the
+same run token, starts a new container from the latest resume layer when one is
+available, overlays any host-side workspace snapshot, restores conversation/tool
+history into `SessionState`, and returns the reattached `session_id` plus
+REST/MCP endpoints. `GET /api/runs/{run_id}/replay`
+returns read-only conversation and tool logs, and `GET /api/runs/{run_id}/state`
+returns `phase`, `turn_count`, and the latest layer tag.
 
 `POST /session/{sid}/retry` (run-token gated) lets the owning agent retry
 a session whose `termination_reason` classifies as
@@ -159,6 +178,21 @@ bench/results/server/{task_id}/{persona_id}/{YYYYMMDD_HHMMSS}_{session_id[:12]}/
 `run_state.json` is the only required machine-readable run artifact. The server
 does not write or require `run_state.md`, bundle manifests, or a sibling
 evaluation tree.
+
+Active run checkpoints live beside run assignments:
+
+```text
+bench/results/runs/{run_id}/
+  run.json
+  run_state.json
+  workspace_snapshot/
+```
+
+The active `run_state.json` contains replay fields (`conversation`, `tool_logs`),
+resume metadata (`phase`, `turn_count`, `latest_layer_tag`, `snapshot_tags`),
+workspace snapshot metadata, and ownership fields used by run-token
+authorization. Completion removes the active checkpoint and workspace snapshot
+after the final result bundle is written and deletes the run's resume layers.
 
 Each `score_n/score.json` export carries `judge_reliability` metadata linking
 the evaluation report to the selected validated judge-validation run, its


### PR DESCRIPTION
## Summary
- add active run checkpoints plus `/api/runs/{run_id}/resume`, `/replay`, and `/state`
- add Docker resume layers with retention and host workspace snapshot fallback
- restore ACTIVE sessions with conversation, tool logs, workspace files, simulator cost, and same-session continuation
- suspend resumable active runs on MCP disconnect/shutdown and clean resume artifacts on completion

## Verification
- `python3 -m py_compile bench/server/api/http_app.py bench/server/api/session_api.py bench/server/core/container.py bench/server/core/proxy.py bench/server/core/session.py`
- `python3 -m pytest bench/tests/api/test_run_resume.py bench/tests/test_mcp_disconnect_cleanup.py bench/tests/api/test_session_lifecycle.py::TestSessionStatus::test_mcp_disconnect_suspends_resumable_run -q --timeout=30 --timeout-method=thread`
- `python3 -m pytest bench/tests/api/test_run_resume.py bench/tests/api/test_session_lifecycle.py bench/tests/api/test_session_completion_api.py bench/tests/api/test_session_retry.py bench/tests/api/test_rest_run_identity.py bench/tests/test_mcp_disconnect_cleanup.py bench/tests/test_server_session_runtime.py bench/tests/unit/test_session_completion.py bench/tests/unit/test_mcp_tool_routing.py bench/tests/test_proxy_success_detection.py bench/tests/api/test_session_concurrency.py -q --timeout=60 --timeout-method=thread`
- `git diff --cached --check`

Closes #142
