### PR TITLE
feat(platform): add RFC-A v0 plugin API

### DIFF
--- a/bench/platform_api/__init__.py
+++ b/bench/platform_api/__init__.py
@@ -1,0 +1,72 @@
+"""Internal platform API v0 for QuantAgentBench plugins.
+
+This package holds unstable platform contracts while the server monolith is
+split into platform-owned runtime pieces and reference-owned business logic.
+"""
+
+from platform_api.contracts import (
+    EvalItem,
+    EvalSample,
+    Evaluator,
+    EvaluatorMetadata,
+    FileArtifact,
+    NPCProvider,
+    NPCReply,
+    Score,
+    TaskSuite,
+    ToolLog,
+    TranscriptMessage,
+)
+from platform_api.plugins import PluginBundle, PluginLoader, PluginLoadError, PluginSpec
+from platform_api.runtime import (
+    DockerSandboxRuntime,
+    ExecResult,
+    LocalSandboxRuntime,
+    SandboxCreateRequest,
+    SandboxHandle,
+    SandboxMount,
+    SandboxRuntime,
+    SandboxRuntimeError,
+    ToolRequest,
+    ToolResult,
+    ToolRouter,
+)
+from platform_api.telemetry import (
+    InMemoryTelemetryHook,
+    NullTelemetryHook,
+    TelemetryRecord,
+    TelemetryTimer,
+)
+
+__all__ = [
+    "DockerSandboxRuntime",
+    "EvalItem",
+    "EvalSample",
+    "Evaluator",
+    "EvaluatorMetadata",
+    "ExecResult",
+    "FileArtifact",
+    "InMemoryTelemetryHook",
+    "LocalSandboxRuntime",
+    "NPCProvider",
+    "NPCReply",
+    "NullTelemetryHook",
+    "PluginBundle",
+    "PluginLoadError",
+    "PluginLoader",
+    "PluginSpec",
+    "SandboxCreateRequest",
+    "SandboxHandle",
+    "SandboxMount",
+    "SandboxRuntime",
+    "SandboxRuntimeError",
+    "Score",
+    "TaskSuite",
+    "TelemetryRecord",
+    "TelemetryTimer",
+    "ToolLog",
+    "ToolRequest",
+    "ToolResult",
+    "ToolRouter",
+    "TranscriptMessage",
+]

--- a/bench/platform_api/contracts/__init__.py
+++ b/bench/platform_api/contracts/__init__.py
@@ -1,0 +1,27 @@
+"""Plugin-facing contract types."""
+
+from platform_api.contracts.models import (
+    EvalItem,
+    EvalSample,
+    EvaluatorMetadata,
+    FileArtifact,
+    NPCReply,
+    Score,
+    ToolLog,
+    TranscriptMessage,
+)
+from platform_api.contracts.plugins import Evaluator, NPCProvider, TaskSuite
+
+__all__ = [
+    "EvalItem",
+    "EvalSample",
+    "Evaluator",
+    "EvaluatorMetadata",
+    "FileArtifact",
+    "NPCProvider",
+    "NPCReply",
+    "Score",
+    "TaskSuite",
+    "ToolLog",
+    "TranscriptMessage",
+]

--- a/bench/platform_api/contracts/models.py
+++ b/bench/platform_api/contracts/models.py
@@ -1,0 +1,104 @@
+"""Dataclasses shared by TaskSuite, NPCProvider, and Evaluator plugins."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+JsonObject = Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class EvalItem:
+    """Task envelope passed across platform and plugin boundaries."""
+
+    task_id: str
+    payload: JsonObject = field(default_factory=dict)
+    version: str = "0"
+    task_type: str = "multi_turn"
+    metadata: JsonObject = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TranscriptMessage:
+    """One visible conversation message."""
+
+    role: str
+    content: str
+    ts: float | None = None
+    metadata: JsonObject = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ToolLog:
+    """Normalized tool-call record available to NPCs and evaluators."""
+
+    name: str
+    args: JsonObject = field(default_factory=dict)
+    result: str = ""
+    success: bool = True
+    duration_ms: float = 0.0
+    turn_index: int = 0
+    metadata: JsonObject = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FileArtifact:
+    """Workspace artifact referenced by a sample."""
+
+    path: str
+    content: bytes | str | None = None
+    sha256: str = ""
+    size: int | None = None
+    media_type: str = ""
+    metadata: JsonObject = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EvalSample:
+    """Completed run sample consumed by an Evaluator."""
+
+    sample_id: str
+    task_id: str
+    transcript: tuple[TranscriptMessage, ...] = ()
+    tool_logs: tuple[ToolLog, ...] = ()
+    files: Mapping[str, FileArtifact] = field(default_factory=dict)
+    payload: JsonObject = field(default_factory=dict)
+    metadata: JsonObject = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class NPCReply:
+    """NPC response plus lifecycle signal."""
+
+    message: str
+    terminate: bool = False
+    reason: str = ""
+    payload: JsonObject = field(default_factory=dict)
+    telemetry: JsonObject = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Score:
+    """Evaluator score payload."""
+
+    value: float | None
+    status: str = "scored"
+    metrics: JsonObject = field(default_factory=dict)
+    reason: str = ""
+    evidence: tuple[str, ...] = ()
+    telemetry: JsonObject = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EvaluatorMetadata:
+    """Static evaluator metadata surfaced by the loader and registry."""
+
+    evaluator_id: str
+    version: str
+    supported_tasks: frozenset[str] = frozenset()
+    required_bundle_fields: frozenset[str] = frozenset()
+    score_schema: JsonObject = field(default_factory=dict)
+    capabilities: frozenset[str] = frozenset()
+    metadata: JsonObject = field(default_factory=dict)

--- a/bench/platform_api/contracts/plugins.py
+++ b/bench/platform_api/contracts/plugins.py
@@ -1,0 +1,63 @@
+"""Abstract base classes implemented by platform plugins."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Mapping, Sequence
+
+from platform_api.contracts.models import (
+    EvalItem,
+    EvalSample,
+    EvaluatorMetadata,
+    FileArtifact,
+    NPCReply,
+    Score,
+    ToolLog,
+    TranscriptMessage,
+)
+
+
+class TaskSuite(ABC):
+    """Task catalog boundary."""
+
+    @abstractmethod
+    def supported_tasks(self) -> set[str]:
+        """Return task IDs this suite can serve."""
+
+    @abstractmethod
+    def get_task(self, task_id: str) -> EvalItem:
+        """Return a task item envelope for *task_id*."""
+
+    @abstractmethod
+    def required_bundle_fields(self) -> set[str]:
+        """Return bundle fields required by this suite."""
+
+
+class NPCProvider(ABC):
+    """Simulated user/NPC boundary."""
+
+    @abstractmethod
+    def initial_message(self, task: EvalItem) -> str:
+        """Return the first NPC-visible message for a task."""
+
+    @abstractmethod
+    def respond(
+        self,
+        transcript: Sequence[TranscriptMessage],
+        tool_logs: Sequence[ToolLog],
+        files: Mapping[str, FileArtifact],
+        payload: Mapping[str, object],
+    ) -> NPCReply:
+        """Return the next NPC reply and optional termination flag."""
+
+
+class Evaluator(ABC):
+    """Scoring boundary."""
+
+    @abstractmethod
+    def evaluate(self, item: EvalItem, sample: EvalSample) -> Score:
+        """Score one sample for one task item."""
+
+    @abstractmethod
+    def metadata(self) -> EvaluatorMetadata:
+        """Return static evaluator metadata."""

--- a/bench/platform_api/naming.py
+++ b/bench/platform_api/naming.py
@@ -1,0 +1,43 @@
+"""Canonical platform/reference naming decisions for RFC-A v0."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CanonicalName:
+    existing_name: str
+    canonical_name: str
+    owner: str
+    note: str = ""
+
+
+CANONICAL_NAMES: tuple[CanonicalName, ...] = (
+    CanonicalName(
+        existing_name="StudentSimulator",
+        canonical_name="NPCProvider",
+        owner="platform_api.contracts",
+        note="Reference implementations use RefPersonaNPC.",
+    ),
+    CanonicalName(
+        existing_name="TutoringSession",
+        canonical_name="Session",
+        owner="platform runtime",
+    ),
+    CanonicalName(
+        existing_name="StudentPersona",
+        canonical_name="Persona",
+        owner="reference implementation",
+    ),
+    CanonicalName(
+        existing_name="student_opening",
+        canonical_name="payload.student_opening",
+        owner="reference task payload",
+    ),
+    CanonicalName(
+        existing_name="TUTOR_SYSTEM_PROMPT",
+        canonical_name="reference internal constant",
+        owner="reference implementation",
+    ),
+)

--- a/bench/platform_api/plugins/__init__.py
+++ b/bench/platform_api/plugins/__init__.py
@@ -1,0 +1,17 @@
+"""Plugin loading API exports."""
+
+from platform_api.plugins.loader import (
+    PluginBundle,
+    PluginLoader,
+    PluginLoadError,
+    PluginSpec,
+    resolve_import,
+)
+
+__all__ = [
+    "PluginBundle",
+    "PluginLoadError",
+    "PluginLoader",
+    "PluginSpec",
+    "resolve_import",
+]

--- a/bench/platform_api/plugins/loader.py
+++ b/bench/platform_api/plugins/loader.py
@@ -1,0 +1,214 @@
+"""Plugin loader for TaskSuite, NPCProvider, and Evaluator triples."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import json
+import tomllib
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+from platform_api.contracts import Evaluator, NPCProvider, TaskSuite
+
+
+class PluginLoadError(RuntimeError):
+    """Raised when a platform plugin cannot be loaded."""
+
+
+@dataclass(frozen=True)
+class PluginBundle:
+    """Loaded plugin implementation triple."""
+
+    name: str
+    task_suite: TaskSuite
+    npc_provider: NPCProvider
+    evaluator: Evaluator
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PluginSpec:
+    """Import or object references for one plugin."""
+
+    name: str
+    task_suite: Any
+    npc_provider: Any
+    evaluator: Any
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+def resolve_import(path: str) -> Any:
+    """Resolve ``module:attribute`` import strings."""
+
+    if ":" not in path:
+        raise PluginLoadError(f"Import path must use module:attribute form: {path}")
+    module_name, attr_path = path.split(":", 1)
+    try:
+        obj: Any = importlib.import_module(module_name)
+    except Exception as exc:
+        raise PluginLoadError(f"Failed to import module {module_name}: {exc}") from exc
+    for attr in attr_path.split("."):
+        try:
+            obj = getattr(obj, attr)
+        except AttributeError as exc:
+            raise PluginLoadError(
+                f"Import path {path} missing attribute {attr}"
+            ) from exc
+    return obj
+
+
+class PluginLoader:
+    """Load plugins from explicit specs, config files, or entry points."""
+
+    DEFAULT_ENTRY_POINT_GROUP = "quantagentbench.plugins"
+
+    def __init__(self, *, entry_point_group: str | None = None) -> None:
+        self.entry_point_group = entry_point_group or self.DEFAULT_ENTRY_POINT_GROUP
+
+    def load_spec(self, spec: PluginSpec | Mapping[str, Any]) -> PluginBundle:
+        """Load one plugin from a spec object or mapping."""
+
+        if isinstance(spec, Mapping):
+            spec = PluginSpec(
+                name=str(spec["name"]),
+                task_suite=spec["task_suite"],
+                npc_provider=spec["npc_provider"],
+                evaluator=spec["evaluator"],
+                metadata=spec.get("metadata", {}),
+            )
+        bundle = PluginBundle(
+            name=spec.name,
+            task_suite=self._materialize(spec.task_suite, TaskSuite, "task_suite"),
+            npc_provider=self._materialize(
+                spec.npc_provider, NPCProvider, "npc_provider"
+            ),
+            evaluator=self._materialize(spec.evaluator, Evaluator, "evaluator"),
+            metadata=dict(spec.metadata),
+        )
+        return self._validate_bundle(bundle)
+
+    def load_config(self, source: str | Path | Mapping[str, Any]) -> list[PluginBundle]:
+        """Load plugins from a JSON/TOML config file or mapping."""
+
+        config = self._read_config(source)
+        entries = config.get("plugins")
+        if entries is None:
+            entries = [config]
+        if not isinstance(entries, Iterable):
+            raise PluginLoadError("Plugin config field 'plugins' must be iterable")
+        return [self.load_spec(entry) for entry in entries]
+
+    def load_entry_points(
+        self,
+        *,
+        group: str | None = None,
+        names: set[str] | None = None,
+    ) -> list[PluginBundle]:
+        """Load plugins from importlib.metadata entry points."""
+
+        group = group or self.entry_point_group
+        discovered = importlib.metadata.entry_points()
+        if hasattr(discovered, "select"):
+            entry_points = discovered.select(group=group)
+        else:
+            entry_points = discovered.get(group, [])  # pragma: no cover
+
+        bundles: list[PluginBundle] = []
+        for entry_point in entry_points:
+            if names is not None and entry_point.name not in names:
+                continue
+            try:
+                loaded = entry_point.load()
+            except Exception as exc:
+                raise PluginLoadError(
+                    f"Failed to load entry point {entry_point.name}: {exc}"
+                ) from exc
+            bundles.append(self._normalize_loaded(entry_point.name, loaded))
+        return bundles
+
+    def load_many(
+        self,
+        *,
+        specs: Iterable[PluginSpec | Mapping[str, Any]] = (),
+        config_files: Iterable[str | Path] = (),
+        include_entry_points: bool = False,
+        entry_point_names: set[str] | None = None,
+    ) -> list[PluginBundle]:
+        """Load plugins from all configured sources."""
+
+        bundles: list[PluginBundle] = []
+        for spec in specs:
+            bundles.append(self.load_spec(spec))
+        for config_file in config_files:
+            bundles.extend(self.load_config(config_file))
+        if include_entry_points:
+            bundles.extend(self.load_entry_points(names=entry_point_names))
+        return bundles
+
+    def _normalize_loaded(self, name: str, loaded: Any) -> PluginBundle:
+        if isinstance(loaded, PluginBundle):
+            return self._validate_bundle(loaded)
+        if isinstance(loaded, Mapping):
+            payload = dict(loaded)
+            payload.setdefault("name", name)
+            return self.load_spec(payload)
+        if callable(loaded):
+            try:
+                produced = loaded()
+            except TypeError:
+                produced = loaded
+            if produced is loaded:
+                raise PluginLoadError(
+                    f"Entry point {name} returned callable without plugin bundle"
+                )
+            return self._normalize_loaded(name, produced)
+        raise PluginLoadError(f"Entry point {name} returned unsupported plugin value")
+
+    def _materialize(self, raw: Any, expected_type: type, field_name: str) -> Any:
+        obj = resolve_import(raw) if isinstance(raw, str) else raw
+        if isinstance(obj, expected_type):
+            return obj
+        if isinstance(obj, type):
+            try:
+                obj = obj()
+            except Exception as exc:
+                raise PluginLoadError(
+                    f"Failed to instantiate {field_name}: {exc}"
+                ) from exc
+        elif callable(obj):
+            try:
+                obj = obj()
+            except Exception as exc:
+                raise PluginLoadError(f"Failed to call {field_name}: {exc}") from exc
+        if not isinstance(obj, expected_type):
+            raise PluginLoadError(
+                f"{field_name} must implement {expected_type.__name__}"
+            )
+        return obj
+
+    def _validate_bundle(self, bundle: PluginBundle) -> PluginBundle:
+        for field_name, value, expected in (
+            ("task_suite", bundle.task_suite, TaskSuite),
+            ("npc_provider", bundle.npc_provider, NPCProvider),
+            ("evaluator", bundle.evaluator, Evaluator),
+        ):
+            if not isinstance(value, expected):
+                raise PluginLoadError(f"{field_name} must implement {expected.__name__}")
+        return bundle
+
+    def _read_config(self, source: str | Path | Mapping[str, Any]) -> Mapping[str, Any]:
+        if isinstance(source, Mapping):
+            return source
+        path = Path(source)
+        try:
+            if path.suffix.lower() == ".toml":
+                with path.open("rb") as f:
+                    return tomllib.load(f)
+            return json.loads(path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            raise PluginLoadError(f"Failed to read plugin config {path}: {exc}") from exc
+        except (json.JSONDecodeError, tomllib.TOMLDecodeError) as exc:
+            raise PluginLoadError(f"Failed to parse plugin config {path}: {exc}") from exc

--- a/bench/platform_api/runtime/__init__.py
+++ b/bench/platform_api/runtime/__init__.py
@@ -1,0 +1,29 @@
+"""Sandbox runtime API exports."""
+
+from platform_api.runtime.sandbox import (
+    DockerSandboxRuntime,
+    ExecResult,
+    LocalSandboxRuntime,
+    SandboxCreateRequest,
+    SandboxHandle,
+    SandboxMount,
+    SandboxRuntime,
+    SandboxRuntimeError,
+    ToolRequest,
+    ToolResult,
+    ToolRouter,
+)
+
+__all__ = [
+    "DockerSandboxRuntime",
+    "ExecResult",
+    "LocalSandboxRuntime",
+    "SandboxCreateRequest",
+    "SandboxHandle",
+    "SandboxMount",
+    "SandboxRuntime",
+    "SandboxRuntimeError",
+    "ToolRequest",
+    "ToolResult",
+    "ToolRouter",
+]

--- a/bench/platform_api/runtime/sandbox.py
+++ b/bench/platform_api/runtime/sandbox.py
@@ -1,0 +1,569 @@
+"""Sandbox runtime and tool routing API for plugin execution."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Sequence
+
+from platform_api.telemetry import TelemetryHook, emit_telemetry
+
+
+class SandboxRuntimeError(RuntimeError):
+    """Raised when sandbox lifecycle operations fail."""
+
+
+@dataclass(frozen=True)
+class SandboxMount:
+    """Host path mounted into a sandbox."""
+
+    host_path: str
+    container_path: str
+    read_only: bool = True
+
+    def to_docker_volume(self) -> str:
+        mode = "ro" if self.read_only else "rw"
+        return f"{self.host_path}:{self.container_path}:{mode}"
+
+
+@dataclass(frozen=True)
+class SandboxCreateRequest:
+    """Request to create an isolated sandbox process."""
+
+    image_uri: str
+    sandbox_id: str | None = None
+    mounts: tuple[SandboxMount, ...] = ()
+    env: Mapping[str, str] = field(default_factory=dict)
+    network_enabled: bool = False
+    cpus: str = "1"
+    memory: str = "768m"
+    workdir: str = "/workspace"
+    command: tuple[str, ...] = ("sleep", "infinity")
+    pull_policy: str = "missing"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SandboxHandle:
+    """Runtime handle returned by a sandbox implementation."""
+
+    sandbox_id: str
+    image_uri: str
+    container_id: str
+    workspace_path: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExecResult:
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+    timed_out: bool = False
+    duration_ms: float = 0.0
+
+
+@dataclass(frozen=True)
+class ToolRequest:
+    name: str
+    args: Mapping[str, Any] = field(default_factory=dict)
+    timeout: float = 60.0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    tool_name: str
+    success: bool
+    output: str = ""
+    data: Mapping[str, Any] = field(default_factory=dict)
+    duration_ms: float = 0.0
+    error: str | None = None
+
+
+ToolRoute = Callable[
+    [SandboxHandle, Mapping[str, Any]], ToolResult | str | Mapping[str, Any]
+]
+CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+class ToolRouter:
+    """Name-based router for sandbox-aware tools."""
+
+    def __init__(self) -> None:
+        self._routes: dict[str, ToolRoute] = {}
+
+    def register(self, name: str, route: ToolRoute) -> None:
+        if not name:
+            raise ValueError("tool route name is required")
+        self._routes[name] = route
+
+    def names(self) -> tuple[str, ...]:
+        return tuple(sorted(self._routes))
+
+    def has_route(self, name: str) -> bool:
+        return name in self._routes
+
+    def route(self, handle: SandboxHandle, request: ToolRequest) -> ToolResult:
+        if request.name not in self._routes:
+            raise SandboxRuntimeError(f"Unknown tool route: {request.name}")
+
+        start = time.perf_counter()
+        try:
+            result = self._routes[request.name](handle, request.args)
+        except Exception as exc:
+            return ToolResult(
+                tool_name=request.name,
+                success=False,
+                duration_ms=(time.perf_counter() - start) * 1000,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+        duration_ms = (time.perf_counter() - start) * 1000
+        if isinstance(result, ToolResult):
+            return result
+        if isinstance(result, Mapping):
+            success = bool(result.get("success", True))
+            output = str(result.get("output", result.get("result", "")))
+            error = result.get("error")
+            data = {
+                key: value
+                for key, value in result.items()
+                if key not in {"success", "output", "result", "error"}
+            }
+            return ToolResult(
+                tool_name=request.name,
+                success=success,
+                output=output,
+                data=data,
+                duration_ms=duration_ms,
+                error=str(error) if error else None,
+            )
+        return ToolResult(
+            tool_name=request.name,
+            success=True,
+            output=str(result),
+            duration_ms=duration_ms,
+        )
+
+
+class SandboxRuntime(ABC):
+    """Abstract sandbox lifecycle and execution boundary."""
+
+    @abstractmethod
+    def pull_image(self, image_uri: str) -> None:
+        """Ensure a sandbox image is available locally."""
+
+    @abstractmethod
+    def create(self, request: SandboxCreateRequest) -> SandboxHandle:
+        """Create a sandbox and return its handle."""
+
+    @abstractmethod
+    def exec(
+        self,
+        handle: SandboxHandle,
+        command: str | Sequence[str],
+        *,
+        timeout: float = 60.0,
+    ) -> ExecResult:
+        """Execute a process inside the sandbox."""
+
+    @abstractmethod
+    def call_tool(self, handle: SandboxHandle, request: ToolRequest) -> ToolResult:
+        """Route a tool call through the sandbox runtime."""
+
+    @abstractmethod
+    def destroy(self, handle: SandboxHandle) -> None:
+        """Destroy a sandbox and release owned resources."""
+
+
+def _default_runner(
+    args: Sequence[str], *, timeout: float | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _timeout_output_text(value: bytes | str | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+class DockerSandboxRuntime(SandboxRuntime):
+    """Docker-backed sandbox runtime."""
+
+    def __init__(
+        self,
+        *,
+        telemetry: TelemetryHook | None = None,
+        router: ToolRouter | None = None,
+        runner: CommandRunner | None = None,
+    ) -> None:
+        self.telemetry = telemetry
+        self.router = router or ToolRouter()
+        self._runner = runner
+        self._handles: dict[str, SandboxHandle] = {}
+
+    def pull_image(self, image_uri: str) -> None:
+        start = time.perf_counter()
+        error: str | None = None
+        result = self._run(["docker", "pull", image_uri], timeout=None)
+        if result.returncode != 0:
+            error = result.stderr.strip() or result.stdout.strip()
+            self._emit("image_pull", start, False, error, {"image_uri": image_uri})
+            raise SandboxRuntimeError(f"docker pull failed: {error}")
+        self._emit("image_pull", start, True, None, {"image_uri": image_uri})
+
+    def create(self, request: SandboxCreateRequest) -> SandboxHandle:
+        if request.pull_policy == "always":
+            self.pull_image(request.image_uri)
+
+        sandbox_id = request.sandbox_id or f"qab_{uuid.uuid4().hex[:12]}"
+        args = self._build_run_args(sandbox_id, request)
+        start = time.perf_counter()
+        result = self._run(args, timeout=None)
+        if result.returncode != 0:
+            error = result.stderr.strip() or result.stdout.strip()
+            self._emit(
+                "create",
+                start,
+                False,
+                error,
+                {"sandbox_id": sandbox_id, "image_uri": request.image_uri},
+            )
+            raise SandboxRuntimeError(f"docker run failed: {error}")
+
+        container_id = result.stdout.strip()
+        if not container_id:
+            error = "docker run returned empty container id"
+            self._emit(
+                "create",
+                start,
+                False,
+                error,
+                {"sandbox_id": sandbox_id, "image_uri": request.image_uri},
+            )
+            raise SandboxRuntimeError(error)
+
+        handle = SandboxHandle(
+            sandbox_id=sandbox_id,
+            image_uri=request.image_uri,
+            container_id=container_id,
+            metadata=dict(request.metadata),
+        )
+        self._handles[sandbox_id] = handle
+        self._emit(
+            "create",
+            start,
+            True,
+            None,
+            {"sandbox_id": sandbox_id, "image_uri": request.image_uri},
+        )
+        return handle
+
+    def exec(
+        self,
+        handle: SandboxHandle,
+        command: str | Sequence[str],
+        *,
+        timeout: float = 60.0,
+    ) -> ExecResult:
+        if isinstance(command, str):
+            exec_command = ["bash", "-lc", command]
+        else:
+            exec_command = list(command)
+
+        args = ["docker", "exec", handle.container_id, *exec_command]
+        start = time.perf_counter()
+        try:
+            result = self._run(args, timeout=timeout)
+            duration_ms = (time.perf_counter() - start) * 1000
+            success = result.returncode == 0
+            error = None if success else (result.stderr.strip() or result.stdout.strip())
+            self._emit(
+                "exec",
+                start,
+                success,
+                error,
+                {"sandbox_id": handle.sandbox_id, "exit_code": result.returncode},
+            )
+            return ExecResult(
+                stdout=result.stdout,
+                stderr=result.stderr,
+                exit_code=result.returncode,
+                duration_ms=duration_ms,
+            )
+        except subprocess.TimeoutExpired as exc:
+            duration_ms = (time.perf_counter() - start) * 1000
+            error = f"timeout after {timeout}s"
+            self._emit(
+                "exec",
+                start,
+                False,
+                error,
+                {"sandbox_id": handle.sandbox_id},
+            )
+            return ExecResult(
+                stdout=_timeout_output_text(exc.stdout),
+                stderr=_timeout_output_text(exc.stderr),
+                exit_code=-1,
+                timed_out=True,
+                duration_ms=duration_ms,
+            )
+
+    def call_tool(self, handle: SandboxHandle, request: ToolRequest) -> ToolResult:
+        start = time.perf_counter()
+        result = self.router.route(handle, request)
+        latency_ms = (time.perf_counter() - start) * 1000
+        error = result.error if not result.success else None
+        self._emit(
+            "tool",
+            start,
+            result.success,
+            error,
+            {"sandbox_id": handle.sandbox_id, "tool": request.name},
+        )
+        if result.duration_ms:
+            return result
+        return ToolResult(
+            tool_name=result.tool_name,
+            success=result.success,
+            output=result.output,
+            data=result.data,
+            duration_ms=latency_ms,
+            error=result.error,
+        )
+
+    def destroy(self, handle: SandboxHandle) -> None:
+        start = time.perf_counter()
+        result = self._run(["docker", "rm", "-f", handle.container_id], timeout=None)
+        success = result.returncode == 0
+        error = None if success else (result.stderr.strip() or result.stdout.strip())
+        self._handles.pop(handle.sandbox_id, None)
+        self._emit(
+            "destroy",
+            start,
+            success,
+            error,
+            {"sandbox_id": handle.sandbox_id},
+        )
+        if not success:
+            raise SandboxRuntimeError(f"docker rm failed: {error}")
+
+    def _build_run_args(
+        self, sandbox_id: str, request: SandboxCreateRequest
+    ) -> list[str]:
+        args = [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            sandbox_id,
+            "--network",
+            "bridge" if request.network_enabled else "none",
+            "--cpus",
+            str(request.cpus),
+            "--memory",
+            str(request.memory),
+        ]
+        for mount in request.mounts:
+            args.extend(["-v", mount.to_docker_volume()])
+        for key, value in sorted(request.env.items()):
+            args.extend(["-e", f"{key}={value}"])
+        if request.workdir:
+            args.extend(["-w", request.workdir])
+        args.append(request.image_uri)
+        args.extend(request.command)
+        return args
+
+    def _run(
+        self, args: Sequence[str], *, timeout: float | None
+    ) -> subprocess.CompletedProcess[str]:
+        if self._runner is None:
+            return _default_runner(args, timeout=timeout)
+        return self._runner(list(args), timeout=timeout)  # type: ignore[misc]
+
+    def _emit(
+        self,
+        event: str,
+        start: float,
+        success: bool,
+        error: str | None,
+        attributes: dict[str, Any],
+    ) -> None:
+        emit_telemetry(
+            self.telemetry,
+            namespace="sandbox",
+            event=event,
+            latency_ms=(time.perf_counter() - start) * 1000,
+            success=success,
+            error=error,
+            attributes=attributes,
+        )
+
+
+class LocalSandboxRuntime(SandboxRuntime):
+    """Local runtime used for tests and development."""
+
+    def __init__(
+        self,
+        *,
+        telemetry: TelemetryHook | None = None,
+        router: ToolRouter | None = None,
+    ) -> None:
+        self.telemetry = telemetry
+        self.router = router or ToolRouter()
+        self._owned_workspaces: set[str] = set()
+        self._env_by_sandbox_id: dict[str, dict[str, str]] = {}
+
+    def pull_image(self, image_uri: str) -> None:
+        emit_telemetry(
+            self.telemetry,
+            namespace="sandbox",
+            event="image_pull",
+            attributes={"image_uri": image_uri, "runtime": "local"},
+        )
+
+    def create(self, request: SandboxCreateRequest) -> SandboxHandle:
+        start = time.perf_counter()
+        workspace = self._resolve_workspace(request)
+        sandbox_id = request.sandbox_id or f"local_{uuid.uuid4().hex[:12]}"
+        handle = SandboxHandle(
+            sandbox_id=sandbox_id,
+            image_uri=request.image_uri,
+            container_id=sandbox_id,
+            workspace_path=workspace,
+            metadata=dict(request.metadata),
+        )
+        self._env_by_sandbox_id[sandbox_id] = dict(request.env)
+        self._emit(
+            "create",
+            start,
+            True,
+            None,
+            {"sandbox_id": sandbox_id, "runtime": "local"},
+        )
+        return handle
+
+    def exec(
+        self,
+        handle: SandboxHandle,
+        command: str | Sequence[str],
+        *,
+        timeout: float = 60.0,
+    ) -> ExecResult:
+        start = time.perf_counter()
+        env = os.environ.copy()
+        env.update(self._env_by_sandbox_id.get(handle.sandbox_id, {}))
+        try:
+            result = subprocess.run(
+                command,
+                shell=isinstance(command, str),
+                cwd=handle.workspace_path or None,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            self._emit(
+                "exec",
+                start,
+                False,
+                f"timeout after {timeout}s",
+                {"sandbox_id": handle.sandbox_id, "runtime": "local"},
+            )
+            return ExecResult(
+                stdout=_timeout_output_text(exc.stdout),
+                stderr=_timeout_output_text(exc.stderr),
+                exit_code=-1,
+                timed_out=True,
+                duration_ms=(time.perf_counter() - start) * 1000,
+            )
+
+        success = result.returncode == 0
+        error = None if success else (result.stderr.strip() or result.stdout.strip())
+        self._emit(
+            "exec",
+            start,
+            success,
+            error,
+            {"sandbox_id": handle.sandbox_id, "runtime": "local"},
+        )
+        return ExecResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.returncode,
+            duration_ms=(time.perf_counter() - start) * 1000,
+        )
+
+    def call_tool(self, handle: SandboxHandle, request: ToolRequest) -> ToolResult:
+        start = time.perf_counter()
+        result = self.router.route(handle, request)
+        self._emit(
+            "tool",
+            start,
+            result.success,
+            result.error if not result.success else None,
+            {
+                "sandbox_id": handle.sandbox_id,
+                "runtime": "local",
+                "tool": request.name,
+            },
+        )
+        return result
+
+    def destroy(self, handle: SandboxHandle) -> None:
+        start = time.perf_counter()
+        if handle.workspace_path in self._owned_workspaces:
+            shutil.rmtree(handle.workspace_path, ignore_errors=True)
+            self._owned_workspaces.remove(handle.workspace_path)
+        self._env_by_sandbox_id.pop(handle.sandbox_id, None)
+        self._emit(
+            "destroy",
+            start,
+            True,
+            None,
+            {"sandbox_id": handle.sandbox_id, "runtime": "local"},
+        )
+
+    def _resolve_workspace(self, request: SandboxCreateRequest) -> str:
+        for mount in request.mounts:
+            if mount.container_path == request.workdir:
+                return mount.host_path
+        workspace = tempfile.mkdtemp(prefix="qab_local_")
+        self._owned_workspaces.add(workspace)
+        return workspace
+
+    def _emit(
+        self,
+        event: str,
+        start: float,
+        success: bool,
+        error: str | None,
+        attributes: dict[str, Any],
+    ) -> None:
+        emit_telemetry(
+            self.telemetry,
+            namespace="sandbox",
+            event=event,
+            latency_ms=(time.perf_counter() - start) * 1000,
+            success=success,
+            error=error,
+            attributes=attributes,
+        )

--- a/bench/platform_api/telemetry.py
+++ b/bench/platform_api/telemetry.py
@@ -1,0 +1,136 @@
+"""Telemetry primitives shared by plugins, loaders, and runtimes."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from types import TracebackType
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class TelemetryRecord:
+    """One platform telemetry event."""
+
+    namespace: str
+    event: str
+    latency_ms: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: float = 0.0
+    count: int = 1
+    success: bool = True
+    error: str | None = None
+    attributes: dict[str, Any] = field(default_factory=dict)
+    ts: float = field(default_factory=time.time)
+
+
+class TelemetryHook(Protocol):
+    """Push sink for platform telemetry."""
+
+    def emit(self, record: TelemetryRecord) -> None:
+        """Receive one telemetry record."""
+
+
+class NullTelemetryHook:
+    """Telemetry sink that drops records."""
+
+    def emit(self, record: TelemetryRecord) -> None:
+        return None
+
+
+class InMemoryTelemetryHook:
+    """Telemetry sink for tests and local diagnostics."""
+
+    def __init__(self) -> None:
+        self.records: list[TelemetryRecord] = []
+
+    def emit(self, record: TelemetryRecord) -> None:
+        self.records.append(record)
+
+    def totals(self) -> dict[str, float]:
+        """Return aggregate counters across all records."""
+
+        return {
+            "count": float(sum(record.count for record in self.records)),
+            "input_tokens": float(sum(record.input_tokens for record in self.records)),
+            "output_tokens": float(
+                sum(record.output_tokens for record in self.records)
+            ),
+            "cost_usd": float(sum(record.cost_usd for record in self.records)),
+            "latency_ms": float(sum(record.latency_ms for record in self.records)),
+            "errors": float(sum(1 for record in self.records if not record.success)),
+        }
+
+
+class TelemetryTimer:
+    """Context manager that emits latency and error telemetry."""
+
+    def __init__(
+        self,
+        hook: TelemetryHook | None,
+        namespace: str,
+        event: str,
+        *,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        self._hook = hook or NullTelemetryHook()
+        self._namespace = namespace
+        self._event = event
+        self._attributes = dict(attributes or {})
+        self._start = 0.0
+
+    def __enter__(self) -> "TelemetryTimer":
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
+        latency_ms = (time.perf_counter() - self._start) * 1000
+        self._hook.emit(
+            TelemetryRecord(
+                namespace=self._namespace,
+                event=self._event,
+                latency_ms=latency_ms,
+                success=exc is None,
+                error=f"{type(exc).__name__}: {exc}" if exc else None,
+                attributes=self._attributes,
+            )
+        )
+        return False
+
+
+def emit_telemetry(
+    hook: TelemetryHook | None,
+    *,
+    namespace: str,
+    event: str,
+    latency_ms: float = 0.0,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cost_usd: float = 0.0,
+    count: int = 1,
+    success: bool = True,
+    error: str | None = None,
+    attributes: dict[str, Any] | None = None,
+) -> None:
+    """Emit one telemetry record through a possibly empty hook."""
+
+    (hook or NullTelemetryHook()).emit(
+        TelemetryRecord(
+            namespace=namespace,
+            event=event,
+            latency_ms=latency_ms,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost_usd,
+            count=count,
+            success=success,
+            error=error,
+            attributes=dict(attributes or {}),
+        )
+    )

--- a/bench/tests/unit/test_platform_api.py
+++ b/bench/tests/unit/test_platform_api.py
@@ -1,0 +1,314 @@
+import json
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from platform_api import (
+    DockerSandboxRuntime,
+    EvalItem,
+    EvalSample,
+    Evaluator,
+    EvaluatorMetadata,
+    InMemoryTelemetryHook,
+    LocalSandboxRuntime,
+    NPCProvider,
+    NPCReply,
+    PluginBundle,
+    PluginLoadError,
+    PluginLoader,
+    SandboxCreateRequest,
+    SandboxMount,
+    Score,
+    TaskSuite,
+    TelemetryRecord,
+    TelemetryTimer,
+    ToolRequest,
+    ToolRouter,
+    TranscriptMessage,
+)
+
+
+class StubTaskSuite(TaskSuite):
+    def supported_tasks(self) -> set[str]:
+        return {"T1"}
+
+    def get_task(self, task_id: str) -> EvalItem:
+        return EvalItem(task_id=task_id, payload={"student_opening": "hello"})
+
+    def required_bundle_fields(self) -> set[str]:
+        return {"conversation", "tool_logs"}
+
+
+class StubNPCProvider(NPCProvider):
+    def initial_message(self, task: EvalItem) -> str:
+        return str(task.payload["student_opening"])
+
+    def respond(self, transcript, tool_logs, files, payload) -> NPCReply:
+        return NPCReply(message=f"turns={len(transcript)}", terminate=True)
+
+
+class StubEvaluator(Evaluator):
+    def evaluate(self, item: EvalItem, sample: EvalSample) -> Score:
+        return Score(value=1.0, metrics={"sample_id": sample.sample_id})
+
+    def metadata(self) -> EvaluatorMetadata:
+        return EvaluatorMetadata(
+            evaluator_id="stub",
+            version="0",
+            supported_tasks=frozenset({"T1"}),
+            required_bundle_fields=frozenset({"conversation"}),
+        )
+
+
+def test_contract_abcs_and_models_round_trip():
+    suite = StubTaskSuite()
+    npc = StubNPCProvider()
+    evaluator = StubEvaluator()
+
+    item = suite.get_task("T1")
+    sample = EvalSample(
+        sample_id="S1",
+        task_id="T1",
+        transcript=(TranscriptMessage(role="user", content="hello"),),
+    )
+
+    assert suite.supported_tasks() == {"T1"}
+    assert npc.initial_message(item) == "hello"
+    assert npc.respond(sample.transcript, (), {}, {}).terminate is True
+    assert evaluator.evaluate(item, sample).value == 1.0
+    assert evaluator.metadata().required_bundle_fields == frozenset({"conversation"})
+
+
+def test_plugin_loader_loads_json_config(tmp_path, monkeypatch):
+    module_path = tmp_path / "stub_plugin.py"
+    module_path.write_text(
+        """
+from platform_api.contracts import (
+    EvalItem, EvalSample, Evaluator, EvaluatorMetadata, NPCProvider,
+    NPCReply, Score, TaskSuite,
+)
+
+class Suite(TaskSuite):
+    def supported_tasks(self):
+        return {"T1"}
+    def get_task(self, task_id):
+        return EvalItem(task_id=task_id)
+    def required_bundle_fields(self):
+        return {"conversation"}
+
+class NPC(NPCProvider):
+    def initial_message(self, task):
+        return "hello"
+    def respond(self, transcript, tool_logs, files, payload):
+        return NPCReply(message="done", terminate=True)
+
+class Eval(Evaluator):
+    def evaluate(self, item, sample):
+        return Score(value=0.5)
+    def metadata(self):
+        return EvaluatorMetadata(evaluator_id="eval", version="1")
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    config_path = tmp_path / "plugins.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "plugins": [
+                    {
+                        "name": "stub",
+                        "task_suite": "stub_plugin:Suite",
+                        "npc_provider": "stub_plugin:NPC",
+                        "evaluator": "stub_plugin:Eval",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    bundles = PluginLoader().load_config(config_path)
+
+    assert len(bundles) == 1
+    assert bundles[0].name == "stub"
+    assert bundles[0].task_suite.supported_tasks() == {"T1"}
+    assert bundles[0].npc_provider.initial_message(EvalItem("T1")) == "hello"
+
+
+def test_plugin_loader_loads_entry_point_bundle(monkeypatch):
+    bundle = PluginBundle(
+        name="entry",
+        task_suite=StubTaskSuite(),
+        npc_provider=StubNPCProvider(),
+        evaluator=StubEvaluator(),
+    )
+
+    class EntryPoints(list):
+        def select(self, group):
+            return self if group == "quantagentbench.plugins" else []
+
+    fake_entry_point = SimpleNamespace(name="entry", load=lambda: (lambda: bundle))
+    monkeypatch.setattr(
+        "platform_api.plugins.loader.importlib.metadata.entry_points",
+        lambda: EntryPoints([fake_entry_point]),
+    )
+
+    bundles = PluginLoader().load_entry_points()
+
+    assert bundles == [bundle]
+
+
+def test_plugin_loader_empty_entry_point_names_loads_none(monkeypatch):
+    class EntryPoints(list):
+        def select(self, group):
+            return self if group == "quantagentbench.plugins" else []
+
+    def fail_load():
+        pytest.fail("empty entry-point names should skip loading")
+
+    fake_entry_point = SimpleNamespace(name="entry", load=fail_load)
+    monkeypatch.setattr(
+        "platform_api.plugins.loader.importlib.metadata.entry_points",
+        lambda: EntryPoints([fake_entry_point]),
+    )
+
+    assert PluginLoader().load_entry_points(names=set()) == []
+
+
+def test_plugin_loader_rejects_incomplete_spec():
+    with pytest.raises(PluginLoadError):
+        PluginLoader().load_spec(
+            {
+                "name": "bad",
+                "task_suite": object(),
+                "npc_provider": StubNPCProvider(),
+                "evaluator": StubEvaluator(),
+            }
+        )
+
+
+def test_local_sandbox_routes_tools_and_emits_telemetry():
+    telemetry = InMemoryTelemetryHook()
+    router = ToolRouter()
+    router.register("echo", lambda handle, args: {"success": True, "output": args["x"]})
+    runtime = LocalSandboxRuntime(telemetry=telemetry, router=router)
+
+    handle = runtime.create(SandboxCreateRequest(image_uri="local:test"))
+    exec_result = runtime.exec(handle, "printf ok")
+    tool_result = runtime.call_tool(handle, ToolRequest(name="echo", args={"x": "hi"}))
+    runtime.destroy(handle)
+
+    assert exec_result.stdout == "ok"
+    assert tool_result.output == "hi"
+    assert [record.event for record in telemetry.records] == [
+        "create",
+        "exec",
+        "tool",
+        "destroy",
+    ]
+    assert telemetry.totals()["errors"] == 0
+
+
+def test_local_sandbox_timeout_output_is_text():
+    runtime = LocalSandboxRuntime()
+    handle = runtime.create(SandboxCreateRequest(image_uri="local:test"))
+
+    result = runtime.exec(handle, "printf hi; sleep 1", timeout=0.05)
+    runtime.destroy(handle)
+
+    assert result.timed_out is True
+    assert result.stdout == "hi"
+    assert isinstance(result.stdout, str)
+    assert isinstance(result.stderr, str)
+
+
+def test_local_sandbox_exec_uses_request_env_and_counts_failed_records():
+    telemetry = InMemoryTelemetryHook()
+    runtime = LocalSandboxRuntime(telemetry=telemetry)
+    handle = runtime.create(
+        SandboxCreateRequest(
+            image_uri="local:test",
+            env={"QAB_PLATFORM_TEST_VALUE": "available"},
+        )
+    )
+
+    env_result = runtime.exec(handle, "printf $QAB_PLATFORM_TEST_VALUE")
+    failed_result = runtime.exec(handle, ["sh", "-c", "exit 7"])
+    runtime.destroy(handle)
+
+    assert env_result.stdout == "available"
+    assert failed_result.exit_code == 7
+    assert telemetry.records[-2].success is False
+    assert telemetry.totals()["errors"] == 1
+
+
+def test_docker_runtime_builds_isolated_run_command():
+    calls = []
+
+    def runner(args, timeout=None):
+        calls.append(list(args))
+        if args[:3] == ["docker", "run", "-d"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                stdout="container123\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    runtime = DockerSandboxRuntime(runner=runner)
+    handle = runtime.create(
+        SandboxCreateRequest(
+            image_uri="example/image:v1",
+            sandbox_id="case1",
+            mounts=(
+                SandboxMount(
+                    host_path="/tmp/data",
+                    container_path="/data",
+                    read_only=True,
+                ),
+            ),
+            env={"A": "B"},
+            network_enabled=False,
+            cpus="2",
+            memory="1g",
+        )
+    )
+    runtime.destroy(handle)
+
+    run_args = calls[0]
+    assert run_args[:4] == ["docker", "run", "-d", "--name"]
+    assert "--network" in run_args
+    assert run_args[run_args.index("--network") + 1] == "none"
+    assert run_args[run_args.index("--cpus") + 1] == "2"
+    assert run_args[run_args.index("--memory") + 1] == "1g"
+    assert "/tmp/data:/data:ro" in run_args
+    assert "A=B" in run_args
+    assert handle.container_id == "container123"
+    assert calls[-1] == ["docker", "rm", "-f", "container123"]
+
+
+def test_telemetry_timer_records_errors_and_token_counts():
+    hook = InMemoryTelemetryHook()
+    hook.emit(
+        TelemetryRecord(
+            namespace="llm",
+            event="call",
+            input_tokens=3,
+            output_tokens=5,
+            cost_usd=0.01,
+        )
+    )
+
+    with pytest.raises(ValueError):
+        with TelemetryTimer(hook, "sandbox", "exec"):
+            raise ValueError("boom")
+
+    totals = hook.totals()
+    assert totals["input_tokens"] == 3
+    assert totals["output_tokens"] == 5
+    assert totals["cost_usd"] == 0.01
+    assert totals["errors"] == 1
+    assert hook.records[-1].success is False

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,7 @@ backward compatibility.
 
 ```text
 bench/
+  platform_api/         Internal RFC-A v0 plugin contracts + sandbox API
   eval/                Standalone scoring package (no server runtime deps)
   server/              HTTP/MCP service, run control, session storage, UI
   client/              External client adapters for MCP and REST
@@ -45,6 +46,39 @@ current UI shell from `bench/server/web/templates/index.html` and static assets
 from `bench/server/web/static/` into `vercel-frontend/public/`, so Vercel branch
 deployments serve branch-local HTML/CSS/JS while backend API routes still proxy
 to the production service.
+
+## Platform API v0
+
+`bench/platform_api/` is the internal RFC-A v0 surface introduced by #152 for
+plugin-based Stage 1 work. Its import path is `platform_api.*`; this package
+name preserves the Python stdlib `platform` module while tests place `bench/`
+first on `sys.path`.
+
+- `contracts/` defines the three plugin ABCs: `TaskSuite`, `NPCProvider`, and
+  `Evaluator`. Shared dataclasses include `EvalItem`, `EvalSample`,
+  `TranscriptMessage`, `ToolLog`, `FileArtifact`, `NPCReply`, `Score`, and
+  `EvaluatorMetadata`.
+- `runtime/` defines `SandboxRuntime`, `SandboxCreateRequest`, `SandboxMount`,
+  `SandboxHandle`, `ExecResult`, `ToolRequest`, `ToolResult`, and `ToolRouter`.
+  `DockerSandboxRuntime` owns image pulls, container creation with volume,
+  CPU/memory, and network flags, process execution through `docker exec`, and
+  routed tool calls. `LocalSandboxRuntime` covers unit tests and local
+  development flows.
+- `plugins/loader.py` loads implementation triples from explicit
+  `PluginSpec`s, JSON/TOML config files, and Python entry points under
+  `quantagentbench.plugins`.
+- `telemetry.py` exposes a push hook: `TelemetryRecord`,
+  `NullTelemetryHook`, `InMemoryTelemetryHook`, and `TelemetryTimer`. Records
+  carry token counts, cost, latency, success, error, and plugin/runtime
+  attributes.
+- `naming.py` records the current canonical naming table: `NPCProvider` for the
+  platform abstract user/NPC boundary, `Session` for platform session runtime,
+  `Persona` for reference business payloads, `payload.student_opening` for the
+  reference opening field, and `TUTOR_SYSTEM_PROMPT` as reference-internal
+  prompt configuration.
+
+This v0 surface is internal and source-level. Stage 2 owns public SDK/docs,
+multi-tenant BYO image security, and formal schema/deprecation policy.
 
 ## Server Entrypoint
 


### PR DESCRIPTION
Closes #152

## Shipped
- Adds `bench/platform_api/` with plugin ABCs, shared contract dataclasses, sandbox runtime API, plugin loader, telemetry hooks, and canonical naming table.
- Adds Docker/local sandbox implementations with volume/env/network/resource flags, exec, tool routing, and telemetry emission.
- Documents the new internal package boundary in `docs/architecture.md`.

## Verification
- `pytest bench/tests/unit/test_platform_api.py bench/tests/unit/test_eval_architecture_contracts.py` -> 19 passed
- `git diff --cached --check` -> passed before commit
- `codex exec review --uncommitted` -> 2 rounds; material findings fixed

## Notes
- `ruff` is absent in the local environment.
- Broader `python3 -m pytest bench/tests/unit -q -x` stops on existing `ModuleNotFoundError: nest_asyncio` in `bench/tests/unit/test_process_metrics_model_keys.py` after 154 tests pass.