### PR TITLE
feat(platform): add Bundle v1 alpha schema

### DIFF
--- a/bench/eval/backfill/run_state_to_bundle.py
+++ b/bench/eval/backfill/run_state_to_bundle.py
@@ -28,22 +28,20 @@ from typing import Any
 
 from eval.contracts import bundle_io
 from eval.contracts.bundle import (
+    BENCH_EVAL_VERSION,
+    REFERENCE_ARTIFACT_KEY,
     SCHEMA_VERSION,
-    AgentMessage,
-    AgentMetadata,
     Bundle,
-    ConversationTurn,
-    RuntimeInfo,
-    SessionInfo,
-    StudentMessage,
+    BundleTimestamps,
+    Message,
     ToolCall,
     WorkspaceFile,
+    WorkspaceSnapshot,
 )
 
 logger = logging.getLogger(__name__)
 
 _BENCH_ROOT_DEFAULT = Path(__file__).resolve().parents[2]
-_TOOL_RESULT_PREVIEW_LIMIT = 4096
 _NPC_TOOL_NAME = "send_message"
 
 
@@ -62,19 +60,29 @@ def backfill(
     if task_json_path:
         task_json = json.loads(task_json_path.read_text(encoding="utf-8"))
 
-    conversation = _build_conversation(state)
+    messages = _build_messages(state)
     bundle = Bundle(
+        bundle_id=_bundle_id(
+            state,
+            run_state_path=run_state_path,
+            bench_root=bench_root,
+        ),
         schema_version=SCHEMA_VERSION,
         task_id=str(state.get("task_id", "")),
-        task_version=str(task_json.get("version", "")),
-        task_spec_hash=_hash_task_json(task_json) if task_json else "",
-        persona_id=str(state.get("persona_id", "")),
-        session=_build_session(state, turn_count=len(conversation)),
-        runtime=RuntimeInfo(),
-        agent_metadata=AgentMetadata(harness="ref_harness"),
-        conversation=conversation,
-        workspace_manifest=_build_workspace_manifest(
-            run_state_path.parent / "agent_files"
+        timestamps=_build_timestamps(state),
+        agent_id=_agent_id(state),
+        sandbox_digest=_build_sandbox_digest(task_json),
+        telemetry=_build_telemetry(state, messages=messages),
+        messages=messages,
+        tool_calls=_build_tool_calls(state),
+        artifacts=_build_artifacts(
+            state,
+            task_json=task_json,
+            task_spec_hash=_hash_task_json(task_json) if task_json else "",
+        ),
+        workspace=WorkspaceSnapshot(
+            root="agent_files",
+            files=_build_workspace_manifest(run_state_path.parent / "agent_files"),
         ),
     )
 
@@ -98,7 +106,39 @@ def _hash_task_json(task_json: dict) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
-def _build_session(state: dict, *, turn_count: int) -> SessionInfo:
+def _bundle_id(state: dict, *, run_state_path: Path, bench_root: Path) -> str:
+    for key in ("session_id", "run_id"):
+        value = str(state.get(key) or "").strip()
+        if value:
+            return value
+
+    source_path = _stable_source_path(run_state_path, bench_root=bench_root)
+    canonical = json.dumps(
+        {
+            "task_id": state.get("task_id"),
+            "persona_id": state.get("persona_id"),
+            "source_path": source_path,
+            "run_state": state,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12]
+    task_id = str(state.get("task_id") or "bundle")
+    slug = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in task_id)
+    return f"legacy-{slug}-{digest}"
+
+
+def _stable_source_path(run_state_path: Path, *, bench_root: Path) -> str:
+    try:
+        return run_state_path.parent.relative_to(bench_root.parent).as_posix()
+    except ValueError:
+        return run_state_path.parent.as_posix()
+
+
+def _build_timestamps(state: dict) -> BundleTimestamps:
     conv = state.get("conversation") or []
     start_ts = ""
     end_ts = ""
@@ -108,87 +148,79 @@ def _build_session(state: dict, *, turn_count: int) -> SessionInfo:
     if not end_ts:
         end_ts = str(state.get("timestamp") or "")
 
-    return SessionInfo(
-        session_id=str(state.get("session_id", "")),
-        start_ts=start_ts,
-        end_ts=end_ts,
-        termination_reason=str(state.get("termination_reason") or ""),
-        turn_count=turn_count,
+    return BundleTimestamps(
+        created_at=str(state.get("timestamp") or start_ts or end_ts),
+        started_at=start_ts,
+        completed_at=end_ts,
+        duration_seconds=_float_or_none(state.get("duration_seconds")),
     )
 
 
-def _build_conversation(state: dict) -> list[ConversationTurn]:
-    """Pair conversation entries by alternating user/assistant role.
+def _agent_id(state: dict) -> str:
+    agent_cost = _get(state, "agent_cost") or {}
+    return str(
+        state.get("agent_id")
+        or _get(agent_cost, "model")
+        or state.get("agent")
+        or state.get("run_id")
+        or "ref_harness"
+    )
 
-    The persisted conversation is the source of truth for turn structure
-    and message text (it omits synthetic auto-completion send_message
-    logs added by the runtime when an agent gets stuck). tool_logs
-    supply per-turn tool invocations matched by ``turn_index``; the
-    synthetic ``send_message`` NPC tool is excluded as a tool call since
-    its text is already in the conversation, but its ``args.attachments``
-    are pulled forward into the agent message.
-    """
+
+def _build_sandbox_digest(task_json: dict) -> dict[str, Any]:
+    environment = task_json.get("environment") if isinstance(task_json, dict) else {}
+    if not isinstance(environment, dict):
+        environment = {}
+    return {
+        "sandbox_image": str(environment.get("sandbox_image") or ""),
+        "digest": "",
+        "source": "task.environment.sandbox_image",
+    }
+
+
+def _build_telemetry(state: dict, *, messages: list[Message]) -> dict[str, Any]:
+    return {
+        "bench_eval_version": BENCH_EVAL_VERSION,
+        "agent_cost": _get(state, "agent_cost") or {},
+        "simulator_cost": state.get("simulator_cost"),
+        "tc_checker_cost": state.get("tc_checker_cost"),
+        "duration_seconds": state.get("duration_seconds"),
+        "step_count": state.get("step_count"),
+        "message_count": len(messages),
+        "tool_call_count": len(state.get("tool_logs") or []),
+    }
+
+
+def _build_messages(state: dict) -> list[Message]:
     conv = state.get("conversation") or []
-    tool_logs = state.get("tool_logs") or []
-
-    tools_by_turn: dict[int, list[dict]] = {}
     npc_logs_by_turn: dict[int, dict] = {}
-    for log in tool_logs:
+    for log in state.get("tool_logs") or []:
         idx = int(_get(log, "turn_index") or 0)
         if _get(log, "name") == _NPC_TOOL_NAME:
             npc_logs_by_turn.setdefault(idx, log)
-        else:
-            tools_by_turn.setdefault(idx, []).append(log)
 
-    turns: list[ConversationTurn] = []
-    i = 0
+    messages: list[Message] = []
     turn_idx = 0
-    while i < len(conv):
-        entry = conv[i]
-        role = _get(entry, "role")
-        if role == "user":
-            user = StudentMessage(text=str(_get(entry, "content") or ""))
-            agent_text = ""
-            if i + 1 < len(conv) and _get(conv[i + 1], "role") == "assistant":
-                agent_text = str(_get(conv[i + 1], "content") or "")
-                i += 2
-            else:
-                i += 1
-            turns.append(
-                ConversationTurn(
-                    turn=turn_idx + 1,
-                    agent=AgentMessage(
-                        text=agent_text,
-                        attachments=_attachments_for_turn(npc_logs_by_turn, turn_idx),
-                    ),
-                    user=user,
-                    tool_calls=[
-                        _tool_call_from_log(log)
-                        for log in tools_by_turn.get(turn_idx, [])
-                    ],
-                )
+    for idx, entry in enumerate(conv):
+        role = str(_get(entry, "role") or "")
+        if idx > 0:
+            prev_role = _get(conv[idx - 1], "role")
+            if prev_role == "assistant":
+                turn_idx += 1
+        attachments: list[dict[str, Any]] = []
+        if role == "assistant":
+            attachments = _attachments_for_turn(npc_logs_by_turn, turn_idx)
+        messages.append(
+            Message(
+                message_id=f"msg_{idx + 1}",
+                role=role,
+                content=_get(entry, "content") or "",
+                created_at=_coerce_iso(_get(entry, "ts")),
+                turn_index=turn_idx,
+                attachments=attachments,
             )
-            turn_idx += 1
-        elif role == "assistant":
-            turns.append(
-                ConversationTurn(
-                    turn=turn_idx + 1,
-                    agent=AgentMessage(
-                        text=str(_get(entry, "content") or ""),
-                        attachments=_attachments_for_turn(npc_logs_by_turn, turn_idx),
-                    ),
-                    user=None,
-                    tool_calls=[
-                        _tool_call_from_log(log)
-                        for log in tools_by_turn.get(turn_idx, [])
-                    ],
-                )
-            )
-            turn_idx += 1
-            i += 1
-        else:
-            i += 1
-    return turns
+        )
+    return messages
 
 
 def _attachments_for_turn(
@@ -204,24 +236,64 @@ def _attachments_for_turn(
     return [a for a in raw if isinstance(a, dict)]
 
 
-def _tool_call_from_log(log: dict) -> ToolCall:
-    args = _get(log, "args")
-    raw_result = _get(log, "result")
-    result_str = "" if raw_result is None else str(raw_result)
-    truncated = len(result_str) > _TOOL_RESULT_PREVIEW_LIMIT
-    preview = (
-        result_str[:_TOOL_RESULT_PREVIEW_LIMIT] + "..." if truncated else result_str
-    )
+def _build_tool_calls(state: dict) -> list[ToolCall]:
+    calls: list[ToolCall] = []
+    for idx, log in enumerate(state.get("tool_logs") or []):
+        if not isinstance(log, dict):
+            continue
+        calls.append(_tool_call_from_log(log, index=idx))
+    return calls
+
+
+def _tool_call_from_log(log: dict, *, index: int) -> ToolCall:
+    metadata: dict[str, Any] = {}
+    if _get(log, "name") == _NPC_TOOL_NAME:
+        metadata["conversation_transport"] = True
     return ToolCall(
-        call_id=str(_get(log, "call_id") or ""),
-        tool=str(_get(log, "name") or ""),
-        args=args if isinstance(args, dict) else {},
-        result_preview=preview,
-        result_truncated=truncated,
-        ts=_epoch_to_iso(_get(log, "timestamp")),
-        duration_ms=float(_get(log, "duration_ms") or 0.0),
-        success=bool(_get(log, "success", True)),
+        tool_call_id=str(_get(log, "call_id") or f"tool_{index + 1}"),
+        tool_name=str(_get(log, "name") or ""),
+        args=_get(log, "args") if _get(log, "args") is not None else {},
+        result=_get(log, "result"),
+        created_at=_epoch_to_iso(_get(log, "timestamp")),
+        duration_ms=_float_or_none(_get(log, "duration_ms")),
+        success=_bool_or_none(_get(log, "success")),
+        turn_index=_int_or_none(_get(log, "turn_index")),
+        metadata=metadata,
     )
+
+
+def _build_artifacts(
+    state: dict,
+    *,
+    task_json: dict,
+    task_spec_hash: str,
+) -> dict[str, Any]:
+    keys = (
+        "public_task_label",
+        "key_results",
+        "workspace_files",
+        "distractor_names",
+        "trace_summary",
+        "thinking_trace",
+        "format_validation",
+        "tc_coverage",
+        "tc_debug_history",
+        "artifact_debug_history",
+        "evaluation_status",
+    )
+    reference: dict[str, Any] = {
+        "run_id": state.get("run_id"),
+        "session_id": state.get("session_id"),
+        "persona_id": state.get("persona_id"),
+        "session_status": state.get("session_status"),
+        "termination_reason": state.get("termination_reason"),
+        "task_version": task_json.get("version", "") if task_json else "",
+        "task_spec_hash": task_spec_hash,
+    }
+    for key in keys:
+        if key in state:
+            reference[key] = state[key]
+    return {REFERENCE_ARTIFACT_KEY: reference}
 
 
 def _build_workspace_manifest(workspace_dir: Path) -> list[WorkspaceFile]:
@@ -241,7 +313,7 @@ def _build_workspace_manifest(workspace_dir: Path) -> list[WorkspaceFile]:
                 WorkspaceFile(
                     path=rel,
                     sha256=hashlib.sha256(data).hexdigest(),
-                    size=len(data),
+                    size_bytes=len(data),
                 )
             )
     return sorted(entries, key=lambda e: e.path)
@@ -272,6 +344,30 @@ def _get(obj: Any, key: str, default: Any = None) -> Any:
     if isinstance(obj, dict):
         return obj.get(key, default)
     return default
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    if value is None:
+        return None
+    return bool(value)
 
 
 def _resolve_targets(target: Path, recursive: bool) -> list[Path]:

--- a/bench/eval/contracts/bundle.py
+++ b/bench/eval/contracts/bundle.py
@@ -1,13 +1,9 @@
-"""Bundle v1 dataclass: the immutable session artifact scoring reads from.
+"""Generic Bundle v1 alpha dataclasses.
 
-A Bundle captures everything a scorer needs to evaluate a finished session
-without depending on the server runtime: task identity, session metadata,
-turn-by-turn conversation with nested tool calls, and a workspace manifest.
-The on-disk layout is one ``bundle.json`` per session; raw workspace files
-live alongside as ordinary files (referenced by ``workspace_manifest``);
-multiple ``score_v*`` files are written into a sibling ``scores/`` directory.
-
-Forward-compat rules live in ``schema_evolution.md``.
+The bundle is the public artifact contract between capture, scoring, and
+downstream research consumers. The v1 alpha shape keeps the envelope generic:
+messages, tool calls, arbitrary artifacts, and a workspace file snapshot.
+Reference-harness fields live under ``artifacts["quanttutor"]``.
 """
 
 from __future__ import annotations
@@ -15,82 +11,95 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION = "1.0.0-alpha"
 BENCH_EVAL_VERSION = "1.0.0"
+REFERENCE_ARTIFACT_KEY = "quanttutor"
+
+
+@dataclass
+class BundleTimestamps:
+    created_at: str = ""
+    started_at: str = ""
+    completed_at: str = ""
+    duration_seconds: float | None = None
+
+
+@dataclass
+class Message:
+    message_id: str
+    role: str
+    content: Any = ""
+    created_at: str = ""
+    turn_index: int | None = None
+    attachments: list[dict[str, Any]] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
 class ToolCall:
-    call_id: str
-    tool: str
-    args: dict[str, Any] = field(default_factory=dict)
-    result_preview: str = ""
-    result_truncated: bool = False
-    ts: str = ""
-    duration_ms: float = 0.0
-    success: bool = True
-
-
-@dataclass
-class AgentMessage:
-    text: str
-    reasoning: str | None = None
-    attachments: list[dict[str, Any]] = field(default_factory=list)
-
-
-@dataclass
-class StudentMessage:
-    text: str
-
-
-@dataclass
-class ConversationTurn:
-    turn: int
-    agent: AgentMessage
-    user: StudentMessage | None = None
-    tool_calls: list[ToolCall] = field(default_factory=list)
+    tool_call_id: str
+    tool_name: str
+    args: Any = field(default_factory=dict)
+    result: Any = None
+    created_at: str = ""
+    duration_ms: float | None = None
+    success: bool | None = None
+    turn_index: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
 class WorkspaceFile:
     path: str
     sha256: str
-    size: int
+    size_bytes: int
+    entry_type: str = "file"
+    content_ref: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def size(self) -> int:
+        return self.size_bytes
 
 
 @dataclass
-class SessionInfo:
-    session_id: str
-    start_ts: str = ""
-    end_ts: str = ""
-    termination_reason: str = ""
-    turn_count: int = 0
-
-
-@dataclass
-class RuntimeInfo:
-    sandbox_image: str = ""
-    npc_model: str = ""
-    bench_eval_version: str = BENCH_EVAL_VERSION
-    seed: int | None = None
-
-
-@dataclass
-class AgentMetadata:
-    self_reported_name: str = ""
-    self_reported_version: str = ""
-    harness: str = ""
+class WorkspaceSnapshot:
+    root: str = ""
+    files: list[WorkspaceFile] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
 class Bundle:
+    bundle_id: str
     schema_version: str
     task_id: str
-    task_version: str
-    task_spec_hash: str
-    persona_id: str
-    session: SessionInfo
-    runtime: RuntimeInfo
-    agent_metadata: AgentMetadata
-    conversation: list[ConversationTurn] = field(default_factory=list)
-    workspace_manifest: list[WorkspaceFile] = field(default_factory=list)
+    timestamps: BundleTimestamps
+    agent_id: str
+    sandbox_digest: dict[str, Any] = field(default_factory=dict)
+    telemetry: dict[str, Any] = field(default_factory=dict)
+    messages: list[Message] = field(default_factory=list)
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    artifacts: dict[str, Any] = field(default_factory=dict)
+    workspace: WorkspaceSnapshot = field(default_factory=WorkspaceSnapshot)
+
+    @property
+    def reference_artifact(self) -> dict[str, Any]:
+        value = self.artifacts.get(REFERENCE_ARTIFACT_KEY)
+        return value if isinstance(value, dict) else {}
+
+    @property
+    def session_id(self) -> str:
+        return str(self.reference_artifact.get("session_id") or self.bundle_id)
+
+    @property
+    def persona_id(self) -> str:
+        return str(self.reference_artifact.get("persona_id") or "")
+
+    @property
+    def termination_reason(self) -> str:
+        return str(self.reference_artifact.get("termination_reason") or "")
+
+    @property
+    def workspace_manifest(self) -> list[WorkspaceFile]:
+        return self.workspace.files

--- a/bench/eval/contracts/bundle_io.py
+++ b/bench/eval/contracts/bundle_io.py
@@ -1,27 +1,20 @@
-"""Bundle JSON serializer and deserializer with forward-compat reads.
-
-The reader pulls only the fields it knows about from the dict and ignores
-anything else. That lets a v1.0 reader open a v1.1 bundle (extra optional
-fields appear, get silently dropped) without raising. See
-``schema_evolution.md`` for the full rule set.
-"""
+"""Bundle JSON serializer and deserializer with forward-compatible reads."""
 
 from __future__ import annotations
 
 import json
 from dataclasses import asdict
 from pathlib import Path
+from typing import Any
 
 from .bundle import (
-    AgentMessage,
-    AgentMetadata,
+    REFERENCE_ARTIFACT_KEY,
     Bundle,
-    ConversationTurn,
-    RuntimeInfo,
-    SessionInfo,
-    StudentMessage,
+    BundleTimestamps,
+    Message,
     ToolCall,
     WorkspaceFile,
+    WorkspaceSnapshot,
 )
 
 
@@ -29,7 +22,7 @@ class BundleError(RuntimeError):
     """Raised when a bundle cannot be parsed."""
 
 
-def to_dict(bundle: Bundle) -> dict:
+def to_dict(bundle: Bundle) -> dict[str, Any]:
     """Serialize a Bundle to a plain dict suitable for JSON dumping."""
     return asdict(bundle)
 
@@ -45,42 +38,45 @@ def write(bundle: Bundle, path: str | Path) -> Path:
     return p
 
 
-def from_dict(data: dict) -> Bundle:
+def from_dict(data: dict[str, Any]) -> Bundle:
     """Build a Bundle from a parsed JSON dict.
 
-    Unknown top-level (and nested-object) fields are dropped. Missing
-    optional fields fall back to dataclass defaults. ``schema_version``
-    is required at the top level — readers use it to decide whether they
-    can handle the bundle at all.
+    Unknown fields are dropped. Missing optional fields fall back to dataclass
+    defaults. ``schema_version`` is required because readers use it for major
+    compatibility dispatch.
     """
     if not isinstance(data, dict):
         raise BundleError(f"Bundle must be a JSON object; got {type(data).__name__}")
     schema_version = data.get("schema_version")
     if not schema_version:
         raise BundleError("Bundle is missing required field 'schema_version'")
-    if not _major_compatible(schema_version):
+    if not _major_compatible(str(schema_version)):
         raise BundleError(
-            f"Bundle schema_version {schema_version!r} is not v1.x; "
-            "this reader handles v1 only"
+            f"Bundle schema_version {schema_version!r} is outside the v1 family"
         )
+    if "messages" not in data and "conversation" in data:
+        data = _legacy_to_alpha_dict(data)
 
     return Bundle(
-        schema_version=schema_version,
-        task_id=str(data.get("task_id", "")),
-        task_version=str(data.get("task_version", "")),
-        task_spec_hash=str(data.get("task_spec_hash", "")),
-        persona_id=str(data.get("persona_id", "")),
-        session=_session_from_dict(data.get("session") or {}),
-        runtime=_runtime_from_dict(data.get("runtime") or {}),
-        agent_metadata=_agent_metadata_from_dict(data.get("agent_metadata") or {}),
-        conversation=[
-            _turn_from_dict(t) for t in (data.get("conversation") or []) if isinstance(t, dict)
+        bundle_id=str(data.get("bundle_id") or ""),
+        schema_version=str(schema_version),
+        task_id=str(data.get("task_id") or ""),
+        timestamps=_timestamps_from_dict(data.get("timestamps") or {}),
+        agent_id=str(data.get("agent_id") or ""),
+        sandbox_digest=_dict_or_empty(data.get("sandbox_digest")),
+        telemetry=_dict_or_empty(data.get("telemetry")),
+        messages=[
+            _message_from_dict(item)
+            for item in (data.get("messages") or [])
+            if isinstance(item, dict)
         ],
-        workspace_manifest=[
-            _workspace_file_from_dict(w)
-            for w in (data.get("workspace_manifest") or [])
-            if isinstance(w, dict)
+        tool_calls=[
+            _tool_call_from_dict(item)
+            for item in (data.get("tool_calls") or [])
+            if isinstance(item, dict)
         ],
+        artifacts=_dict_or_empty(data.get("artifacts")),
+        workspace=_workspace_from_dict(data.get("workspace") or {}),
     )
 
 
@@ -93,91 +89,207 @@ def read(path: str | Path) -> Bundle:
     return from_json(p.read_text(encoding="utf-8"))
 
 
+def validate(data: dict[str, Any]) -> None:
+    from .bundle_schema import validate_bundle_dict
+
+    validate_bundle_dict(data)
+
+
+def validate_path(path: str | Path) -> None:
+    from .bundle_schema import validate_bundle_path
+
+    validate_bundle_path(path)
+
+
 def _major_compatible(version: str) -> bool:
     try:
-        major = int(str(version).split(".")[0])
+        major = int(str(version).split(".", 1)[0])
     except (ValueError, IndexError):
         return False
     return major == 1
 
 
-def _session_from_dict(d: dict) -> SessionInfo:
-    return SessionInfo(
-        session_id=str(d.get("session_id", "")),
-        start_ts=str(d.get("start_ts", "")),
-        end_ts=str(d.get("end_ts", "")),
-        termination_reason=str(d.get("termination_reason", "")),
-        turn_count=int(d.get("turn_count", 0) or 0),
+def _dict_or_empty(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _timestamps_from_dict(d: dict[str, Any]) -> BundleTimestamps:
+    return BundleTimestamps(
+        created_at=str(d.get("created_at") or ""),
+        started_at=str(d.get("started_at") or ""),
+        completed_at=str(d.get("completed_at") or ""),
+        duration_seconds=_float_or_none(d.get("duration_seconds")),
     )
 
 
-def _runtime_from_dict(d: dict) -> RuntimeInfo:
-    kwargs: dict = {}
-    if "sandbox_image" in d:
-        kwargs["sandbox_image"] = str(d["sandbox_image"])
-    if "npc_model" in d:
-        kwargs["npc_model"] = str(d["npc_model"])
-    if "bench_eval_version" in d:
-        kwargs["bench_eval_version"] = str(d["bench_eval_version"])
-    if d.get("seed") is not None:
-        kwargs["seed"] = int(d["seed"])
-    return RuntimeInfo(**kwargs)
-
-
-def _agent_metadata_from_dict(d: dict) -> AgentMetadata:
-    return AgentMetadata(
-        self_reported_name=str(d.get("self_reported_name", "")),
-        self_reported_version=str(d.get("self_reported_version", "")),
-        harness=str(d.get("harness", "")),
-    )
-
-
-def _turn_from_dict(d: dict) -> ConversationTurn:
-    return ConversationTurn(
-        turn=int(d.get("turn", 0) or 0),
-        agent=_agent_message_from_dict(d.get("agent") or {}),
-        user=_user_message_from_dict(d.get("user")) if d.get("user") else None,
-        tool_calls=[
-            _tool_call_from_dict(tc)
-            for tc in (d.get("tool_calls") or [])
-            if isinstance(tc, dict)
-        ],
-    )
-
-
-def _agent_message_from_dict(d: dict) -> AgentMessage:
+def _message_from_dict(d: dict[str, Any]) -> Message:
     attachments = d.get("attachments") or []
-    if not isinstance(attachments, list):
-        attachments = []
-    return AgentMessage(
-        text=str(d.get("text", "")),
-        reasoning=d.get("reasoning"),
-        attachments=[a for a in attachments if isinstance(a, dict)],
+    return Message(
+        message_id=str(d.get("message_id") or ""),
+        role=str(d.get("role") or ""),
+        content=d.get("content", ""),
+        created_at=str(d.get("created_at") or ""),
+        turn_index=_int_or_none(d.get("turn_index")),
+        attachments=[a for a in attachments if isinstance(a, dict)]
+        if isinstance(attachments, list)
+        else [],
+        metadata=_dict_or_empty(d.get("metadata")),
     )
 
 
-def _user_message_from_dict(d: dict | None) -> StudentMessage | None:
-    if not isinstance(d, dict):
-        return None
-    return StudentMessage(text=str(d.get("text", "")))
-
-
-def _tool_call_from_dict(d: dict) -> ToolCall:
+def _tool_call_from_dict(d: dict[str, Any]) -> ToolCall:
     return ToolCall(
-        call_id=str(d.get("call_id", "")),
-        tool=str(d.get("tool", "")),
-        args=d.get("args") if isinstance(d.get("args"), dict) else {},
-        result_preview=str(d.get("result_preview", "")),
-        result_truncated=bool(d.get("result_truncated", False)),
-        ts=str(d.get("ts", "")),
-        duration_ms=float(d.get("duration_ms", 0.0) or 0.0),
-        success=bool(d.get("success", True)),
+        tool_call_id=str(d.get("tool_call_id") or ""),
+        tool_name=str(d.get("tool_name") or ""),
+        args=d.get("args", {}),
+        result=d.get("result"),
+        created_at=str(d.get("created_at") or ""),
+        duration_ms=_float_or_none(d.get("duration_ms")),
+        success=_bool_or_none(d.get("success")),
+        turn_index=_int_or_none(d.get("turn_index")),
+        metadata=_dict_or_empty(d.get("metadata")),
     )
 
 
-def _workspace_file_from_dict(d: dict) -> WorkspaceFile:
+def _workspace_from_dict(d: dict[str, Any]) -> WorkspaceSnapshot:
+    files = d.get("files") or []
+    return WorkspaceSnapshot(
+        root=str(d.get("root") or ""),
+        files=[
+            _workspace_file_from_dict(item)
+            for item in files
+            if isinstance(item, dict)
+        ],
+        metadata=_dict_or_empty(d.get("metadata")),
+    )
+
+
+def _workspace_file_from_dict(d: dict[str, Any]) -> WorkspaceFile:
     return WorkspaceFile(
-        path=str(d.get("path", "")),
-        sha256=str(d.get("sha256", "")),
-        size=int(d.get("size", 0) or 0),
+        path=str(d.get("path") or ""),
+        sha256=str(d.get("sha256") or ""),
+        size_bytes=int(d.get("size_bytes", d.get("size", 0)) or 0),
+        entry_type=str(d.get("entry_type") or "file"),
+        content_ref=str(d.get("content_ref") or ""),
+        metadata=_dict_or_empty(d.get("metadata")),
     )
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    if value is None:
+        return None
+    return bool(value)
+
+
+def _legacy_to_alpha_dict(data: dict[str, Any]) -> dict[str, Any]:
+    session = data.get("session") if isinstance(data.get("session"), dict) else {}
+    runtime = data.get("runtime") if isinstance(data.get("runtime"), dict) else {}
+    agent = (
+        data.get("agent_metadata")
+        if isinstance(data.get("agent_metadata"), dict)
+        else {}
+    )
+    messages: list[dict[str, Any]] = []
+    tool_calls: list[dict[str, Any]] = []
+    for turn in data.get("conversation") or []:
+        if not isinstance(turn, dict):
+            continue
+        turn_number = int(turn.get("turn") or len(messages) + 1)
+        user = turn.get("user") if isinstance(turn.get("user"), dict) else None
+        agent_msg = turn.get("agent") if isinstance(turn.get("agent"), dict) else {}
+        if user:
+            messages.append(
+                {
+                    "message_id": f"legacy_user_{turn_number}",
+                    "role": "user",
+                    "content": user.get("text", ""),
+                    "turn_index": turn_number - 1,
+                }
+            )
+        messages.append(
+            {
+                "message_id": f"legacy_agent_{turn_number}",
+                "role": "assistant",
+                "content": agent_msg.get("text", ""),
+                "turn_index": turn_number - 1,
+                "attachments": agent_msg.get("attachments") or [],
+                "metadata": {"reasoning": agent_msg.get("reasoning")},
+            }
+        )
+        for tc in turn.get("tool_calls") or []:
+            if not isinstance(tc, dict):
+                continue
+            tool_calls.append(
+                {
+                    "tool_call_id": tc.get("call_id", ""),
+                    "tool_name": tc.get("tool", ""),
+                    "args": tc.get("args", {}),
+                    "result": tc.get("result_preview", ""),
+                    "created_at": tc.get("ts", ""),
+                    "duration_ms": tc.get("duration_ms"),
+                    "success": tc.get("success"),
+                    "turn_index": turn_number - 1,
+                    "metadata": {"result_truncated": tc.get("result_truncated", False)},
+                }
+            )
+
+    artifacts = _dict_or_empty(data.get("artifacts"))
+    artifacts.setdefault(
+        REFERENCE_ARTIFACT_KEY,
+        {
+            "persona_id": data.get("persona_id", ""),
+            "session_id": session.get("session_id", ""),
+            "termination_reason": session.get("termination_reason", ""),
+            "task_version": data.get("task_version", ""),
+            "task_spec_hash": data.get("task_spec_hash", ""),
+            "agent_metadata": agent,
+        },
+    )
+    workspace_files = [
+        {
+            "path": item.get("path", ""),
+            "sha256": item.get("sha256", ""),
+            "size_bytes": item.get("size", item.get("size_bytes", 0)),
+        }
+        for item in data.get("workspace_manifest") or []
+        if isinstance(item, dict)
+    ]
+    return {
+        "bundle_id": session.get("session_id", ""),
+        "schema_version": data.get("schema_version", ""),
+        "task_id": data.get("task_id", ""),
+        "timestamps": {
+            "created_at": session.get("start_ts", ""),
+            "started_at": session.get("start_ts", ""),
+            "completed_at": session.get("end_ts", ""),
+        },
+        "agent_id": agent.get("self_reported_name") or agent.get("harness") or "",
+        "sandbox_digest": {"image": runtime.get("sandbox_image", "")},
+        "telemetry": {
+            "npc_model": runtime.get("npc_model", ""),
+            "bench_eval_version": runtime.get("bench_eval_version", ""),
+            "seed": runtime.get("seed"),
+        },
+        "messages": messages,
+        "tool_calls": tool_calls,
+        "artifacts": artifacts,
+        "workspace": {"root": "agent_files", "files": workspace_files},
+    }

--- a/bench/eval/contracts/bundle_schema.py
+++ b/bench/eval/contracts/bundle_schema.py
@@ -1,0 +1,71 @@
+"""JSON Schema validation tool for Bundle v1 alpha."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_PATH = Path(__file__).with_name("bundle_v1_alpha.schema.json")
+
+
+class BundleValidationError(ValueError):
+    """Raised when a bundle fails JSON Schema validation."""
+
+
+def load_schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def validate_bundle_dict(data: dict[str, Any]) -> None:
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("Install jsonschema>=4.0 to validate bundle JSON") from exc
+
+    validator = Draft202012Validator(load_schema())
+    errors = sorted(validator.iter_errors(data), key=lambda err: list(err.path))
+    if errors:
+        lines = []
+        for err in errors:
+            path = ".".join(str(part) for part in err.absolute_path) or "$"
+            lines.append(f"{path}: {err.message}")
+        raise BundleValidationError("\n".join(lines))
+
+
+def validate_bundle_path(path: str | Path) -> None:
+    bundle_path = Path(path)
+    data = json.loads(bundle_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise BundleValidationError("Bundle JSON root must be an object")
+    validate_bundle_dict(data)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle", nargs="*", type=Path, help="bundle.json path")
+    parser.add_argument(
+        "--print-schema",
+        action="store_true",
+        help="Print the Bundle v1 alpha JSON Schema",
+    )
+    args = parser.parse_args(argv)
+
+    if args.print_schema:
+        print(json.dumps(load_schema(), indent=2))
+    failures = 0
+    for path in args.bundle:
+        try:
+            validate_bundle_path(path)
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"{path}: invalid\n{exc}", file=sys.stderr)
+        else:
+            print(f"{path}: valid")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/eval/contracts/bundle_v1_alpha.schema.json
+++ b/bench/eval/contracts/bundle_v1_alpha.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://quanttutorbench.dev/schemas/bundle-v1-alpha.schema.json",
+  "title": "QuantTutorBench Bundle v1 alpha",
+  "type": "object",
+  "required": [
+    "bundle_id",
+    "schema_version",
+    "task_id",
+    "timestamps",
+    "agent_id",
+    "sandbox_digest",
+    "telemetry",
+    "messages",
+    "tool_calls",
+    "artifacts",
+    "workspace"
+  ],
+  "properties": {
+    "bundle_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "schema_version": {
+      "const": "1.0.0-alpha"
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamps": {
+      "type": "object",
+      "required": ["created_at"],
+      "properties": {
+        "created_at": {
+          "type": "string"
+        },
+        "started_at": {
+          "type": "string"
+        },
+        "completed_at": {
+          "type": "string"
+        },
+        "duration_seconds": {
+          "type": ["number", "null"],
+          "minimum": 0
+        }
+      },
+      "additionalProperties": true
+    },
+    "agent_id": {
+      "type": "string"
+    },
+    "sandbox_digest": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "telemetry": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "messages": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/message"
+      }
+    },
+    "tool_calls": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/tool_call"
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "workspace": {
+      "$ref": "#/$defs/workspace"
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "message": {
+      "type": "object",
+      "required": ["message_id", "role", "content"],
+      "properties": {
+        "message_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": true,
+        "created_at": {
+          "type": "string"
+        },
+        "turn_index": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "attachments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "tool_call": {
+      "type": "object",
+      "required": ["tool_call_id", "tool_name"],
+      "properties": {
+        "tool_call_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tool_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "args": true,
+        "result": true,
+        "created_at": {
+          "type": "string"
+        },
+        "duration_ms": {
+          "type": ["number", "null"],
+          "minimum": 0
+        },
+        "success": {
+          "type": ["boolean", "null"]
+        },
+        "turn_index": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "workspace": {
+      "type": "object",
+      "required": ["files"],
+      "properties": {
+        "root": {
+          "type": "string"
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/workspace_file"
+          }
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "workspace_file": {
+      "type": "object",
+      "required": ["path", "sha256", "size_bytes"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "entry_type": {
+          "type": "string",
+          "enum": ["file", "directory"]
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{64}$"
+        },
+        "size_bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "content_ref": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/bench/eval/contracts/fixtures/bundle_v1_alpha/impl_a_ref_harness.json
+++ b/bench/eval/contracts/fixtures/bundle_v1_alpha/impl_a_ref_harness.json
@@ -1,0 +1,122 @@
+{
+  "bundle_id": "impl-a-smoke-001",
+  "schema_version": "1.0.0-alpha",
+  "task_id": "I01_implement_sma",
+  "timestamps": {
+    "created_at": "2026-05-02T10:00:00Z",
+    "started_at": "2026-05-02T10:00:00Z",
+    "completed_at": "2026-05-02T10:14:32Z",
+    "duration_seconds": 872.0
+  },
+  "agent_id": "ref_harness:gpt-5.2",
+  "sandbox_digest": {
+    "sandbox_image": "quant-tutor-env:v2.2",
+    "digest": ""
+  },
+  "telemetry": {
+    "bench_eval_version": "1.0.0",
+    "agent_cost": {
+      "input_tokens": 1200,
+      "output_tokens": 600,
+      "cost_usd": 0.42
+    },
+    "message_count": 2,
+    "tool_call_count": 2
+  },
+  "messages": [
+    {
+      "message_id": "msg_1",
+      "role": "user",
+      "content": "Implement a single-SMA Lean strategy.",
+      "created_at": "2026-05-02T10:00:00Z",
+      "turn_index": 0,
+      "attachments": [],
+      "metadata": {}
+    },
+    {
+      "message_id": "msg_2",
+      "role": "assistant",
+      "content": "Created Algorithm.cs and ran a smoke backtest.",
+      "created_at": "2026-05-02T10:14:32Z",
+      "turn_index": 0,
+      "attachments": [
+        {
+          "path": "trade_log.csv",
+          "kind": "csv"
+        }
+      ],
+      "metadata": {}
+    }
+  ],
+  "tool_calls": [
+    {
+      "tool_call_id": "file_write_0",
+      "tool_name": "file_write",
+      "args": {
+        "path": "Algorithm.cs"
+      },
+      "result": "wrote Algorithm.cs",
+      "created_at": "2026-05-02T10:05:00Z",
+      "duration_ms": 28.0,
+      "success": true,
+      "turn_index": 0,
+      "metadata": {}
+    },
+    {
+      "tool_call_id": "run_lean_backtest_0",
+      "tool_name": "run_lean_backtest",
+      "args": {
+        "algorithm_path": "Algorithm.cs",
+        "run_id": "sma_smoke"
+      },
+      "result": {
+        "status": "completed",
+        "total_return": 0.012
+      },
+      "created_at": "2026-05-02T10:12:00Z",
+      "duration_ms": 5400.0,
+      "success": true,
+      "turn_index": 0,
+      "metadata": {}
+    }
+  ],
+  "artifacts": {
+    "quanttutor": {
+      "persona_id": "intermediate_developer",
+      "session_id": "impl-a-smoke-001",
+      "termination_reason": "tc_pass",
+      "task_version": "2.2",
+      "task_spec_hash": "abc123",
+      "scores": {
+        "task_score": 0.91,
+        "score_status": "completed_scored"
+      }
+    }
+  },
+  "workspace": {
+    "root": "agent_files",
+    "files": [
+      {
+        "path": "Algorithm.cs",
+        "entry_type": "file",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "size_bytes": 2048,
+        "content_ref": "",
+        "metadata": {
+          "language": "csharp"
+        }
+      },
+      {
+        "path": "trade_log.csv",
+        "entry_type": "file",
+        "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "size_bytes": 512,
+        "content_ref": "",
+        "metadata": {
+          "media_type": "text/csv"
+        }
+      }
+    ],
+    "metadata": {}
+  }
+}

--- a/bench/eval/contracts/fixtures/bundle_v1_alpha/impl_c_financebench_qa.json
+++ b/bench/eval/contracts/fixtures/bundle_v1_alpha/impl_c_financebench_qa.json
@@ -1,0 +1,65 @@
+{
+  "bundle_id": "impl-c-financebench-001",
+  "schema_version": "1.0.0-alpha",
+  "task_id": "financebench_qa_001",
+  "timestamps": {
+    "created_at": "2026-05-02T11:00:00Z",
+    "started_at": "2026-05-02T11:00:00Z",
+    "completed_at": "2026-05-02T11:01:30Z",
+    "duration_seconds": 90.0
+  },
+  "agent_id": "financebench-baseline",
+  "sandbox_digest": {
+    "sandbox_image": "",
+    "digest": ""
+  },
+  "telemetry": {
+    "message_count": 2,
+    "tool_call_count": 0
+  },
+  "messages": [
+    {
+      "message_id": "msg_1",
+      "role": "user",
+      "content": {
+        "question": "What was the reported revenue?",
+        "context_ref": "filing_excerpt_001"
+      },
+      "created_at": "2026-05-02T11:00:00Z",
+      "turn_index": 0,
+      "attachments": [],
+      "metadata": {}
+    },
+    {
+      "message_id": "msg_2",
+      "role": "assistant",
+      "content": {
+        "answer": "$12.4 billion",
+        "evidence": ["filing_excerpt_001"]
+      },
+      "created_at": "2026-05-02T11:01:30Z",
+      "turn_index": 0,
+      "attachments": [],
+      "metadata": {}
+    }
+  ],
+  "tool_calls": [],
+  "artifacts": {
+    "financebench": {
+      "qa_pair": {
+        "question_id": "qa_001",
+        "question": "What was the reported revenue?",
+        "answer": "$12.4 billion"
+      },
+      "score": {
+        "exact_match": true,
+        "confidence": 0.98
+      }
+    }
+  },
+  "workspace": {
+    "root": "",
+    "files": [],
+    "metadata": {}
+  }
+}

--- a/bench/eval/contracts/fixtures/bundle_v1_alpha/impl_d_factor_mining.json
+++ b/bench/eval/contracts/fixtures/bundle_v1_alpha/impl_d_factor_mining.json
@@ -1,0 +1,98 @@
+{
+  "bundle_id": "impl-d-factor-001",
+  "schema_version": "1.0.0-alpha",
+  "task_id": "factor_mining_001",
+  "timestamps": {
+    "created_at": "2026-05-02T12:00:00Z",
+    "started_at": "2026-05-02T12:00:00Z",
+    "completed_at": "2026-05-02T12:09:10Z",
+    "duration_seconds": 550.0
+  },
+  "agent_id": "factor-mining-baseline",
+  "sandbox_digest": {
+    "sandbox_image": "factor-lab:v0",
+    "digest": ""
+  },
+  "telemetry": {
+    "message_count": 1,
+    "tool_call_count": 1
+  },
+  "messages": [
+    {
+      "message_id": "msg_1",
+      "role": "assistant",
+      "content": "Generated a mean-reversion factor and IC matrix outputs.",
+      "created_at": "2026-05-02T12:09:10Z",
+      "turn_index": 0,
+      "attachments": [
+        {
+          "path": "signals/mr_signal.parquet",
+          "kind": "parquet"
+        },
+        {
+          "path": "ic/ic_matrix.csv",
+          "kind": "csv"
+        }
+      ],
+      "metadata": {}
+    }
+  ],
+  "tool_calls": [
+    {
+      "tool_call_id": "factor_eval_0",
+      "tool_name": "evaluate_factor",
+      "args": {
+        "formula": "rank(-1 * returns_5d)",
+        "horizons": [1, 5, 10]
+      },
+      "result": {
+        "mean_ic": 0.041,
+        "icir": 0.72
+      },
+      "created_at": "2026-05-02T12:08:00Z",
+      "duration_ms": 1842.0,
+      "success": true,
+      "turn_index": 0,
+      "metadata": {}
+    }
+  ],
+  "artifacts": {
+    "factor_mining": {
+      "factor_formula": "rank(-1 * returns_5d)",
+      "signal_series": {
+        "path": "signals/mr_signal.parquet",
+        "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      },
+      "ic_matrices": {
+        "path": "ic/ic_matrix.csv",
+        "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      }
+    }
+  },
+  "workspace": {
+    "root": "outputs",
+    "files": [
+      {
+        "path": "signals/mr_signal.parquet",
+        "entry_type": "file",
+        "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "size_bytes": 4096,
+        "content_ref": "",
+        "metadata": {
+          "media_type": "application/vnd.apache.parquet"
+        }
+      },
+      {
+        "path": "ic/ic_matrix.csv",
+        "entry_type": "file",
+        "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "size_bytes": 1024,
+        "content_ref": "",
+        "metadata": {
+          "media_type": "text/csv"
+        }
+      }
+    ],
+    "metadata": {}
+  }
+}

--- a/bench/eval/contracts/schema_evolution.md
+++ b/bench/eval/contracts/schema_evolution.md
@@ -1,71 +1,61 @@
 # Bundle Schema Evolution
 
-The Bundle schema is the contract between session capture and scoring.
-Old bundles must remain readable indefinitely so historical sessions can
-be re-scored with newer evaluators. The rules below balance immutability
-of past data with room for legitimate future evolution.
+The Bundle schema is the contract between session capture, scoring, and
+research consumers. The current release is Stage 1 v0: a v1-family alpha
+baseline that fixes the generic envelope while implementation pressure tests
+continue.
 
 ## Versioning
 
-Top-level `schema_version` is mandatory and uses `MAJOR.MINOR` semver:
+Top-level `schema_version` is mandatory and uses semantic version strings.
 
-- `MAJOR` bumps signal incompatible changes (field rename, semantic
-  change, deletion). They require an explicit migration plan reviewed
-  before merge.
-- `MINOR` bumps are additive only. New optional fields are allowed; no
-  rename, no deletion, no semantic change.
+- Current version: `1.0.0-alpha`
+- The `1.x` family is the Bundle v1 family.
+- Alpha versions can grow through additive fields and fixture-driven schema
+  pressure tests during Stage 1.
+- The Stage 2 freeze issue will define the stable `1.0.0` release and the
+  compatibility window for historical bundles.
 
-Current version: **`1.0`** (constant `SCHEMA_VERSION` in `bundle.py`).
+## Reader Compatibility
 
-## Reader compatibility
+A reader declares the major versions it handles. The current reader handles
+the `1.x` family.
 
-A reader declares the `MAJOR` versions it handles. The current reader
-handles `1.x` only. Within a major version, reads are forward-compatible:
-
-- Unknown top-level keys are ignored.
-- Unknown keys in nested objects (`session`, `runtime`,
-  `agent_metadata`, each conversation turn's nested objects, each tool
-  call, each workspace manifest entry) are ignored.
+- Unknown top-level keys are ignored by the dataclass reader.
+- Unknown keys in nested objects are ignored by the dataclass reader.
 - Missing optional fields fall back to dataclass defaults.
-- `schema_version` is the only field that may abort the read; a v2.x
-  bundle opened by the v1 reader raises `BundleError`.
+- `schema_version` gates the major-family dispatch.
 
-This means a v1.0 reader correctly opens a future v1.5 bundle: the v1.0
-fields populate, the v1.5 additions silently disappear. A v1.5 reader
-opens both v1.0 and v1.5 bundles.
+JSON Schema validation is stricter than the dataclass reader. Use it for
+producer tests and public fixtures:
 
-## Adding a field (MINOR bump)
+```bash
+python -m eval.contracts.bundle_schema bench/eval/contracts/fixtures/bundle_v1_alpha/impl_a_ref_harness.json
+```
 
-1. Add the field to the dataclass in `bundle.py` with a sensible default
-   (so older bundles that lack it deserialize cleanly).
-2. Pull it from `from_dict()` in `bundle_io.py` with `dict.get()` and the
-   same default.
-3. Bump `SCHEMA_VERSION` from `1.N` to `1.N+1` in `bundle.py`. Any newly
-   written bundle stamps the new version; old bundles keep their old
-   stamp.
-4. Update the writer (or backfill script) to populate the field.
+## Additive Changes During Alpha
 
-No reader code changes are needed for older callers — they keep dropping
-the unknown field.
+1. Add the field to `bundle.py` with a default.
+2. Pull it from `from_dict()` in `bundle_io.py`.
+3. Update `bundle_v1_alpha.schema.json`.
+4. Add or update a fixture that demonstrates the field.
+5. Update `docs/bundle_v1_schema.md`.
 
-## Renaming, removing, or changing semantics (MAJOR bump)
+## Stage 2 Placeholder
 
-Forbidden in MINOR. To do any of these:
+Stage 2 will fill in the migration policy after Impl A, Impl C, and Impl D
+exercise the alpha schema end to end. The freeze issue should define:
 
-1. File an issue describing the migration.
-2. Bump `SCHEMA_VERSION` to `2.0`.
-3. Either ship a one-shot migration script that rewrites historical
-   bundles, or extend the reader to handle both majors via a version
-   dispatch.
-4. Update consumers.
+- supported backward-compatibility window;
+- conversion path for `1.0.0-alpha` fixtures;
+- public deprecation policy;
+- score artifact compatibility rules;
+- workspace content reference rules for hashes, external paths, and inline
+  payloads.
 
-## Bundle immutability
+## Bundle Immutability
 
-A `bundle.json` is immutable once written. Re-evaluation produces new
-files under `scores/score_v*_<judge_model>_<ts>.json`; the bundle itself
-is never rewritten. This keeps `task_spec_hash` meaningful as an audit
-anchor.
-
-If the underlying conversation truly needs amendment (a privacy redaction,
-a corrupted ts), write a new bundle directory rather than mutating the
-existing file.
+A `bundle.json` is immutable once written. Re-evaluation produces score
+artifacts under the result directory or under `artifacts` in research exports.
+Historical bundle data stays tied to its original `task_id`, transcript, tool
+calls, and workspace file hashes.

--- a/bench/eval/score.py
+++ b/bench/eval/score.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from eval.contracts import bundle_io
-from eval.contracts.bundle import Bundle, ConversationTurn
+from eval.contracts.bundle import Bundle, Message, ToolCall
 from eval.contracts.output import EvalOutput
 from eval.contracts.request import EvalRequest
 from eval.core.coordinator import EvalCoordinator, load_persona_by_id, load_task_by_id
@@ -38,8 +38,8 @@ def score(
         bench_root: Repo ``bench/`` root used to locate task and persona JSON.
         task: Pre-loaded task object (otherwise resolved from
             ``bundle.task_id``). Pass an in-memory object to avoid disk I/O.
-        persona: Pre-loaded persona object (otherwise resolved from
-            ``bundle.persona_id``).
+        persona: Pre-loaded persona object (otherwise resolved from the
+            QuantTutor artifact persona id).
         eval_mode: ``"full"`` (default), ``"qr"``, or ``"qp"``.
         eval_model: Override judge model (otherwise the eval default).
         workspace_path: Directory containing the agent's workspace files.
@@ -61,11 +61,11 @@ def score(
     if persona is None:
         persona = load_persona_by_id(bench_root, bundle_obj.persona_id)
 
-    conversation = _bundle_to_flat_conversation(bundle_obj.conversation)
-    tool_logs = _bundle_to_flat_tool_logs(bundle_obj.conversation)
+    conversation = _bundle_to_flat_conversation(bundle_obj.messages)
+    tool_logs = _bundle_to_flat_tool_logs(bundle_obj.messages, bundle_obj.tool_calls)
 
     request = EvalRequest(
-        session_id=bundle_obj.session.session_id,
+        session_id=bundle_obj.session_id,
         eval_mode=eval_mode,
         eval_model=eval_model,
     )
@@ -79,9 +79,9 @@ def score(
         run_state = {
             "task_id": bundle_obj.task_id,
             "persona_id": bundle_obj.persona_id,
-            "session_id": bundle_obj.session.session_id,
+            "session_id": bundle_obj.session_id,
             "session_status": "completed",
-            "termination_reason": bundle_obj.session.termination_reason,
+            "termination_reason": bundle_obj.termination_reason,
             "conversation": conversation,
             "tool_logs": tool_logs,
             "workspace_path": ws_path,
@@ -105,51 +105,66 @@ def score(
         )
 
 
-def _bundle_to_flat_conversation(turns: list[ConversationTurn]) -> list[dict]:
-    """Flatten Bundle turns back to the {role, content, ts} list shape the
+def _bundle_to_flat_conversation(messages: list[Message]) -> list[dict]:
+    """Flatten Bundle messages back to the {role, content, ts} list shape the
     coordinator pipeline reads."""
     flat: list[dict] = []
-    for turn in turns:
-        if turn.user is not None:
-            flat.append({"role": "user", "content": turn.user.text, "ts": ""})
-        if turn.agent.text:
-            flat.append({"role": "assistant", "content": turn.agent.text, "ts": ""})
+    for message in messages:
+        flat.append(
+            {
+                "role": message.role,
+                "content": _content_to_text(message.content),
+                "ts": message.created_at,
+            }
+        )
     return flat
 
 
-def _bundle_to_flat_tool_logs(turns: list[ConversationTurn]) -> list[dict]:
-    """Reconstruct flat tool_logs from per-turn tool_calls plus a synthetic
-    ``send_message`` entry per turn so downstream code that filters on
-    ``send_message`` continues to work."""
+def _bundle_to_flat_tool_logs(
+    messages: list[Message],
+    tool_calls: list[ToolCall],
+) -> list[dict]:
+    """Reconstruct flat tool_logs for the coordinator pipeline."""
     flat: list[dict] = []
-    for turn in turns:
-        idx = turn.turn - 1
+    has_send_message = False
+    for tc in tool_calls:
+        if tc.tool_name == "send_message":
+            has_send_message = True
+        flat.append(
+            {
+                "name": tc.tool_name,
+                "args": tc.args if isinstance(tc.args, dict) else {},
+                "call_id": tc.tool_call_id,
+                "result": tc.result,
+                "timestamp": tc.created_at,
+                "duration_ms": tc.duration_ms or 0.0,
+                "success": True if tc.success is None else tc.success,
+                "turn_index": tc.turn_index or 0,
+            }
+        )
+    if has_send_message:
+        return flat
+    for idx, message in enumerate(m for m in messages if m.role == "assistant"):
+        turn_index = message.turn_index if message.turn_index is not None else idx
         flat.append(
             {
                 "name": "send_message",
                 "args": {
-                    "text": turn.agent.text,
-                    "attachments": list(turn.agent.attachments),
+                    "text": _content_to_text(message.content),
+                    "attachments": list(message.attachments),
                 },
-                "call_id": f"send_message_{idx}",
+                "call_id": f"send_message_{turn_index}",
                 "result": "",
-                "timestamp": 0.0,
+                "timestamp": message.created_at,
                 "duration_ms": 0.0,
                 "success": True,
-                "turn_index": idx,
+                "turn_index": turn_index,
             }
         )
-        for tc in turn.tool_calls:
-            flat.append(
-                {
-                    "name": tc.tool,
-                    "args": dict(tc.args),
-                    "call_id": tc.call_id,
-                    "result": tc.result_preview,
-                    "timestamp": 0.0,
-                    "duration_ms": tc.duration_ms,
-                    "success": tc.success,
-                    "turn_index": idx,
-                }
-            )
     return flat
+
+
+def _content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    return json.dumps(content, ensure_ascii=False, default=str)

--- a/bench/requirements.txt
+++ b/bench/requirements.txt
@@ -1,5 +1,6 @@
 # QuantTutorBench dependencies
 pydantic>=2.0.0
+jsonschema>=4.0.0
 pandas>=2.0.0
 numpy>=1.24.0
 matplotlib>=3.7.0

--- a/bench/tests/unit/test_backfill.py
+++ b/bench/tests/unit/test_backfill.py
@@ -1,4 +1,4 @@
-"""Tests for run_state.json -> bundle.json v1 backfill."""
+"""Tests for run_state.json -> Bundle v1 alpha backfill."""
 
 from __future__ import annotations
 
@@ -10,6 +10,8 @@ import pytest
 
 from eval.backfill.run_state_to_bundle import backfill, main
 from eval.contracts import bundle_io
+from eval.contracts.bundle import REFERENCE_ARTIFACT_KEY, SCHEMA_VERSION
+from eval.contracts.bundle_schema import validate_bundle_path
 
 
 def _write_run_state(result_dir: Path, payload: dict) -> Path:
@@ -54,15 +56,25 @@ def _minimal_run_state(**overrides) -> dict:
 
 
 def _bench_root_with_task(tmp_path: Path, task_id: str) -> Path:
-    """Build a fake bench root with one task JSON the backfill can find."""
     bench = tmp_path / "bench"
     task_dir = bench / "tasks" / "layer2" / "strategy"
     task_dir.mkdir(parents=True)
     (task_dir / f"{task_id}.json").write_text(
-        json.dumps({"task_id": task_id, "version": "2.2", "category": "strategy"}),
+        json.dumps(
+            {
+                "task_id": task_id,
+                "version": "2.2",
+                "category": "strategy",
+                "environment": {"sandbox_image": "quant-tutor-env:v2.2"},
+            }
+        ),
         encoding="utf-8",
     )
     return bench
+
+
+def _qtb(bundle):
+    return bundle.artifacts[REFERENCE_ARTIFACT_KEY]
 
 
 def test_backfill_populates_top_level_fields(tmp_path):
@@ -73,13 +85,17 @@ def test_backfill_populates_top_level_fields(tmp_path):
     out = backfill(run_state, bench_root=bench_root)
     bundle = bundle_io.read(out)
 
-    assert bundle.schema_version == "1.0"
+    assert bundle.schema_version == SCHEMA_VERSION
+    assert bundle.bundle_id == state["session_id"]
     assert bundle.task_id == state["task_id"]
-    assert bundle.task_version == "2.2"
-    assert bundle.task_spec_hash  # non-empty sha256
+    assert bundle.agent_id == "ref_harness"
+    assert bundle.sandbox_digest["sandbox_image"] == "quant-tutor-env:v2.2"
+    assert _qtb(bundle)["task_version"] == "2.2"
+    assert _qtb(bundle)["task_spec_hash"]
     assert bundle.persona_id == state["persona_id"]
-    assert bundle.session.session_id == state["session_id"]
-    assert bundle.session.termination_reason == "tc_pass"
+    assert bundle.session_id == state["session_id"]
+    assert bundle.termination_reason == "tc_pass"
+    validate_bundle_path(out)
 
 
 def test_backfill_writes_bundle_next_to_run_state_by_default(tmp_path):
@@ -89,7 +105,25 @@ def test_backfill_writes_bundle_next_to_run_state_by_default(tmp_path):
     assert out.exists()
 
 
-def test_conversation_pairs_alternating_user_assistant(tmp_path):
+def test_backfill_legacy_bundle_id_is_unique_without_session_or_run_id(tmp_path):
+    bench_root = _bench_root_with_task(tmp_path, "B01_interpret_metrics")
+    state = _minimal_run_state(
+        task_id="B01_interpret_metrics",
+        conversation=_conv_pair("u", "a"),
+    )
+    del state["session_id"]
+    left = _write_run_state(tmp_path / "results" / "agent_a" / "result", state)
+    right = _write_run_state(tmp_path / "results" / "agent_b" / "result", state)
+
+    left_bundle = bundle_io.read(backfill(left, bench_root=bench_root))
+    right_bundle = bundle_io.read(backfill(right, bench_root=bench_root))
+
+    assert left_bundle.bundle_id.startswith("legacy-B01_interpret_metrics-")
+    assert right_bundle.bundle_id.startswith("legacy-B01_interpret_metrics-")
+    assert left_bundle.bundle_id != right_bundle.bundle_id
+
+
+def test_conversation_messages_preserve_order_and_turn_index(tmp_path):
     state = _minimal_run_state(
         conversation=_conv_pair("u0", "a0", ts_start=100)
         + _conv_pair("u1", "a1", ts_start=200),
@@ -98,19 +132,13 @@ def test_conversation_pairs_alternating_user_assistant(tmp_path):
     bundle = bundle_io.read(
         backfill(run_state, bench_root=_bench_root_with_task(tmp_path, "S01_ma_crossover"))
     )
-    assert [t.turn for t in bundle.conversation] == [1, 2]
-    assert bundle.conversation[0].user.text == "u0"
-    assert bundle.conversation[0].agent.text == "a0"
-    assert bundle.conversation[1].user.text == "u1"
-    assert bundle.conversation[1].agent.text == "a1"
-    assert bundle.session.turn_count == 2
+    assert [m.role for m in bundle.messages] == ["user", "assistant", "user", "assistant"]
+    assert [m.content for m in bundle.messages] == ["u0", "a0", "u1", "a1"]
+    assert [m.turn_index for m in bundle.messages] == [0, 0, 1, 1]
+    assert bundle.telemetry["message_count"] == 4
 
 
-def test_trailing_lone_user_becomes_turn_with_empty_agent(tmp_path):
-    """Repro of X01-shaped legacy bundle: 5 conv entries (u,a,u,a,u) +
-    3 send_message logs where the third is the synthetic 'agent_stuck'
-    auto-completion. Bundle should have 3 user-led turns; the third
-    has empty agent text — not duplicated text from the synthetic log."""
+def test_trailing_lone_user_is_preserved_without_synthetic_agent_text(tmp_path):
     state = _minimal_run_state(
         conversation=_conv_pair("u0", "a0", ts_start=100)
         + _conv_pair("u1", "a1", ts_start=200)
@@ -130,17 +158,16 @@ def test_trailing_lone_user_becomes_turn_with_empty_agent(tmp_path):
     bundle = bundle_io.read(
         backfill(run_state, bench_root=_bench_root_with_task(tmp_path, "S01_ma_crossover"))
     )
-    assert bundle.session.turn_count == 3
-    assert [t.user.text for t in bundle.conversation] == ["u0", "u1", "u2-no-reply"]
-    assert [t.agent.text for t in bundle.conversation] == ["a0", "a1", ""]
-    # The synthetic send_message log content must not bleed into the third agent message.
-    assert "Repeated message for completion" not in bundle.conversation[2].agent.text
+    assert [m.content for m in bundle.messages if m.role == "user"] == [
+        "u0",
+        "u1",
+        "u2-no-reply",
+    ]
+    assert [m.content for m in bundle.messages if m.role == "assistant"] == ["a0", "a1"]
+    assert len([tc for tc in bundle.tool_calls if tc.tool_name == "send_message"]) == 3
 
 
-def test_domain_tool_only_logs_yield_full_conversation(tmp_path):
-    """Repro of run-single shape: conversation is fully populated, tool_logs
-    are domain tools only (no send_message). Bundle should mirror the
-    persisted conversation and attach tool_logs by turn_index."""
+def test_domain_tool_logs_are_flat_generic_tool_calls(tmp_path):
     state = _minimal_run_state(
         conversation=_conv_pair("u0", "a0", ts_start=100)
         + _conv_pair("u1", "a1", ts_start=200)
@@ -155,18 +182,16 @@ def test_domain_tool_only_logs_yield_full_conversation(tmp_path):
     bundle = bundle_io.read(
         backfill(run_state, bench_root=_bench_root_with_task(tmp_path, "S01_ma_crossover"))
     )
-    assert bundle.session.turn_count == 3
-    assert [t.tool_calls[0].tool for t in bundle.conversation] == [
+    assert [tc.tool_name for tc in bundle.tool_calls] == [
         "file_read",
         "shell_exec",
         "run_lean_backtest",
     ]
-    assert bundle.conversation[1].tool_calls[0].args == {"command": "ls"}
+    assert bundle.tool_calls[1].args == {"command": "ls"}
+    assert bundle.tool_calls[1].result == "a\nb"
 
 
-def test_send_message_logs_excluded_from_tool_calls(tmp_path):
-    """The synthetic send_message NPC tool is the conversation conduit, not a
-    domain tool call — must not appear in any turn's tool_calls list."""
+def test_send_message_logs_are_marked_as_conversation_transport(tmp_path):
     state = _minimal_run_state(
         tool_logs=[
             _tool_log("send_message", turn_index=0, args={"text": "hello"}),
@@ -177,14 +202,11 @@ def test_send_message_logs_excluded_from_tool_calls(tmp_path):
     bundle = bundle_io.read(
         backfill(run_state, bench_root=_bench_root_with_task(tmp_path, "S01_ma_crossover"))
     )
-    tools = bundle.conversation[0].tool_calls
-    assert len(tools) == 1
-    assert tools[0].tool == "file_read"
+    assert [tc.tool_name for tc in bundle.tool_calls] == ["send_message", "file_read"]
+    assert bundle.tool_calls[0].metadata["conversation_transport"] is True
 
 
-def test_send_message_attachments_carry_into_agent_message(tmp_path):
-    """attachments live on the synthetic send_message log's args, not on the
-    conversation entry — backfill must pull them forward to agent.attachments."""
+def test_send_message_attachments_carry_into_assistant_message(tmp_path):
     attachments = [{"path": "report.csv", "kind": "csv"}]
     state = _minimal_run_state(
         tool_logs=[
@@ -195,10 +217,42 @@ def test_send_message_attachments_carry_into_agent_message(tmp_path):
     bundle = bundle_io.read(
         backfill(run_state, bench_root=_bench_root_with_task(tmp_path, "S01_ma_crossover"))
     )
-    assert bundle.conversation[0].agent.attachments == attachments
+    assistant = next(m for m in bundle.messages if m.role == "assistant")
+    assert assistant.attachments == attachments
 
 
-def test_truncates_long_tool_results(tmp_path):
+def test_consecutive_assistant_attachments_match_send_message_turn(tmp_path):
+    state = _minimal_run_state(
+        conversation=[
+            {"role": "assistant", "content": "a0"},
+            {"role": "assistant", "content": "a1"},
+        ],
+        tool_logs=[
+            _tool_log(
+                "send_message",
+                turn_index=0,
+                args={"text": "a0", "attachments": [{"path": "a0.csv"}]},
+            ),
+            _tool_log(
+                "send_message",
+                turn_index=1,
+                args={"text": "a1", "attachments": [{"path": "a1.csv"}]},
+            ),
+        ],
+    )
+    run_state = _write_run_state(tmp_path / "result", state)
+    bundle = bundle_io.read(
+        backfill(run_state, bench_root=_bench_root_with_task(tmp_path, "S01_ma_crossover"))
+    )
+
+    assert [message.turn_index for message in bundle.messages] == [0, 1]
+    assert [message.attachments for message in bundle.messages] == [
+        [{"path": "a0.csv"}],
+        [{"path": "a1.csv"}],
+    ]
+
+
+def test_preserves_long_tool_results_as_artifact_json(tmp_path):
     long_blob = "x" * 10000
     state = _minimal_run_state(
         tool_logs=[_tool_log("shell_exec", turn_index=0, result=long_blob)],
@@ -207,10 +261,7 @@ def test_truncates_long_tool_results(tmp_path):
     bundle = bundle_io.read(
         backfill(run_state, bench_root=_bench_root_with_task(tmp_path, "S01_ma_crossover"))
     )
-    tc = bundle.conversation[0].tool_calls[0]
-    assert tc.result_truncated is True
-    assert tc.result_preview.endswith("...")
-    assert len(tc.result_preview) <= 4096 + 3
+    assert bundle.tool_calls[0].result == long_blob
 
 
 def test_workspace_manifest_hashes_files(tmp_path):
@@ -226,12 +277,13 @@ def test_workspace_manifest_hashes_files(tmp_path):
         backfill(run_state, bench_root=_bench_root_with_task(tmp_path, "S01_ma_crossover"))
     )
 
-    paths = [w.path for w in bundle.workspace_manifest]
+    paths = [w.path for w in bundle.workspace.files]
     assert paths == sorted(paths)
     assert "Algorithm.cs" in paths
     assert "subdir/data.csv" in paths
 
-    cs_entry = next(w for w in bundle.workspace_manifest if w.path == "Algorithm.cs")
+    cs_entry = next(w for w in bundle.workspace.files if w.path == "Algorithm.cs")
+    assert cs_entry.size_bytes == len("class A {}")
     assert cs_entry.size == len("class A {}")
     assert cs_entry.sha256 == hashlib.sha256(b"class A {}").hexdigest()
 
@@ -243,8 +295,8 @@ def test_handles_missing_task_json(tmp_path):
     (bench_root / "tasks" / "layer2").mkdir(parents=True)
 
     bundle = bundle_io.read(backfill(run_state, bench_root=bench_root))
-    assert bundle.task_version == ""
-    assert bundle.task_spec_hash == ""
+    assert _qtb(bundle)["task_version"] == ""
+    assert _qtb(bundle)["task_spec_hash"] == ""
 
 
 def test_handles_empty_conversation(tmp_path):
@@ -253,8 +305,8 @@ def test_handles_empty_conversation(tmp_path):
     bundle = bundle_io.read(
         backfill(run_state, bench_root=_bench_root_with_task(tmp_path, "S01_ma_crossover"))
     )
-    assert bundle.conversation == []
-    assert bundle.session.turn_count == 0
+    assert bundle.messages == []
+    assert bundle.telemetry["message_count"] == 0
 
 
 def test_main_recursive_walks_results_tree(tmp_path):
@@ -294,8 +346,6 @@ def test_main_rejects_path_with_no_run_state(tmp_path):
 
 
 def test_real_sample_smokes(tmp_path):
-    """Backfill any existing run_state.json in bench/results/server/ and
-    verify the result deserializes round-trip clean."""
     bench_root = Path(__file__).resolve().parents[2]
     samples = list((bench_root / "results" / "server").rglob("run_state.json"))
     if not samples:
@@ -306,15 +356,14 @@ def test_real_sample_smokes(tmp_path):
     backfill(sample, bench_root=bench_root, output=out)
 
     bundle = bundle_io.read(out)
-    assert bundle.schema_version == "1.0"
+    assert bundle.schema_version == SCHEMA_VERSION
     assert bundle.task_id
     assert bundle.persona_id
-    assert bundle.session.session_id
+    assert bundle.session_id
+    validate_bundle_path(out)
 
 
 def test_real_run_single_sample_smokes(tmp_path):
-    """Same smoke for the older bench/results/run-single/ shape (domain tools
-    only, no send_message logs)."""
     bench_root = Path(__file__).resolve().parents[2]
     samples = list((bench_root / "results" / "run-single").rglob("run_state.json"))
     if not samples:
@@ -324,4 +373,5 @@ def test_real_run_single_sample_smokes(tmp_path):
     out = tmp_path / "bundle.json"
     backfill(sample, bench_root=bench_root, output=out)
     bundle = bundle_io.read(out)
-    assert bundle.schema_version == "1.0"
+    assert bundle.schema_version == SCHEMA_VERSION
+    validate_bundle_path(out)

--- a/bench/tests/unit/test_bundle.py
+++ b/bench/tests/unit/test_bundle.py
@@ -1,78 +1,88 @@
-"""Tests for Bundle v1 dataclass + JSON serializer."""
+"""Tests for Bundle v1 alpha dataclasses, JSON IO, and JSON Schema."""
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
 from eval.contracts import bundle_io
 from eval.contracts.bundle import (
+    REFERENCE_ARTIFACT_KEY,
     SCHEMA_VERSION,
-    AgentMessage,
-    AgentMetadata,
     Bundle,
-    ConversationTurn,
-    RuntimeInfo,
-    SessionInfo,
-    StudentMessage,
+    BundleTimestamps,
+    Message,
     ToolCall,
     WorkspaceFile,
+    WorkspaceSnapshot,
 )
+from eval.contracts.bundle_schema import BundleValidationError, validate_bundle_dict
 
 
 def _make_bundle() -> Bundle:
     return Bundle(
+        bundle_id="sess-1",
         schema_version=SCHEMA_VERSION,
         task_id="S01_ma_crossover",
-        task_version="2.2",
-        task_spec_hash="abc123",
-        persona_id="double_novice",
-        session=SessionInfo(
-            session_id="sess-1",
-            start_ts="2026-05-02T10:00:00Z",
-            end_ts="2026-05-02T10:14:32Z",
-            termination_reason="tc_pass",
-            turn_count=2,
+        timestamps=BundleTimestamps(
+            created_at="2026-05-02T10:00:00Z",
+            started_at="2026-05-02T10:00:00Z",
+            completed_at="2026-05-02T10:14:32Z",
+            duration_seconds=872.0,
         ),
-        runtime=RuntimeInfo(
-            sandbox_image="quant-tutor-env:v2.2",
-            npc_model="gpt-5.2-2026-01-15",
-            bench_eval_version="1.0.0",
-            seed=42,
-        ),
-        agent_metadata=AgentMetadata(
-            self_reported_name="claude-opus-4-7",
-            self_reported_version="1.0",
-            harness="ref_harness",
-        ),
-        conversation=[
-            ConversationTurn(
-                turn=1,
-                agent=AgentMessage(text="hello", reasoning=None, attachments=[]),
-                user=StudentMessage(text="hi back"),
-                tool_calls=[
-                    ToolCall(
-                        call_id="tc_001",
-                        tool="fetch_market_data",
-                        args={"symbol": "AAPL"},
-                        result_preview="...",
-                        result_truncated=True,
-                        ts="2026-05-02T10:01:00Z",
-                        duration_ms=1234.0,
-                        success=True,
-                    ),
-                ],
+        agent_id="claude-opus-4-7",
+        sandbox_digest={"sandbox_image": "quant-tutor-env:v2.2", "digest": ""},
+        telemetry={"bench_eval_version": "1.0.0", "seed": 42},
+        messages=[
+            Message(
+                message_id="msg_1",
+                role="user",
+                content="hi back",
+                created_at="2026-05-02T10:00:00Z",
+                turn_index=0,
             ),
-            ConversationTurn(
-                turn=2,
-                agent=AgentMessage(text="ok", reasoning="thinking"),
-                user=None,
+            Message(
+                message_id="msg_2",
+                role="assistant",
+                content="hello",
+                created_at="2026-05-02T10:01:00Z",
+                turn_index=0,
+                attachments=[{"path": "AAPL_with_sma.csv", "kind": "csv"}],
             ),
         ],
-        workspace_manifest=[
-            WorkspaceFile(path="AAPL_with_sma.csv", sha256="deadbeef", size=102400),
+        tool_calls=[
+            ToolCall(
+                tool_call_id="tc_001",
+                tool_name="fetch_market_data",
+                args={"symbol": "AAPL"},
+                result={"rows": 10},
+                created_at="2026-05-02T10:01:00Z",
+                duration_ms=1234.0,
+                success=True,
+                turn_index=0,
+            )
         ],
+        artifacts={
+            REFERENCE_ARTIFACT_KEY: {
+                "persona_id": "double_novice",
+                "session_id": "sess-1",
+                "termination_reason": "tc_pass",
+                "task_version": "2.2",
+                "task_spec_hash": "abc123",
+            }
+        },
+        workspace=WorkspaceSnapshot(
+            root="agent_files",
+            files=[
+                WorkspaceFile(
+                    path="AAPL_with_sma.csv",
+                    sha256="0" * 64,
+                    size_bytes=102400,
+                )
+            ],
+        ),
     )
 
 
@@ -94,72 +104,62 @@ def test_bundle_write_and_read(tmp_path):
 def test_to_json_is_indented_and_unicode_safe():
     b = _make_bundle()
     s = bundle_io.to_json(b)
-    # indent=2 means there's at least one newline + spaces in the output
     assert "\n  " in s
-    # ensure_ascii=False keeps non-ASCII intact (regression guard)
-    b2 = Bundle(
-        schema_version=SCHEMA_VERSION,
-        task_id="S01",
-        task_version="1",
-        task_spec_hash="h",
-        persona_id="p",
-        session=SessionInfo(session_id="s"),
-        runtime=RuntimeInfo(),
-        agent_metadata=AgentMetadata(),
-        conversation=[
-            ConversationTurn(turn=1, agent=AgentMessage(text="日本語チェック"))
-        ],
-    )
-    out = bundle_io.to_json(b2)
+    b.messages[0].content = "日本語チェック"
+    out = bundle_io.to_json(b)
     assert "日本語チェック" in out
 
 
-def test_reader_ignores_unknown_top_level_fields():
+def test_json_schema_accepts_current_bundle():
+    raw = json.loads(bundle_io.to_json(_make_bundle()))
+    validate_bundle_dict(raw)
+
+
+def test_json_schema_rejects_missing_envelope_field():
+    raw = json.loads(bundle_io.to_json(_make_bundle()))
+    del raw["bundle_id"]
+    with pytest.raises(BundleValidationError, match="bundle_id"):
+        validate_bundle_dict(raw)
+
+
+def test_reader_ignores_unknown_fields():
     b = _make_bundle()
     raw = json.loads(bundle_io.to_json(b))
     raw["future_field"] = {"some": "future expansion"}
-    raw["another_unknown"] = 42
-    b2 = bundle_io.from_dict(raw)
-    assert b2 == b
-
-
-def test_reader_ignores_unknown_nested_fields():
-    b = _make_bundle()
-    raw = json.loads(bundle_io.to_json(b))
-    raw["session"]["future_subfield"] = "x"
-    raw["runtime"]["future_subfield"] = "y"
-    raw["agent_metadata"]["future_subfield"] = "z"
-    raw["conversation"][0]["future_subfield"] = "w"
-    raw["conversation"][0]["agent"]["future_subfield"] = "v"
-    raw["conversation"][0]["tool_calls"][0]["future_subfield"] = "u"
-    raw["workspace_manifest"][0]["future_subfield"] = "t"
+    raw["messages"][0]["future_subfield"] = "v"
+    raw["tool_calls"][0]["future_subfield"] = "u"
+    raw["workspace"]["files"][0]["future_subfield"] = "t"
     b2 = bundle_io.from_dict(raw)
     assert b2 == b
 
 
 def test_reader_fills_missing_optional_fields_with_defaults():
     minimal = {
+        "bundle_id": "b",
         "schema_version": SCHEMA_VERSION,
         "task_id": "S01",
-        "task_version": "1",
-        "task_spec_hash": "h",
-        "persona_id": "p",
-        "session": {"session_id": "s"},
-        "runtime": {},
-        "agent_metadata": {},
-        "conversation": [],
-        "workspace_manifest": [],
+        "timestamps": {"created_at": "2026-05-02T10:00:00Z"},
+        "agent_id": "agent",
+        "sandbox_digest": {},
+        "telemetry": {},
+        "messages": [],
+        "tool_calls": [],
+        "artifacts": {},
+        "workspace": {"files": []},
     }
     b = bundle_io.from_dict(minimal)
-    assert b.session.session_id == "s"
-    assert b.session.start_ts == ""
-    assert b.session.turn_count == 0
-    assert b.runtime.seed is None
-    # Missing optional fields fall back to dataclass defaults (see schema_evolution.md).
-    assert b.runtime.bench_eval_version == "1.0.0"
-    assert b.agent_metadata.harness == ""
-    assert b.conversation == []
-    assert b.workspace_manifest == []
+    assert b.bundle_id == "b"
+    assert b.timestamps.completed_at == ""
+    assert b.messages == []
+    assert b.workspace.files == []
+
+
+def test_reference_properties_read_quanttutor_artifact():
+    b = _make_bundle()
+    assert b.session_id == "sess-1"
+    assert b.persona_id == "double_novice"
+    assert b.termination_reason == "tc_pass"
+    assert b.workspace_manifest == b.workspace.files
 
 
 def test_reader_rejects_missing_schema_version():
@@ -171,17 +171,17 @@ def test_reader_rejects_missing_schema_version():
 
 def test_reader_rejects_incompatible_major_version():
     raw = json.loads(bundle_io.to_json(_make_bundle()))
-    raw["schema_version"] = "2.0"
-    with pytest.raises(bundle_io.BundleError, match="v1 only"):
+    raw["schema_version"] = "2.0.0"
+    with pytest.raises(bundle_io.BundleError, match="v1 family"):
         bundle_io.from_dict(raw)
 
 
 def test_reader_accepts_minor_bump_within_v1():
     raw = json.loads(bundle_io.to_json(_make_bundle()))
-    raw["schema_version"] = "1.5"
+    raw["schema_version"] = "1.5.0"
     raw["unrecognized_v1_5_field"] = "ok"
     b = bundle_io.from_dict(raw)
-    assert b.schema_version == "1.5"
+    assert b.schema_version == "1.5.0"
 
 
 def test_reader_rejects_non_dict_payload():
@@ -189,19 +189,16 @@ def test_reader_rejects_non_dict_payload():
         bundle_io.from_dict([1, 2, 3])  # type: ignore[arg-type]
 
 
-def test_turn_with_none_user_roundtrips():
-    b = Bundle(
-        schema_version=SCHEMA_VERSION,
-        task_id="S01",
-        task_version="1",
-        task_spec_hash="h",
-        persona_id="p",
-        session=SessionInfo(session_id="s"),
-        runtime=RuntimeInfo(),
-        agent_metadata=AgentMetadata(),
-        conversation=[
-            ConversationTurn(turn=1, agent=AgentMessage(text="hi"), user=None),
-        ],
+def test_fixture_bundles_validate_against_json_schema():
+    fixture_dir = (
+        Path(__file__).resolve().parents[2]
+        / "eval"
+        / "contracts"
+        / "fixtures"
+        / "bundle_v1_alpha"
     )
-    b2 = bundle_io.from_json(bundle_io.to_json(b))
-    assert b2.conversation[0].user is None
+    fixtures = sorted(fixture_dir.glob("*.json"))
+    assert len(fixtures) >= 3
+    for fixture in fixtures:
+        raw = json.loads(fixture.read_text(encoding="utf-8"))
+        validate_bundle_dict(raw)

--- a/bench/tests/unit/test_eval_score_standalone.py
+++ b/bench/tests/unit/test_eval_score_standalone.py
@@ -18,14 +18,11 @@ import subprocess
 from pathlib import Path
 
 from eval.contracts.bundle import (
+    REFERENCE_ARTIFACT_KEY,
     SCHEMA_VERSION,
-    AgentMessage,
-    AgentMetadata,
     Bundle,
-    ConversationTurn,
-    RuntimeInfo,
-    SessionInfo,
-    StudentMessage,
+    BundleTimestamps,
+    Message,
 )
 from eval.contracts.output import EvalOutput
 from eval.score import score
@@ -101,25 +98,39 @@ def _write_minimal_persona(tmp_path: Path, persona_id: str) -> Path:
 
 def _make_bundle(task_id: str, persona_id: str) -> Bundle:
     return Bundle(
+        bundle_id="smoke-sess",
         schema_version=SCHEMA_VERSION,
         task_id=task_id,
-        task_version="1.0",
-        task_spec_hash="smoke",
-        persona_id=persona_id,
-        session=SessionInfo(
-            session_id="smoke-sess",
-            termination_reason="max_turns",
-            turn_count=1,
+        timestamps=BundleTimestamps(
+            created_at="2026-05-02T10:00:00Z",
+            completed_at="2026-05-02T10:01:00Z",
         ),
-        runtime=RuntimeInfo(),
-        agent_metadata=AgentMetadata(harness="smoke"),
-        conversation=[
-            ConversationTurn(
-                turn=1,
-                agent=AgentMessage(text="Here's a brief plan."),
-                user=StudentMessage(text="Walk me through the strategy."),
+        agent_id="smoke",
+        sandbox_digest={},
+        telemetry={},
+        messages=[
+            Message(
+                message_id="msg_1",
+                role="user",
+                content="Walk me through the strategy.",
+                turn_index=0,
+            ),
+            Message(
+                message_id="msg_2",
+                role="assistant",
+                content="Here's a brief plan.",
+                turn_index=0,
             ),
         ],
+        artifacts={
+            REFERENCE_ARTIFACT_KEY: {
+                "persona_id": persona_id,
+                "session_id": "smoke-sess",
+                "termination_reason": "max_turns",
+                "task_version": "1.0",
+                "task_spec_hash": "smoke",
+            }
+        },
     )
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,17 +239,18 @@ of server in #123 since score persistence is a scoring concern).
 
 ### Bundle v1
 
-`bench/eval/contracts/bundle.py` defines the immutable per-session artifact
-that the scoring path reads from. A `bundle.json` carries `task_id`,
-`task_version`, `task_spec_hash` (sha256 of the canonical task JSON),
-`persona_id`, session metadata, runtime metadata (sandbox image, NPC
-model, `bench_eval_version`, seed), agent self-report metadata,
-turn-keyed `conversation` with nested `tool_calls`, and a
-`workspace_manifest` (path + sha256 + size for every file under
-`agent_files/`). `contracts/bundle_io.py` is the JSON serializer; the
-reader is forward-compatible within the v1 major (unknown fields drop
-silently, missing optional fields fall back to dataclass defaults). See
-`bench/eval/contracts/schema_evolution.md` for the rules.
+`bench/eval/contracts/bundle.py` defines the generic Bundle v1 alpha artifact
+that the scoring path reads from. A `bundle.json` carries `bundle_id`,
+`schema_version = "1.0.0-alpha"`, `task_id`, `timestamps`, `agent_id`,
+`sandbox_digest`, `telemetry`, flat `messages`, flat `tool_calls`,
+namespaced `artifacts`, and a `workspace` file snapshot (path + sha256 +
+size for every file under `agent_files/`). Reference-harness fields such
+as `persona_id`, `session_id`, `termination_reason`, task version/hash, TC
+debug data, and scores live under `artifacts.quanttutor`. `contracts/bundle_io.py`
+is the JSON serializer; `contracts/bundle_schema.py` validates against
+`contracts/bundle_v1_alpha.schema.json`. See
+`docs/bundle_v1_schema.md` and `bench/eval/contracts/schema_evolution.md`
+for the rules.
 
 `bench/eval/backfill/run_state_to_bundle.py` converts legacy
 `run_state.json` artifacts to v1 bundles in place; pass `--recursive` to

--- a/docs/bundle_v1_schema.md
+++ b/docs/bundle_v1_schema.md
@@ -1,0 +1,174 @@
+# Bundle v1 Schema
+
+Status: Stage 1 v0 alpha
+Current `schema_version`: `1.0.0-alpha`
+Canonical schema file: `bench/eval/contracts/bundle_v1_alpha.schema.json`
+Validator: `python -m eval.contracts.bundle_schema <bundle.json>`
+
+## Goal
+
+Bundle v1 is the public artifact contract for benchmark runs. It must carry
+conversation, tool traces, arbitrary task artifacts, and workspace evidence for
+reference-harness tutoring runs, FinanceBench-style QA items, and factor-mining
+outputs.
+
+## Legacy Field Audit
+
+Observed `run_state.json` fields from `bench/results/server/...`:
+
+| Field | Destination |
+|---|---|
+| `run_id` | `artifacts.quanttutor.run_id` |
+| `public_task_label` | `artifacts.quanttutor.public_task_label` |
+| `task_id` | envelope `task_id` |
+| `session_id` | envelope `bundle_id`, `artifacts.quanttutor.session_id` |
+| `persona_id` | `artifacts.quanttutor.persona_id` |
+| `timestamp` | `timestamps.created_at` |
+| `session_status` | `artifacts.quanttutor.session_status` |
+| `termination_reason` | `artifacts.quanttutor.termination_reason` |
+| `conversation[].role/content/ts` | `messages[]` |
+| `tool_logs[].name/call_id/args/result/timestamp/duration_ms/success/turn_index` | `tool_calls[]` |
+| `distractor_names` | `artifacts.quanttutor.distractor_names` |
+| `duration_seconds` | `timestamps.duration_seconds`, `telemetry.duration_seconds` |
+| `evaluation_status` | `artifacts.quanttutor.evaluation_status` |
+| `format_validation` | `artifacts.quanttutor.format_validation` |
+| `key_results` | `artifacts.quanttutor.key_results` |
+| `simulator_cost` | `telemetry.simulator_cost` |
+| `step_count` | `telemetry.step_count` |
+| `tc_checker_cost` | `telemetry.tc_checker_cost` |
+| `tc_coverage` | `artifacts.quanttutor.tc_coverage` |
+| `tc_debug_history` | `artifacts.quanttutor.tc_debug_history` |
+| `artifact_debug_history` | `artifacts.quanttutor.artifact_debug_history` |
+| `trace_summary` | `artifacts.quanttutor.trace_summary` |
+| `workspace_files` | `artifacts.quanttutor.workspace_files` |
+
+Observed `run_state.json` fields from `bench/results/run-single/...`:
+
+| Field | Destination |
+|---|---|
+| `task_id`, `persona_id`, `conversation`, `tool_logs`, `distractor_names`, `duration_seconds`, `simulator_cost`, `step_count`, `trace_summary`, `workspace_files` | same destinations as server runs |
+| `agent_cost` | `telemetry.agent_cost` |
+| `thinking_trace` | `artifacts.quanttutor.thinking_trace` |
+
+Observed `manifest.json` fields from older server bundles:
+
+| Field | Destination |
+|---|---|
+| `bundle_schema_version` | superseded by envelope `schema_version` |
+| `created_at` | `timestamps.created_at` |
+| `task_id`, `session_id`, `persona_id`, `run_id`, `session_status`, `termination_reason` | same destinations as server runs |
+| `artifacts.agent_files`, `artifacts.run_state`, `artifacts.run_state_md` | `artifacts.quanttutor.legacy_manifest` when migrated later |
+
+Observed score export shape from `eval.storage.score_store` and
+`eval.contracts.output`:
+
+| Field | Destination |
+|---|---|
+| `version` | score artifact-local version |
+| `score_id`, `score_status`, `created_at`, `completed_at`, `eval_model`, `eval_mode`, `duration_seconds` | score artifact metadata under `artifacts.<producer>.score` |
+| `overall_score`, `qr`, `qp`, `blocking_missing`, `interrupted`, `error`, `preflight` | score artifact payload |
+| `judge_reliability` | score artifact payload |
+| `cost.json.version`, `eval_cost_usd`, `eval_cost_by_track`, `eval_cost_by_model`, `eval_cost_by_stage_model` | score artifact cost payload |
+
+Observed workspace tree fields:
+
+| Field | Destination |
+|---|---|
+| relative file path | `workspace.files[].path` |
+| sha256 digest | `workspace.files[].sha256` |
+| byte length | `workspace.files[].size_bytes` |
+| file type hints | `workspace.files[].metadata` |
+
+## Generic Envelope
+
+Top-level fields in `1.0.0-alpha`:
+
+| Field | Type | Semantics |
+|---|---|---|
+| `bundle_id` | string | Stable bundle identifier. Reference backfill uses `session_id`. |
+| `schema_version` | string | Current alpha stamp: `1.0.0-alpha`. |
+| `task_id` | string | Producer task identifier. |
+| `timestamps` | object | `created_at`, `started_at`, `completed_at`, `duration_seconds`. |
+| `agent_id` | string | Producer/harness/model identifier. |
+| `sandbox_digest` | object | Sandbox image, digest, and runtime metadata. |
+| `telemetry` | object | Generic counters, costs, and timing metadata. |
+| `messages` | array | Generic conversation messages. |
+| `tool_calls` | array | Generic tool calls with arbitrary args/result JSON. |
+| `artifacts` | object | Producer-specific payloads keyed by namespace. |
+| `workspace` | object | Workspace file tree snapshot. |
+
+## Message Shape
+
+Each message has:
+
+- `message_id`: producer-scoped stable id;
+- `role`: producer role string, such as `user` or `assistant`;
+- `content`: arbitrary JSON;
+- `created_at`: timestamp string;
+- `turn_index`: zero-based turn grouping;
+- `attachments`: array of producer attachment objects;
+- `metadata`: arbitrary producer metadata.
+
+## Tool Call Shape
+
+Each tool call has:
+
+- `tool_call_id`: producer-scoped stable id;
+- `tool_name`: tool identifier;
+- `args`: arbitrary JSON;
+- `result`: arbitrary JSON;
+- `created_at`: timestamp string;
+- `duration_ms`: numeric duration;
+- `success`: boolean outcome;
+- `turn_index`: zero-based turn grouping;
+- `metadata`: arbitrary producer metadata.
+
+Reference backfill preserves `send_message` entries in `tool_calls` and marks
+them with `metadata.conversation_transport = true`.
+
+## Artifacts
+
+`artifacts` is an open object keyed by producer namespace. Current fixtures use:
+
+- `quanttutor`: reference harness metadata, task hash/version, scores, TC data;
+- `financebench`: QA pair and score payload;
+- `factor_mining`: factor formula, signal series, and IC matrix references.
+
+Score payloads remain producer artifacts during alpha. A task can include
+`task_score`, exact-match results, IC metrics, or richer evaluator output without
+changing the envelope.
+
+## Workspace Snapshot
+
+`workspace.files[]` records relative file paths, type, sha256, byte size, an
+optional `content_ref`, and metadata. The Stage 1 policy is path plus sha256 plus
+size. Inline content belongs in namespaced `artifacts` for alpha fixtures. Stage
+2 will decide long-term inline payload and external-reference rules.
+
+## TBD Decisions Resolved For Stage 1
+
+| Issue TBD | Stage 1 decision |
+|---|---|
+| JSON Schema vs Pydantic vs custom DSL | JSON Schema is canonical for public validation. Python dataclasses are the in-repo typed convenience layer. |
+| Workspace reference policy | Use relative path + sha256 + size in `workspace.files[]`; keep optional `content_ref` for later external stores. |
+| Compatibility fixtures | Ship three schema fixtures: Impl A reference harness, Impl C FinanceBench QA, Impl D factor mining. |
+| Score openness | Scores live under namespaced `artifacts`; the envelope requires zero score fields. |
+
+## Migration Placeholder
+
+Stage 2 freeze will define:
+
+- conversion from `1.0.0-alpha` to `1.0.0`;
+- supported historical read window;
+- deprecation notice cadence;
+- score artifact stability contract;
+- workspace inline/external content policy.
+
+## Validation
+
+Run focused validation:
+
+```bash
+python -m eval.contracts.bundle_schema bench/eval/contracts/fixtures/bundle_v1_alpha/impl_a_ref_harness.json
+python -m pytest bench/tests/unit/test_bundle.py bench/tests/unit/test_backfill.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Data Handling
 pandas>=2.0.0
 pydantic>=2.0.0
+jsonschema>=4.0.0
 
 # Web Scraping & Parsing
 requests>=2.28.0


### PR DESCRIPTION
Closes #153.

Adds the Stage 1 Bundle v1 alpha baseline:
- generic `schema_version` 1.0.0-alpha envelope with flat messages/tool_calls, telemetry, sandbox digest, namespaced artifacts, and workspace snapshot
- JSON Schema validator plus Impl A/C/D fixtures
- run_state backfill and standalone scoring adapters for the alpha shape
- schema audit docs, evolution notes, and architecture update

Verification:
- pytest bench/tests/unit/test_bundle.py bench/tests/unit/test_backfill.py bench/tests/unit/test_eval_score_standalone.py bench/tests/unit/test_eval_architecture_contracts.py -> 44 passed
- python3 -m eval.contracts.bundle_schema for all three alpha fixtures -> valid
- python3 -m py_compile for bundle/backfill/score modules -> passed
- git diff --cached --check -> passed
- local recursive backfill validation over 23 run_state files -> validated=23 unique_ids=23

Codex review:
- Round 1 fixed legacy run-single bundle ID collisions.
- Round 2 fixed assistant-only attachment turn association.

Note: full bench/tests/unit collection is blocked in this environment by missing `nest_asyncio`.