### PR TITLE
feat(platform): DataMount and SandboxSpec protocol

### DIFF
--- a/bench/eval/backfill/run_state_to_bundle.py
+++ b/bench/eval/backfill/run_state_to_bundle.py
@@ -71,7 +71,7 @@ def backfill(
         task_id=str(state.get("task_id", "")),
         timestamps=_build_timestamps(state),
         agent_id=_agent_id(state),
-        sandbox_digest=_build_sandbox_digest(task_json),
+        sandbox_digest=_build_sandbox_digest(task_json, state),
         telemetry=_build_telemetry(state, messages=messages),
         messages=messages,
         tool_calls=_build_tool_calls(state),
@@ -167,14 +167,55 @@ def _agent_id(state: dict) -> str:
     )
 
 
-def _build_sandbox_digest(task_json: dict) -> dict[str, Any]:
+def _image_digest(image_uri: str) -> str:
+    marker = "@sha256:"
+    if marker in image_uri:
+        return "sha256:" + image_uri.split(marker, 1)[1]
+    return ""
+
+
+def _build_sandbox_digest(task_json: dict, state: dict | None = None) -> dict[str, Any]:
+    state_digest = state.get("sandbox_digest") if isinstance(state, dict) else None
+    if isinstance(state_digest, dict) and state_digest:
+        return dict(state_digest)
+
     environment = task_json.get("environment") if isinstance(task_json, dict) else {}
     if not isinstance(environment, dict):
         environment = {}
+    sandbox_spec = environment.get("sandbox_spec")
+    if not isinstance(sandbox_spec, dict):
+        sandbox_spec = {}
+    image_uri = str(
+        sandbox_spec.get("image_uri") or environment.get("sandbox_image") or ""
+    )
+    resource_limits = sandbox_spec.get("resource_limits")
+    if not isinstance(resource_limits, dict):
+        resource_limits = {}
+    else:
+        resource_limits = dict(resource_limits)
+    if "network_enabled" not in resource_limits and bool(
+        environment.get("network_enabled")
+    ):
+        resource_limits["network_enabled"] = True
+    data_mounts = environment.get("data_mounts")
+    if not isinstance(data_mounts, list):
+        data_mounts = []
     return {
-        "sandbox_image": str(environment.get("sandbox_image") or ""),
-        "digest": "",
-        "source": "task.environment.sandbox_image",
+        "sandbox_image": image_uri,
+        "image_uri": image_uri,
+        "digest": _image_digest(image_uri),
+        "resource_limits": resource_limits,
+        "data_mounts": data_mounts,
+        "sandbox_policy": {
+            "stage": "1",
+            "image_policy": "reference_base_image",
+            "data_fetch": "materialize_then_bind_mount",
+        },
+        "source": (
+            "task.environment.sandbox_spec"
+            if sandbox_spec
+            else "task.environment.sandbox_image"
+        ),
     }
 
 

--- a/bench/eval/contracts/schemas.py
+++ b/bench/eval/contracts/schemas.py
@@ -2,10 +2,25 @@
 
 from __future__ import annotations
 
+import re
 from enum import Enum
-from typing import Optional, Union
+from typing import Any, Optional, Union
+from urllib.parse import parse_qs, urlparse
 
 from pydantic import BaseModel, Field, model_validator
+
+
+SUPPORTED_DATA_URI_SCHEMES = frozenset({"hf", "s3", "file"})
+HF_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+
+
+def _hf_commit_from_uri(uri: str) -> str:
+    parsed = urlparse(uri)
+    ref = f"{parsed.netloc}{parsed.path}".strip("/")
+    if "@" not in ref:
+        return ""
+    revision = ref.rsplit("@", 1)[1]
+    return revision.split("/", 1)[0]
 
 
 class Difficulty(str, Enum):
@@ -41,6 +56,49 @@ class QuantValidation(BaseModel):
     eval_script: str
 
 
+class DataMount(BaseModel):
+    uri: str
+    target_path: str
+    read_only: bool = True
+
+    @model_validator(mode="after")
+    def _validate_mount(self):
+        self.uri = self.uri.strip()
+        self.target_path = self.target_path.strip()
+        if not self.uri:
+            raise ValueError("data_mount.uri is required")
+        if not self.target_path.startswith("/"):
+            raise ValueError("data_mount.target_path must be an absolute sandbox path")
+
+        parsed = urlparse(self.uri)
+        scheme = parsed.scheme.lower()
+        if scheme not in SUPPORTED_DATA_URI_SCHEMES:
+            supported = ", ".join(sorted(SUPPORTED_DATA_URI_SCHEMES))
+            raise ValueError(f"unsupported data URI scheme {scheme!r}; expected {supported}")
+        if scheme == "hf":
+            commit = _hf_commit_from_uri(self.uri)
+            if not commit or not HF_COMMIT_RE.fullmatch(commit):
+                raise ValueError(
+                    "hf:// data mounts require an explicit @commit SHA "
+                    "(40 hex characters)"
+                )
+        if scheme == "s3" and not parse_qs(parsed.query).get("versionId"):
+            raise ValueError("s3:// data mounts require a versionId query parameter")
+        return self
+
+
+class SandboxSpec(BaseModel):
+    image_uri: str
+    resource_limits: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_spec(self):
+        self.image_uri = self.image_uri.strip()
+        if not self.image_uri:
+            raise ValueError("sandbox_spec.image_uri is required")
+        return self
+
+
 class GroundTruth(BaseModel):
     termination_criteria: Union[str, dict[str, str]] = ""
     required_capabilities: list[str] = Field(default_factory=list)
@@ -51,14 +109,33 @@ class GroundTruth(BaseModel):
 
 class EnvironmentConfig(BaseModel):
     data_files: list[str] = Field(default_factory=list)
+    data_mounts: list[DataMount] = Field(default_factory=list)
     core_mcp_tools: list[str] = Field(default_factory=list)
     docs_available: list[str] = Field(default_factory=list)
     sandbox_image: str = "quant-tutor-env:v2.2"
+    sandbox_spec: Optional[SandboxSpec] = None
     # Maximum backtest trials for I-series tasks (0 = no trial system).
     max_backtest_trials: int = 0
     # Whether this task requires outbound internet access inside the sandbox.
     # Default is False for reproducibility/safety.
     network_enabled: bool = False
+
+    @property
+    def sandbox_image_uri(self) -> str:
+        if self.sandbox_spec is not None:
+            return self.sandbox_spec.image_uri
+        return self.sandbox_image
+
+    @property
+    def sandbox_resource_limits(self) -> dict[str, Any]:
+        limits = (
+            dict(self.sandbox_spec.resource_limits)
+            if self.sandbox_spec is not None
+            else {}
+        )
+        if "network_enabled" not in limits and self.network_enabled:
+            limits["network_enabled"] = True
+        return limits
 
 
 class QuantTutorTask(BaseModel):

--- a/bench/eval/tracks/qr.py
+++ b/bench/eval/tracks/qr.py
@@ -109,7 +109,12 @@ def _code_eval(
     try:
         from eval.programmatic.code_eval import evaluate_code_combined
 
-        sandbox_img = task.environment.sandbox_image if task.environment else ""
+        env = task.environment if task.environment else None
+        sandbox_img = (
+            getattr(env, "sandbox_image_uri", None)
+            or getattr(env, "sandbox_image", "")
+            or ""
+        )
         result = evaluate_code_combined(
             workspace_path=workspace_path,
             tool_logs=tool_logs,

--- a/bench/mcp_servers/mcp_server.py
+++ b/bench/mcp_servers/mcp_server.py
@@ -24,6 +24,37 @@ from mcp.types import TextContent, Tool
 logger = logging.getLogger(__name__)
 
 
+def _environment_sandbox_image(environment) -> str:
+    if environment is None:
+        return ""
+    return str(
+        getattr(environment, "sandbox_image_uri", None)
+        or getattr(environment, "sandbox_image", "")
+        or ""
+    )
+
+
+def _environment_resource_limits(environment) -> dict:
+    spec = getattr(environment, "sandbox_spec", None)
+    limits = getattr(spec, "resource_limits", None)
+    resolved = dict(limits or {})
+    if "network_enabled" not in resolved and bool(
+        getattr(environment, "network_enabled", False)
+    ):
+        resolved["network_enabled"] = True
+    return resolved
+
+
+def _environment_network_enabled(environment) -> bool:
+    limits = _environment_resource_limits(environment)
+    value = limits.get("network_enabled")
+    if value is None:
+        return bool(getattr(environment, "network_enabled", False))
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
 def create_mcp_server(proxy, name: str = "QuantTutorBench") -> Server:
     """Create an MCP server backed by a configured MCPProxy.
 
@@ -111,7 +142,7 @@ def _build_standalone_server(task_id: str, persona_id: str, use_docker: bool = T
     persona = _load_persona(persona_id)
 
     # Download data
-    sandbox_img = task.environment.sandbox_image if task.environment else ""
+    sandbox_img = _environment_sandbox_image(task.environment)
     if sandbox_img and "lean" in sandbox_img:
         paths = ensure_data(series="lean", revision=DATASET_REVISION)
     else:
@@ -141,18 +172,26 @@ def _build_standalone_server(task_id: str, persona_id: str, use_docker: bool = T
         data_dir=staged_data_dir,
         docs_dir=staged_docs_dir,
         user_code_dir=user_code_dir,
-        sandbox_image=(task.environment.sandbox_image if task.environment else None),
+        sandbox_image=(
+            _environment_sandbox_image(task.environment) if task.environment else None
+        ),
         network_enabled=(
-            task.environment.network_enabled if task.environment else False
+            _environment_network_enabled(task.environment) if task.environment else False
         ),
         lean_data_dir=paths.lean_data,
         custom_data_dir=custom_data_dir,
+        data_mounts=task.environment.data_mounts if task.environment else [],
+        resource_limits=(
+            _environment_resource_limits(task.environment) if task.environment else None
+        ),
     )
 
     max_bt = task.environment.max_backtest_trials if task.environment else 0
     task_core_tools = list(task.environment.core_mcp_tools if task.environment else [])
-    sandbox_image = task.environment.sandbox_image if task.environment else ""
-    is_lean_task = "lean" in str(sandbox_image).lower() or "run_lean_backtest" in task_core_tools
+    sandbox_image = _environment_sandbox_image(task.environment)
+    is_lean_task = (
+        "lean" in str(sandbox_image).lower() or "run_lean_backtest" in task_core_tools
+    )
     if is_lean_task and "get_lean_template" not in task_core_tools:
         task_core_tools.append("get_lean_template")
 

--- a/bench/orchestrator/container_manager.py
+++ b/bench/orchestrator/container_manager.py
@@ -9,8 +9,8 @@ import tempfile
 import threading
 import time
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Optional
+from pathlib import Path, PurePosixPath
+from typing import Optional, Sequence
 
 
 @dataclass
@@ -87,6 +87,78 @@ class ContainerManager:
                 return preset
         return cls._RESOURCE_PRESETS["_default"]
 
+    @staticmethod
+    def _apply_resource_limits(
+        mem_limit: str,
+        cpu_limit: str,
+        resource_limits: dict | None,
+    ) -> tuple[str, str]:
+        if not resource_limits:
+            return mem_limit, cpu_limit
+        if resource_limits.get("memory"):
+            mem_limit = str(resource_limits["memory"])
+        elif resource_limits.get("memory_mb"):
+            mem_limit = f"{int(resource_limits['memory_mb'])}m"
+        cpu_value = resource_limits.get("cpus", resource_limits.get("cpu_count"))
+        if cpu_value not in (None, ""):
+            cpu_limit = str(cpu_value)
+        return mem_limit, cpu_limit
+
+    @staticmethod
+    def _normalize_data_mounts(data_mounts: Sequence[object] | None):
+        if not data_mounts:
+            return ()
+        from platform_api.contracts import DataMount
+
+        normalized = []
+        for item in data_mounts:
+            if isinstance(item, DataMount):
+                normalized.append(item)
+                continue
+            if hasattr(item, "model_dump"):
+                payload = item.model_dump()
+            elif isinstance(item, dict):
+                payload = dict(item)
+            else:
+                payload = {
+                    "uri": getattr(item, "uri"),
+                    "target_path": getattr(item, "target_path"),
+                    "read_only": getattr(item, "read_only", True),
+                }
+            normalized.append(
+                DataMount(
+                    uri=str(payload["uri"]),
+                    target_path=str(payload["target_path"]),
+                    read_only=bool(payload.get("read_only", True)),
+                )
+            )
+        return tuple(normalized)
+
+    @staticmethod
+    def _prepare_nested_mount_targets(
+        mounts: Sequence[object],
+        parent_mounts: Sequence[tuple[str | None, str]],
+    ) -> None:
+        for mount in mounts:
+            container_path = PurePosixPath(getattr(mount, "container_path"))
+            host_path = Path(str(getattr(mount, "host_path")))
+            for parent_host, parent_container in parent_mounts:
+                if not parent_host:
+                    continue
+                parent_path = PurePosixPath(parent_container)
+                try:
+                    relative_target = container_path.relative_to(parent_path)
+                except ValueError:
+                    continue
+                if not relative_target.parts:
+                    continue
+                staged_target = Path(parent_host, *relative_target.parts)
+                if host_path.is_dir():
+                    staged_target.mkdir(parents=True, exist_ok=True)
+                else:
+                    staged_target.parent.mkdir(parents=True, exist_ok=True)
+                    staged_target.touch(exist_ok=True)
+
     def create_container(
         self,
         task_id: str,
@@ -97,6 +169,8 @@ class ContainerManager:
         network_enabled: bool = False,
         lean_data_dir: Optional[str] = None,
         custom_data_dir: Optional[str] = None,
+        data_mounts: Sequence[object] | None = None,
+        resource_limits: dict | None = None,
     ) -> ContainerInfo:
         """Create a sandboxed Docker container (or local workspace fallback).
 
@@ -112,6 +186,7 @@ class ContainerManager:
         """
         image = sandbox_image or self.docker_image
         workspace = tempfile.mkdtemp(prefix=f"qtb_{task_id}_")
+        normalized_data_mounts = self._normalize_data_mounts(data_mounts)
 
         if self.use_docker:
             # Docker cannot create a nested bind mount like /data/custom when /data
@@ -131,10 +206,33 @@ class ContainerManager:
                 mounts.append(f"-v {lean_data_dir}:/lean/Data:ro")
             if custom_data_dir:
                 mounts.append(f"-v {custom_data_dir}:/data/custom:ro")
+            if normalized_data_mounts:
+                from platform_api.runtime import DataMountResolver
+
+                resolver = DataMountResolver(base_dir=Path.cwd())
+                resolved_data_mounts = resolver.resolve_all(normalized_data_mounts)
+                self._prepare_nested_mount_targets(
+                    resolved_data_mounts,
+                    (
+                        (data_dir, "/data"),
+                        (docs_dir, "/docs"),
+                        (user_code_dir, "/user_code"),
+                        (lean_data_dir, "/lean/Data"),
+                        (custom_data_dir, "/data/custom"),
+                    ),
+                )
+                mounts.extend(
+                    f"-v {mount.to_docker_volume()}" for mount in resolved_data_mounts
+                )
 
             network_flag = "--network bridge" if network_enabled else "--network none"
             network_mode = "bridge" if network_enabled else "none"
             mem_limit, cpu_limit = self._resolve_resources(image)
+            mem_limit, cpu_limit = self._apply_resource_limits(
+                mem_limit,
+                cpu_limit,
+                resource_limits,
+            )
             cmd = (
                 f"docker run -d --name qtb_{task_id}_{int(time.time())} "
                 f"{network_flag} --cpus {cpu_limit} --memory {mem_limit} "

--- a/bench/orchestrator/orchestrator.py
+++ b/bench/orchestrator/orchestrator.py
@@ -61,7 +61,36 @@ class EvalAbortError(RuntimeError):
     only.  Other parallel tasks are not affected.
     """
 
-    pass
+
+def _environment_sandbox_image(environment) -> str:
+    if environment is None:
+        return ""
+    spec = getattr(environment, "sandbox_spec", None)
+    image_uri = str(getattr(spec, "image_uri", "") or "").strip()
+    if image_uri:
+        return image_uri
+    return str(getattr(environment, "sandbox_image", "") or "")
+
+
+def _environment_resource_limits(environment) -> dict:
+    spec = getattr(environment, "sandbox_spec", None)
+    limits = getattr(spec, "resource_limits", None)
+    resolved = dict(limits or {})
+    if "network_enabled" not in resolved and bool(
+        getattr(environment, "network_enabled", False)
+    ):
+        resolved["network_enabled"] = True
+    return resolved
+
+
+def _environment_network_enabled(environment) -> bool:
+    limits = _environment_resource_limits(environment)
+    value = limits.get("network_enabled")
+    if value is None:
+        return bool(getattr(environment, "network_enabled", False))
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
 
 
 # ──────────────────────────────────────────────────────────────
@@ -198,7 +227,7 @@ class BenchmarkOrchestrator:
 
         from scripts.data_manager import ensure_data
 
-        sandbox_img = task.environment.sandbox_image if task.environment else ""
+        sandbox_img = _environment_sandbox_image(task.environment)
         if sandbox_img and "lean" in sandbox_img:
             if self._paths_i is None:
                 self._paths_i = ensure_data(series="lean", revision=DATASET_REVISION)
@@ -286,13 +315,23 @@ class BenchmarkOrchestrator:
                 docs_dir=staged_docs_dir,
                 user_code_dir=user_code_dir,
                 sandbox_image=(
-                    task.environment.sandbox_image if task.environment else None
+                    _environment_sandbox_image(task.environment)
+                    if task.environment
+                    else None
                 ),
                 network_enabled=(
-                    task.environment.network_enabled if task.environment else False
+                    _environment_network_enabled(task.environment)
+                    if task.environment
+                    else False
                 ),
                 lean_data_dir=lean_data_dir,
                 custom_data_dir=custom_data_dir,
+                data_mounts=task.environment.data_mounts if task.environment else [],
+                resource_limits=(
+                    _environment_resource_limits(task.environment)
+                    if task.environment
+                    else None
+                ),
             )
 
             # 1b.5. Start tool executor daemon inside the container (Docker only).
@@ -500,9 +539,7 @@ class BenchmarkOrchestrator:
                 "network_enabled": container.network_enabled,
                 "network_mode": container.network_mode,
                 "use_docker": self.container_manager.use_docker,
-                "sandbox_image": (
-                    task.environment.sandbox_image if task.environment else "N/A"
-                ),
+                "sandbox_image": _environment_sandbox_image(task.environment) or "N/A",
             }
 
             # === PHASE 3.25: TRIAL FINALIZATION ===

--- a/bench/orchestrator/schemas.py
+++ b/bench/orchestrator/schemas.py
@@ -2,10 +2,25 @@
 
 from __future__ import annotations
 
+import re
 from enum import Enum
-from typing import Optional, Union
+from typing import Any, Optional, Union
+from urllib.parse import parse_qs, urlparse
 
 from pydantic import BaseModel, Field, model_validator
+
+
+SUPPORTED_DATA_URI_SCHEMES = frozenset({"hf", "s3", "file"})
+HF_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+
+
+def _hf_commit_from_uri(uri: str) -> str:
+    parsed = urlparse(uri)
+    ref = f"{parsed.netloc}{parsed.path}".strip("/")
+    if "@" not in ref:
+        return ""
+    revision = ref.rsplit("@", 1)[1]
+    return revision.split("/", 1)[0]
 
 
 class Difficulty(str, Enum):
@@ -41,6 +56,49 @@ class QuantValidation(BaseModel):
     eval_script: str
 
 
+class DataMount(BaseModel):
+    uri: str
+    target_path: str
+    read_only: bool = True
+
+    @model_validator(mode="after")
+    def _validate_mount(self):
+        self.uri = self.uri.strip()
+        self.target_path = self.target_path.strip()
+        if not self.uri:
+            raise ValueError("data_mount.uri is required")
+        if not self.target_path.startswith("/"):
+            raise ValueError("data_mount.target_path must be an absolute sandbox path")
+
+        parsed = urlparse(self.uri)
+        scheme = parsed.scheme.lower()
+        if scheme not in SUPPORTED_DATA_URI_SCHEMES:
+            supported = ", ".join(sorted(SUPPORTED_DATA_URI_SCHEMES))
+            raise ValueError(f"unsupported data URI scheme {scheme!r}; expected {supported}")
+        if scheme == "hf":
+            commit = _hf_commit_from_uri(self.uri)
+            if not commit or not HF_COMMIT_RE.fullmatch(commit):
+                raise ValueError(
+                    "hf:// data mounts require an explicit @commit SHA "
+                    "(40 hex characters)"
+                )
+        if scheme == "s3" and not parse_qs(parsed.query).get("versionId"):
+            raise ValueError("s3:// data mounts require a versionId query parameter")
+        return self
+
+
+class SandboxSpec(BaseModel):
+    image_uri: str
+    resource_limits: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_spec(self):
+        self.image_uri = self.image_uri.strip()
+        if not self.image_uri:
+            raise ValueError("sandbox_spec.image_uri is required")
+        return self
+
+
 class GroundTruth(BaseModel):
     termination_criteria: Union[str, dict[str, str]] = ""
     required_capabilities: list[str] = Field(default_factory=list)
@@ -51,14 +109,33 @@ class GroundTruth(BaseModel):
 
 class EnvironmentConfig(BaseModel):
     data_files: list[str] = Field(default_factory=list)
+    data_mounts: list[DataMount] = Field(default_factory=list)
     core_mcp_tools: list[str] = Field(default_factory=list)
     docs_available: list[str] = Field(default_factory=list)
     sandbox_image: str = "quant-tutor-env:v2.2"
+    sandbox_spec: Optional[SandboxSpec] = None
     # Maximum backtest trials for I-series tasks (0 = no trial system).
     max_backtest_trials: int = 0
     # Whether this task requires outbound internet access inside the sandbox.
     # Default is False for reproducibility/safety.
     network_enabled: bool = False
+
+    @property
+    def sandbox_image_uri(self) -> str:
+        if self.sandbox_spec is not None:
+            return self.sandbox_spec.image_uri
+        return self.sandbox_image
+
+    @property
+    def sandbox_resource_limits(self) -> dict[str, Any]:
+        limits = (
+            dict(self.sandbox_spec.resource_limits)
+            if self.sandbox_spec is not None
+            else {}
+        )
+        if "network_enabled" not in limits and self.network_enabled:
+            limits["network_enabled"] = True
+        return limits
 
 
 class QuantTutorTask(BaseModel):

--- a/bench/platform_api/__init__.py
+++ b/bench/platform_api/__init__.py
@@ -5,6 +5,7 @@ split into platform-owned runtime pieces and reference-owned business logic.
 """
 
 from platform_api.contracts import (
+    DataMount,
     EvalItem,
     EvalSample,
     Evaluator,
@@ -12,6 +13,7 @@ from platform_api.contracts import (
     FileArtifact,
     NPCProvider,
     NPCReply,
+    SandboxSpec,
     Score,
     TaskSuite,
     ToolLog,
@@ -19,6 +21,7 @@ from platform_api.contracts import (
 )
 from platform_api.plugins import PluginBundle, PluginLoader, PluginLoadError, PluginSpec
 from platform_api.runtime import (
+    DataMountResolver,
     DockerSandboxRuntime,
     ExecResult,
     LocalSandboxRuntime,
@@ -30,6 +33,7 @@ from platform_api.runtime import (
     ToolRequest,
     ToolResult,
     ToolRouter,
+    build_sandbox_digest,
 )
 from platform_api.telemetry import (
     InMemoryTelemetryHook,
@@ -39,6 +43,8 @@ from platform_api.telemetry import (
 )
 
 __all__ = [
+    "DataMount",
+    "DataMountResolver",
     "DockerSandboxRuntime",
     "EvalItem",
     "EvalSample",
@@ -56,6 +62,7 @@ __all__ = [
     "PluginLoader",
     "PluginSpec",
     "SandboxCreateRequest",
+    "SandboxSpec",
     "SandboxHandle",
     "SandboxMount",
     "SandboxRuntime",
@@ -69,4 +76,5 @@ __all__ = [
     "ToolResult",
     "ToolRouter",
     "TranscriptMessage",
+    "build_sandbox_digest",
 ]

--- a/bench/platform_api/contracts/__init__.py
+++ b/bench/platform_api/contracts/__init__.py
@@ -1,11 +1,13 @@
 """Plugin-facing contract types."""
 
 from platform_api.contracts.models import (
+    DataMount,
     EvalItem,
     EvalSample,
     EvaluatorMetadata,
     FileArtifact,
     NPCReply,
+    SandboxSpec,
     Score,
     ToolLog,
     TranscriptMessage,
@@ -13,6 +15,7 @@ from platform_api.contracts.models import (
 from platform_api.contracts.plugins import Evaluator, NPCProvider, TaskSuite
 
 __all__ = [
+    "DataMount",
     "EvalItem",
     "EvalSample",
     "Evaluator",
@@ -20,6 +23,7 @@ __all__ = [
     "FileArtifact",
     "NPCProvider",
     "NPCReply",
+    "SandboxSpec",
     "Score",
     "TaskSuite",
     "ToolLog",

--- a/bench/platform_api/contracts/models.py
+++ b/bench/platform_api/contracts/models.py
@@ -2,11 +2,73 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Any, Mapping
+from urllib.parse import parse_qs, urlparse
 
 
 JsonObject = Mapping[str, Any]
+SUPPORTED_DATA_URI_SCHEMES = frozenset({"hf", "s3", "file"})
+HF_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+
+
+def _hf_commit_from_uri(uri: str) -> str:
+    parsed = urlparse(uri)
+    ref = f"{parsed.netloc}{parsed.path}".strip("/")
+    if "@" not in ref:
+        return ""
+    revision = ref.rsplit("@", 1)[1]
+    return revision.split("/", 1)[0]
+
+
+@dataclass(frozen=True)
+class DataMount:
+    """Task-declared data dependency mounted into a sandbox."""
+
+    uri: str
+    target_path: str
+    read_only: bool = True
+
+    def __post_init__(self) -> None:
+        uri = self.uri.strip()
+        target_path = self.target_path.strip()
+        if not uri:
+            raise ValueError("DataMount.uri is required")
+        if not target_path.startswith("/"):
+            raise ValueError("DataMount.target_path must be an absolute sandbox path")
+
+        parsed = urlparse(uri)
+        scheme = parsed.scheme.lower()
+        if scheme not in SUPPORTED_DATA_URI_SCHEMES:
+            supported = ", ".join(sorted(SUPPORTED_DATA_URI_SCHEMES))
+            raise ValueError(f"Unsupported data URI scheme {scheme!r}; expected {supported}")
+        if scheme == "hf":
+            commit = _hf_commit_from_uri(uri)
+            if not commit or not HF_COMMIT_RE.fullmatch(commit):
+                raise ValueError(
+                    "hf:// data mounts require an explicit @commit SHA "
+                    "(40 hex characters)"
+                )
+        if scheme == "s3" and not parse_qs(parsed.query).get("versionId"):
+            raise ValueError("s3:// data mounts require a versionId query parameter")
+
+        object.__setattr__(self, "uri", uri)
+        object.__setattr__(self, "target_path", target_path)
+
+
+@dataclass(frozen=True)
+class SandboxSpec:
+    """Sandbox image and resource policy declared by a TaskSuite."""
+
+    image_uri: str
+    resource_limits: JsonObject = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        image_uri = self.image_uri.strip()
+        if not image_uri:
+            raise ValueError("SandboxSpec.image_uri is required")
+        object.__setattr__(self, "image_uri", image_uri)
 
 
 @dataclass(frozen=True)
@@ -18,6 +80,11 @@ class EvalItem:
     version: str = "0"
     task_type: str = "multi_turn"
     metadata: JsonObject = field(default_factory=dict)
+    data_mounts: tuple[DataMount, ...] = ()
+    sandbox_spec: SandboxSpec | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "data_mounts", tuple(self.data_mounts))
 
 
 @dataclass(frozen=True)

--- a/bench/platform_api/contracts/plugins.py
+++ b/bench/platform_api/contracts/plugins.py
@@ -6,11 +6,13 @@ from abc import ABC, abstractmethod
 from typing import Mapping, Sequence
 
 from platform_api.contracts.models import (
+    DataMount,
     EvalItem,
     EvalSample,
     EvaluatorMetadata,
     FileArtifact,
     NPCReply,
+    SandboxSpec,
     Score,
     ToolLog,
     TranscriptMessage,
@@ -31,6 +33,18 @@ class TaskSuite(ABC):
     @abstractmethod
     def required_bundle_fields(self) -> set[str]:
         """Return bundle fields required by this suite."""
+
+    def data_mounts(self, task_id: str | None = None) -> tuple[DataMount, ...]:
+        """Return data dependencies declared for a task or suite."""
+        if task_id is None:
+            return ()
+        return self.get_task(task_id).data_mounts
+
+    def sandbox_spec(self, task_id: str | None = None) -> SandboxSpec | None:
+        """Return the sandbox image and resource limits for a task or suite."""
+        if task_id is None:
+            return None
+        return self.get_task(task_id).sandbox_spec
 
 
 class NPCProvider(ABC):

--- a/bench/platform_api/runtime/__init__.py
+++ b/bench/platform_api/runtime/__init__.py
@@ -1,6 +1,7 @@
 """Sandbox runtime API exports."""
 
 from platform_api.runtime.sandbox import (
+    DataMountResolver,
     DockerSandboxRuntime,
     ExecResult,
     LocalSandboxRuntime,
@@ -12,9 +13,11 @@ from platform_api.runtime.sandbox import (
     ToolRequest,
     ToolResult,
     ToolRouter,
+    build_sandbox_digest,
 )
 
 __all__ = [
+    "DataMountResolver",
     "DockerSandboxRuntime",
     "ExecResult",
     "LocalSandboxRuntime",
@@ -26,4 +29,5 @@ __all__ = [
     "ToolRequest",
     "ToolResult",
     "ToolRouter",
+    "build_sandbox_digest",
 ]

--- a/bench/platform_api/runtime/sandbox.py
+++ b/bench/platform_api/runtime/sandbox.py
@@ -9,14 +9,174 @@ import tempfile
 import time
 import uuid
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
+from urllib.parse import parse_qs, quote, unquote, urlparse
 
+from platform_api.contracts.models import DataMount, SandboxSpec
 from platform_api.telemetry import TelemetryHook, emit_telemetry
 
 
 class SandboxRuntimeError(RuntimeError):
     """Raised when sandbox lifecycle operations fail."""
+
+
+DataMountFetcher = Callable[[DataMount, Path], str | Path]
+_DEFAULT_REMOTE_FETCHER = object()
+
+
+def _image_digest(image_uri: str) -> str:
+    marker = "@sha256:"
+    if marker in image_uri:
+        return "sha256:" + image_uri.split(marker, 1)[1]
+    return ""
+
+
+def build_sandbox_digest(
+    image_uri: str,
+    *,
+    resource_limits: Mapping[str, Any] | None = None,
+    data_mounts: Sequence[DataMount] = (),
+) -> dict[str, Any]:
+    """Build the bundle-ready sandbox digest metadata."""
+    return {
+        "sandbox_image": image_uri,
+        "image_uri": image_uri,
+        "digest": _image_digest(image_uri),
+        "resource_limits": dict(resource_limits or {}),
+        "data_mounts": [asdict(mount) for mount in data_mounts],
+        "sandbox_policy": {
+            "stage": "1",
+            "image_policy": "reference_base_image",
+            "data_fetch": "materialize_then_bind_mount",
+        },
+        "source": "SandboxSpec",
+    }
+
+
+def _limit_str(
+    limits: Mapping[str, Any], primary: str, aliases: Sequence[str], default: str
+) -> str:
+    for key in (primary, *aliases):
+        value = limits.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return default
+
+
+def _memory_limit(limits: Mapping[str, Any], default: str) -> str:
+    if limits.get("memory"):
+        return str(limits["memory"])
+    if limits.get("memory_mb"):
+        return f"{int(limits['memory_mb'])}m"
+    return default
+
+
+def _bool_limit(limits: Mapping[str, Any], key: str, default: bool) -> bool:
+    value = limits.get(key)
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _parse_hf_data_uri(uri: str) -> tuple[str, str, str, str]:
+    parsed = urlparse(uri)
+    ref = f"{parsed.netloc}{parsed.path}".strip("/")
+    repo_ref, _, revision_and_path = ref.rpartition("@")
+    revision, _, subpath = revision_and_path.partition("/")
+    query = parse_qs(parsed.query)
+    repo_type = (query.get("repo_type") or query.get("type") or ["dataset"])[0]
+    if repo_ref.startswith("datasets/"):
+        repo_ref = repo_ref.removeprefix("datasets/")
+        repo_type = "dataset"
+    elif repo_ref.startswith("models/"):
+        repo_ref = repo_ref.removeprefix("models/")
+        repo_type = "model"
+    if not repo_ref or not revision:
+        raise SandboxRuntimeError(f"Invalid hf data mount URI: {uri}")
+    return repo_ref, revision, unquote(subpath), repo_type
+
+
+def _fetch_hf_data_mount(mount: DataMount, cache_path: Path) -> Path:
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:
+        raise SandboxRuntimeError(
+            "huggingface_hub is required to materialize hf:// data mounts"
+        ) from exc
+
+    repo_id, revision, subpath, repo_type = _parse_hf_data_uri(mount.uri)
+    try:
+        local_path = Path(
+            snapshot_download(
+                repo_id=repo_id,
+                revision=revision,
+                repo_type=repo_type or None,
+                local_dir=str(cache_path),
+            )
+        ).resolve()
+    except Exception as exc:
+        raise SandboxRuntimeError(
+            f"hf data mount fetch failed for {mount.uri}: {exc}"
+        ) from exc
+    return local_path / subpath if subpath else local_path
+
+
+def _fetch_s3_data_mount(mount: DataMount, cache_path: Path) -> Path:
+    parsed = urlparse(mount.uri)
+    bucket = parsed.netloc
+    key = unquote(parsed.path.lstrip("/"))
+    version_id = (parse_qs(parsed.query).get("versionId") or [""])[0]
+    if not bucket or not key or not version_id:
+        raise SandboxRuntimeError(f"Invalid s3 data mount URI: {mount.uri}")
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        import boto3
+    except ImportError:
+        aws = shutil.which("aws")
+        if not aws:
+            raise SandboxRuntimeError(
+                "boto3 or the aws CLI is required to materialize s3:// data mounts"
+            )
+        result = subprocess.run(
+            [
+                aws,
+                "s3api",
+                "get-object",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--version-id",
+                version_id,
+                str(cache_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            error = result.stderr.strip() or result.stdout.strip()
+            raise SandboxRuntimeError(f"aws s3api get-object failed: {error}")
+        return cache_path.resolve()
+
+    try:
+        client = boto3.client("s3")
+        client.download_file(
+            bucket,
+            key,
+            str(cache_path),
+            ExtraArgs={"VersionId": version_id},
+        )
+    except Exception as exc:
+        raise SandboxRuntimeError(
+            f"s3 data mount fetch failed for {mount.uri}: {exc}"
+        ) from exc
+    return cache_path.resolve()
 
 
 @dataclass(frozen=True)
@@ -32,6 +192,100 @@ class SandboxMount:
         return f"{self.host_path}:{self.container_path}:{mode}"
 
 
+class DataMountResolver:
+    """Materialize Stage 1 data URIs to host paths for bind mounts."""
+
+    def __init__(
+        self,
+        *,
+        cache_root: str | Path | None = None,
+        base_dir: str | Path | None = None,
+        hf_fetcher: DataMountFetcher | None | object = _DEFAULT_REMOTE_FETCHER,
+        s3_fetcher: DataMountFetcher | None | object = _DEFAULT_REMOTE_FETCHER,
+    ) -> None:
+        default_cache = Path.home() / ".cache" / "quantagentbench" / "data"
+        self.cache_root = Path(cache_root or default_cache).expanduser()
+        self.base_dir = Path(base_dir or os.getcwd()).expanduser()
+        self.hf_fetcher = (
+            _fetch_hf_data_mount
+            if hf_fetcher is _DEFAULT_REMOTE_FETCHER
+            else hf_fetcher
+        )
+        self.s3_fetcher = (
+            _fetch_s3_data_mount
+            if s3_fetcher is _DEFAULT_REMOTE_FETCHER
+            else s3_fetcher
+        )
+
+    def resolve(self, mount: DataMount) -> SandboxMount:
+        parsed = urlparse(mount.uri)
+        scheme = parsed.scheme.lower()
+        if scheme == "file":
+            host_path = self._resolve_file(mount.uri)
+        elif scheme == "hf":
+            host_path = self._resolve_cached("hf", mount, self.hf_fetcher)
+        elif scheme == "s3":
+            host_path = self._resolve_cached("s3", mount, self.s3_fetcher)
+        else:
+            raise SandboxRuntimeError(f"Unsupported data URI scheme: {scheme}")
+
+        return SandboxMount(
+            host_path=str(host_path),
+            container_path=mount.target_path,
+            read_only=mount.read_only,
+        )
+
+    def resolve_all(self, mounts: Sequence[DataMount]) -> tuple[SandboxMount, ...]:
+        return tuple(self.resolve(mount) for mount in mounts)
+
+    def _resolve_file(self, uri: str) -> Path:
+        raw = uri.removeprefix("file://")
+        if raw.startswith("localhost/"):
+            raw = raw.removeprefix("localhost")
+        path = Path(unquote(raw)).expanduser()
+        if not path.is_absolute():
+            path = self.base_dir / path
+        path = path.resolve()
+        if not path.exists():
+            raise SandboxRuntimeError(f"file data mount does not exist: {path}")
+        return path
+
+    def _resolve_cached(
+        self,
+        scheme: str,
+        mount: DataMount,
+        fetcher: DataMountFetcher | None,
+    ) -> Path:
+        cache_path = self.cache_root / scheme / quote(mount.uri, safe="")
+        hf_subpath = ""
+        if scheme == "hf":
+            _, _, hf_subpath, _ = _parse_hf_data_uri(mount.uri)
+        if cache_path.exists():
+            if hf_subpath:
+                subpath_cache = cache_path / hf_subpath
+                if subpath_cache.exists():
+                    return subpath_cache.resolve()
+            elif not hf_subpath:
+                return cache_path.resolve()
+        if fetcher is not None:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            fetched_path = Path(fetcher(mount, cache_path)).expanduser().resolve()
+            if not fetched_path.exists():
+                raise SandboxRuntimeError(
+                    f"{scheme} fetcher returned missing path: {fetched_path}"
+                )
+            return fetched_path
+        if not cache_path.exists():
+            raise SandboxRuntimeError(
+                f"{scheme} data mount is not materialized in cache: {mount.uri}"
+            )
+        if hf_subpath:
+            raise SandboxRuntimeError(
+                f"hf data mount subpath is not materialized in cache: {mount.uri}"
+            )
+        return cache_path.resolve()
+
+
 @dataclass(frozen=True)
 class SandboxCreateRequest:
     """Request to create an isolated sandbox process."""
@@ -39,14 +293,69 @@ class SandboxCreateRequest:
     image_uri: str
     sandbox_id: str | None = None
     mounts: tuple[SandboxMount, ...] = ()
+    data_mounts: tuple[DataMount, ...] = ()
     env: Mapping[str, str] = field(default_factory=dict)
     network_enabled: bool = False
     cpus: str = "1"
     memory: str = "768m"
+    resource_limits: Mapping[str, Any] = field(default_factory=dict)
     workdir: str = "/workspace"
     command: tuple[str, ...] = ("sleep", "infinity")
     pull_policy: str = "missing"
     metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "mounts", tuple(self.mounts))
+        object.__setattr__(self, "data_mounts", tuple(self.data_mounts))
+        object.__setattr__(self, "command", tuple(self.command))
+
+    @classmethod
+    def from_spec(
+        cls,
+        spec: SandboxSpec,
+        *,
+        sandbox_id: str | None = None,
+        mounts: Sequence[SandboxMount] = (),
+        data_mounts: Sequence[DataMount] = (),
+        env: Mapping[str, str] | None = None,
+        network_enabled: bool | None = None,
+        workdir: str = "/workspace",
+        command: Sequence[str] = ("sleep", "infinity"),
+        pull_policy: str = "missing",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "SandboxCreateRequest":
+        limits = dict(spec.resource_limits)
+        effective_network = _bool_limit(
+            limits,
+            "network_enabled",
+            False if network_enabled is None else network_enabled,
+        )
+        request_metadata = dict(metadata or {})
+        if "wall_timeout_seconds" in limits:
+            request_metadata["wall_timeout_seconds"] = limits["wall_timeout_seconds"]
+        request_metadata.setdefault(
+            "sandbox_digest",
+            build_sandbox_digest(
+                spec.image_uri,
+                resource_limits=limits,
+                data_mounts=data_mounts,
+            ),
+        )
+        return cls(
+            image_uri=spec.image_uri,
+            sandbox_id=sandbox_id,
+            mounts=tuple(mounts),
+            data_mounts=tuple(data_mounts),
+            env=dict(env or {}),
+            network_enabled=effective_network,
+            cpus=_limit_str(limits, "cpus", ("cpu_count",), "1"),
+            memory=_memory_limit(limits, "768m"),
+            resource_limits=limits,
+            workdir=workdir,
+            command=tuple(command),
+            pull_policy=pull_policy,
+            metadata=request_metadata,
+        )
 
 
 @dataclass(frozen=True)
@@ -212,10 +521,12 @@ class DockerSandboxRuntime(SandboxRuntime):
         telemetry: TelemetryHook | None = None,
         router: ToolRouter | None = None,
         runner: CommandRunner | None = None,
+        data_mount_resolver: DataMountResolver | None = None,
     ) -> None:
         self.telemetry = telemetry
         self.router = router or ToolRouter()
         self._runner = runner
+        self.data_mount_resolver = data_mount_resolver or DataMountResolver()
         self._handles: dict[str, SandboxHandle] = {}
 
     def pull_image(self, image_uri: str) -> None:
@@ -229,6 +540,7 @@ class DockerSandboxRuntime(SandboxRuntime):
         self._emit("image_pull", start, True, None, {"image_uri": image_uri})
 
     def create(self, request: SandboxCreateRequest) -> SandboxHandle:
+        request = self._prepare_request(request)
         if request.pull_policy == "always":
             self.pull_image(request.image_uri)
 
@@ -271,7 +583,11 @@ class DockerSandboxRuntime(SandboxRuntime):
             start,
             True,
             None,
-            {"sandbox_id": sandbox_id, "image_uri": request.image_uri},
+            {
+                "sandbox_id": sandbox_id,
+                "image_uri": request.image_uri,
+                "data_mount_count": len(request.data_mounts),
+            },
         )
         return handle
 
@@ -390,6 +706,42 @@ class DockerSandboxRuntime(SandboxRuntime):
         args.extend(request.command)
         return args
 
+    def _prepare_request(
+        self, request: SandboxCreateRequest
+    ) -> SandboxCreateRequest:
+        metadata = dict(request.metadata)
+        metadata.setdefault(
+            "sandbox_digest",
+            build_sandbox_digest(
+                request.image_uri,
+                resource_limits=request.resource_limits,
+                data_mounts=request.data_mounts,
+            ),
+        )
+        if not request.data_mounts:
+            return replace(request, metadata=metadata)
+
+        resolved_mounts = self.data_mount_resolver.resolve_all(request.data_mounts)
+        metadata["resolved_data_mounts"] = [
+            {
+                "uri": data_mount.uri,
+                "host_path": sandbox_mount.host_path,
+                "target_path": sandbox_mount.container_path,
+                "read_only": sandbox_mount.read_only,
+            }
+            for data_mount, sandbox_mount in zip(
+                request.data_mounts, resolved_mounts, strict=True
+            )
+        ]
+        digest = dict(metadata["sandbox_digest"])
+        digest["data_mounts"] = [asdict(mount) for mount in request.data_mounts]
+        metadata["sandbox_digest"] = digest
+        return replace(
+            request,
+            mounts=(*request.mounts, *resolved_mounts),
+            metadata=metadata,
+        )
+
     def _run(
         self, args: Sequence[str], *, timeout: float | None
     ) -> subprocess.CompletedProcess[str]:
@@ -424,9 +776,11 @@ class LocalSandboxRuntime(SandboxRuntime):
         *,
         telemetry: TelemetryHook | None = None,
         router: ToolRouter | None = None,
+        data_mount_resolver: DataMountResolver | None = None,
     ) -> None:
         self.telemetry = telemetry
         self.router = router or ToolRouter()
+        self.data_mount_resolver = data_mount_resolver or DataMountResolver()
         self._owned_workspaces: set[str] = set()
         self._env_by_sandbox_id: dict[str, dict[str, str]] = {}
 
@@ -439,6 +793,7 @@ class LocalSandboxRuntime(SandboxRuntime):
         )
 
     def create(self, request: SandboxCreateRequest) -> SandboxHandle:
+        request = self._prepare_request(request)
         start = time.perf_counter()
         workspace = self._resolve_workspace(request)
         sandbox_id = request.sandbox_id or f"local_{uuid.uuid4().hex[:12]}"
@@ -455,7 +810,11 @@ class LocalSandboxRuntime(SandboxRuntime):
             start,
             True,
             None,
-            {"sandbox_id": sandbox_id, "runtime": "local"},
+            {
+                "sandbox_id": sandbox_id,
+                "runtime": "local",
+                "data_mount_count": len(request.data_mounts),
+            },
         )
         return handle
 
@@ -549,6 +908,42 @@ class LocalSandboxRuntime(SandboxRuntime):
         workspace = tempfile.mkdtemp(prefix="qab_local_")
         self._owned_workspaces.add(workspace)
         return workspace
+
+    def _prepare_request(
+        self, request: SandboxCreateRequest
+    ) -> SandboxCreateRequest:
+        metadata = dict(request.metadata)
+        metadata.setdefault(
+            "sandbox_digest",
+            build_sandbox_digest(
+                request.image_uri,
+                resource_limits=request.resource_limits,
+                data_mounts=request.data_mounts,
+            ),
+        )
+        if not request.data_mounts:
+            return replace(request, metadata=metadata)
+
+        resolved_mounts = self.data_mount_resolver.resolve_all(request.data_mounts)
+        metadata["resolved_data_mounts"] = [
+            {
+                "uri": data_mount.uri,
+                "host_path": sandbox_mount.host_path,
+                "target_path": sandbox_mount.container_path,
+                "read_only": sandbox_mount.read_only,
+            }
+            for data_mount, sandbox_mount in zip(
+                request.data_mounts, resolved_mounts, strict=True
+            )
+        ]
+        digest = dict(metadata["sandbox_digest"])
+        digest["data_mounts"] = [asdict(mount) for mount in request.data_mounts]
+        metadata["sandbox_digest"] = digest
+        return replace(
+            request,
+            mounts=(*request.mounts, *resolved_mounts),
+            metadata=metadata,
+        )
 
     def _emit(
         self,

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -140,9 +140,72 @@ def _task_is_lean(task) -> bool:
     environment = getattr(task, "environment", None)
     if environment is None:
         return False
-    sandbox_image = str(getattr(environment, "sandbox_image", "") or "").lower()
+    sandbox_image = _environment_sandbox_image(environment).lower()
     core_tools = list(getattr(environment, "core_mcp_tools", []) or [])
     return "lean" in sandbox_image or "run_lean_backtest" in core_tools
+
+
+def _environment_sandbox_image(environment) -> str:
+    if environment is None:
+        return ""
+    spec = getattr(environment, "sandbox_spec", None)
+    image_uri = str(getattr(spec, "image_uri", "") or "").strip()
+    if image_uri:
+        return image_uri
+    return str(getattr(environment, "sandbox_image", "") or "")
+
+
+def _environment_resource_limits(environment) -> dict:
+    spec = getattr(environment, "sandbox_spec", None)
+    limits = getattr(spec, "resource_limits", None)
+    resolved = dict(limits or {})
+    if "network_enabled" not in resolved and bool(
+        getattr(environment, "network_enabled", False)
+    ):
+        resolved["network_enabled"] = True
+    return resolved
+
+
+def _environment_network_enabled(environment) -> bool:
+    limits = _environment_resource_limits(environment)
+    value = limits.get("network_enabled")
+    if value is None:
+        return bool(getattr(environment, "network_enabled", False))
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _environment_sandbox_digest(environment) -> dict:
+    if environment is None:
+        return {}
+    from platform_api.contracts import DataMount
+    from platform_api.runtime import build_sandbox_digest
+
+    data_mounts = []
+    for item in getattr(environment, "data_mounts", []) or []:
+        if hasattr(item, "model_dump"):
+            payload = item.model_dump()
+        elif isinstance(item, dict):
+            payload = dict(item)
+        else:
+            payload = {
+                "uri": getattr(item, "uri"),
+                "target_path": getattr(item, "target_path"),
+                "read_only": getattr(item, "read_only", True),
+            }
+        data_mounts.append(
+            DataMount(
+                uri=str(payload["uri"]),
+                target_path=str(payload["target_path"]),
+                read_only=bool(payload.get("read_only", True)),
+            )
+        )
+    return build_sandbox_digest(
+        _environment_sandbox_image(environment),
+        resource_limits=_environment_resource_limits(environment),
+        data_mounts=tuple(data_mounts),
+    )
 
 
 def _effective_core_tool_names(task) -> list[str]:
@@ -175,7 +238,7 @@ def _lean_template_context(task, *, user_code_dir: Optional[str | Path]) -> dict
         "requires_code": bool(task.requires_code),
         "template_type": template_type,
         "expects_universe": template_type == "multi_symbol",
-        "sandbox_image": environment.sandbox_image if environment else "",
+        "sandbox_image": _environment_sandbox_image(environment),
         "user_code_available": bool(user_code_dir),
     }
 
@@ -489,7 +552,7 @@ class SessionState:
             "requires_code": bool(self.task.requires_code) if self.task else False,
             "docs_available": list(docs_available or []),
             "max_backtest_trials": max_backtest_trials,
-            "sandbox_image": environment.sandbox_image if environment else "",
+            "sandbox_image": _environment_sandbox_image(environment),
             "user_code_available": bool(user_code_dir),
         }
 
@@ -604,7 +667,7 @@ class SessionState:
             except RuntimeError as exc:
                 return {"error": str(exc)}
 
-            sandbox_img = task.environment.sandbox_image if task.environment else ""
+            sandbox_img = _environment_sandbox_image(task.environment)
             series = "lean" if sandbox_img and "lean" in sandbox_img else "normal"
             paths = ensure_data(
                 series=series,
@@ -636,7 +699,9 @@ class SessionState:
                 self.staged_temp_dirs.extend(sample_temp_dirs)
 
             base_sandbox_img = (
-                task.environment.sandbox_image if task.environment else None
+                _environment_sandbox_image(task.environment)
+                if task.environment
+                else None
             )
             self.container = self.container_manager.create_container(
                 task_id=f"{task_id}_{self.session_id[:8]}",
@@ -645,12 +710,20 @@ class SessionState:
                 user_code_dir=user_code_dir,
                 sandbox_image=(self._resume_layer_tag or base_sandbox_img),
                 network_enabled=(
-                    task.environment.network_enabled if task.environment else False
+                    _environment_network_enabled(task.environment)
+                    if task.environment
+                    else False
                 ),
                 lean_data_dir=paths.lean_data,
                 custom_data_dir=paths.custom_data,
+                data_mounts=task.environment.data_mounts if task.environment else [],
                 restore_workspace_snapshot=bool(self._resume_layer_tag),
                 resource_image=base_sandbox_img,
+                resource_limits=(
+                    _environment_resource_limits(task.environment)
+                    if task.environment
+                    else None
+                ),
             )
 
             local_tool_env = self._build_tool_env(
@@ -1460,6 +1533,9 @@ class SessionState:
             "simulator_cost": self.user_sim.total_cost if self.user_sim else 0.0,
             "duration_seconds": duration,
             "step_count": step_count,
+            "sandbox_digest": _environment_sandbox_digest(
+                self.task.environment if self.task else None
+            ),
             "latest_layer_tag": self._latest_layer_tag,
             "snapshot_tags": list(self._snapshot_tags),
             "snapshot_interval": self._snapshot_interval,
@@ -1554,6 +1630,9 @@ class SessionState:
             owner_github_login=self.owner_github_login,
             owner_email=self.owner_email,
             visibility=self.visibility,
+            sandbox_digest=_environment_sandbox_digest(
+                self.task.environment if self.task else None
+            ),
         )
         logger.info("Results saved: %s", result_dir)
 

--- a/bench/server/core/container.py
+++ b/bench/server/core/container.py
@@ -9,8 +9,8 @@ import tempfile
 import threading
 import time
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Optional
+from pathlib import Path, PurePosixPath
+from typing import Optional, Sequence
 
 
 @dataclass
@@ -88,6 +88,78 @@ class ContainerManager:
                 return preset
         return cls._RESOURCE_PRESETS["_default"]
 
+    @staticmethod
+    def _apply_resource_limits(
+        mem_limit: str,
+        cpu_limit: str,
+        resource_limits: dict | None,
+    ) -> tuple[str, str]:
+        if not resource_limits:
+            return mem_limit, cpu_limit
+        if resource_limits.get("memory"):
+            mem_limit = str(resource_limits["memory"])
+        elif resource_limits.get("memory_mb"):
+            mem_limit = f"{int(resource_limits['memory_mb'])}m"
+        cpu_value = resource_limits.get("cpus", resource_limits.get("cpu_count"))
+        if cpu_value not in (None, ""):
+            cpu_limit = str(cpu_value)
+        return mem_limit, cpu_limit
+
+    @staticmethod
+    def _normalize_data_mounts(data_mounts: Sequence[object] | None):
+        if not data_mounts:
+            return ()
+        from platform_api.contracts import DataMount
+
+        normalized = []
+        for item in data_mounts:
+            if isinstance(item, DataMount):
+                normalized.append(item)
+                continue
+            if hasattr(item, "model_dump"):
+                payload = item.model_dump()
+            elif isinstance(item, dict):
+                payload = dict(item)
+            else:
+                payload = {
+                    "uri": getattr(item, "uri"),
+                    "target_path": getattr(item, "target_path"),
+                    "read_only": getattr(item, "read_only", True),
+                }
+            normalized.append(
+                DataMount(
+                    uri=str(payload["uri"]),
+                    target_path=str(payload["target_path"]),
+                    read_only=bool(payload.get("read_only", True)),
+                )
+            )
+        return tuple(normalized)
+
+    @staticmethod
+    def _prepare_nested_mount_targets(
+        mounts: Sequence[object],
+        parent_mounts: Sequence[tuple[str | None, str]],
+    ) -> None:
+        for mount in mounts:
+            container_path = PurePosixPath(getattr(mount, "container_path"))
+            host_path = Path(str(getattr(mount, "host_path")))
+            for parent_host, parent_container in parent_mounts:
+                if not parent_host:
+                    continue
+                parent_path = PurePosixPath(parent_container)
+                try:
+                    relative_target = container_path.relative_to(parent_path)
+                except ValueError:
+                    continue
+                if not relative_target.parts:
+                    continue
+                staged_target = Path(parent_host, *relative_target.parts)
+                if host_path.is_dir():
+                    staged_target.mkdir(parents=True, exist_ok=True)
+                else:
+                    staged_target.parent.mkdir(parents=True, exist_ok=True)
+                    staged_target.touch(exist_ok=True)
+
     def create_container(
         self,
         task_id: str,
@@ -100,6 +172,8 @@ class ContainerManager:
         custom_data_dir: Optional[str] = None,
         restore_workspace_snapshot: bool = False,
         resource_image: Optional[str] = None,
+        data_mounts: Sequence[object] | None = None,
+        resource_limits: dict | None = None,
     ) -> ContainerInfo:
         """Create a sandboxed Docker container (or local workspace fallback).
 
@@ -115,6 +189,7 @@ class ContainerManager:
         """
         image = sandbox_image or self.docker_image
         workspace = tempfile.mkdtemp(prefix=f"qtb_{task_id}_")
+        normalized_data_mounts = self._normalize_data_mounts(data_mounts)
 
         if self.use_docker:
             if custom_data_dir and data_dir and os.path.isdir(data_dir):
@@ -131,10 +206,33 @@ class ContainerManager:
                 mounts.append(f"-v {lean_data_dir}:/lean/Data:ro")
             if custom_data_dir:
                 mounts.append(f"-v {custom_data_dir}:/data/custom:ro")
+            if normalized_data_mounts:
+                from platform_api.runtime import DataMountResolver
+
+                resolver = DataMountResolver(base_dir=Path.cwd())
+                resolved_data_mounts = resolver.resolve_all(normalized_data_mounts)
+                self._prepare_nested_mount_targets(
+                    resolved_data_mounts,
+                    (
+                        (data_dir, "/data"),
+                        (docs_dir, "/docs"),
+                        (user_code_dir, "/user_code"),
+                        (lean_data_dir, "/lean/Data"),
+                        (custom_data_dir, "/data/custom"),
+                    ),
+                )
+                mounts.extend(
+                    f"-v {mount.to_docker_volume()}" for mount in resolved_data_mounts
+                )
 
             network_flag = "--network bridge" if network_enabled else "--network none"
             network_mode = "bridge" if network_enabled else "none"
             mem_limit, cpu_limit = self._resolve_resources(resource_image or image)
+            mem_limit, cpu_limit = self._apply_resource_limits(
+                mem_limit,
+                cpu_limit,
+                resource_limits,
+            )
             cmd = (
                 f"docker run -d --name qtb_{task_id}_{int(time.time())} "
                 f"{network_flag} --cpus {cpu_limit} --memory {mem_limit} "

--- a/bench/server/core/session.py
+++ b/bench/server/core/session.py
@@ -58,12 +58,15 @@ def build_background(task) -> str:
     behavioural directives or scoring hints.
     """
     env = task.environment if task.environment else None
-    sandbox_image = (env.sandbox_image or "") if env else ""
+    sandbox_image = (
+        getattr(env, "sandbox_image_uri", None) or getattr(env, "sandbox_image", "") or ""
+    ) if env else ""
     is_lean = "lean" in sandbox_image
     has_user_code = bool(task.sample_code)
     has_docs = bool(env.docs_available) if env else False
     has_data = bool(
         (env.data_files if env else None)
+        or (getattr(env, "data_mounts", None) if env else None)
         or getattr(task, "series", None)
         or getattr(task, "custom_data_key", None)
     )

--- a/bench/server/storage/result_writer.py
+++ b/bench/server/storage/result_writer.py
@@ -45,6 +45,7 @@ def save_run_state(
     owner_github_login: str = "",
     owner_email: str = "",
     visibility: str = "private",
+    sandbox_digest: Optional[dict] = None,
 ) -> Path:
     """Save ``run_state.json`` and ``.session_id``."""
     result_dir = Path(result_dir)
@@ -111,6 +112,7 @@ def save_run_state(
         "simulator_cost": simulator_cost,
         "artifact_debug_history": artifact_debug_history or [],
         "duration_seconds": duration_seconds,
+        "sandbox_digest": sandbox_digest or {},
         "key_results": key_results,
         "trace_summary": trace_summary,
         "step_count": step_count,

--- a/bench/tests/test_server_session_runtime.py
+++ b/bench/tests/test_server_session_runtime.py
@@ -30,6 +30,7 @@ if "mcp" not in sys.modules:
 
 from server.api.session_api import (
     SessionState,
+    _environment_sandbox_digest,
     _resolve_persona_pin,
     _session_random_seed,
 )
@@ -93,6 +94,85 @@ class SessionContextTests(unittest.TestCase):
         )
         self.assertNotIn("task_id", context)
         self.assertNotIn("sample_code", context)
+
+    def test_session_context_uses_sandbox_spec_image(self):
+        state = SessionState(session_id="sess-123", use_docker=False)
+        state.task = SimpleNamespace(
+            category=SimpleNamespace(value="implementation"),
+            requires_code=True,
+            sample_code=None,
+            environment=SimpleNamespace(
+                sandbox_image="legacy:image",
+                sandbox_spec=SimpleNamespace(image_uri="spec:image-lean"),
+                max_backtest_trials=3,
+            ),
+        )
+
+        context = state._build_session_context(
+            docs_available=[],
+            user_code_dir=None,
+        )
+
+        self.assertEqual(context["sandbox_image"], "spec:image-lean")
+
+    def test_build_background_uses_sandbox_spec_and_data_mounts(self):
+        from server.core.session import build_background
+
+        task = SimpleNamespace(
+            sample_code=None,
+            series=None,
+            custom_data_key=None,
+            environment=SimpleNamespace(
+                sandbox_image="legacy:image",
+                sandbox_image_uri="spec:image-lean",
+                docs_available=[],
+                data_files=[],
+                data_mounts=[{"target_path": "/data/lean"}],
+            ),
+        )
+
+        background = build_background(task)
+
+        self.assertIn("algorithmic trading engine", background)
+        self.assertIn("Market data files are pre-loaded", background)
+
+    def test_sandbox_digest_preserves_legacy_network_flag(self):
+        digest = _environment_sandbox_digest(
+            SimpleNamespace(
+                sandbox_image="legacy:image",
+                sandbox_spec=None,
+                network_enabled=True,
+                data_mounts=[],
+            )
+        )
+
+        self.assertTrue(digest["resource_limits"]["network_enabled"])
+
+
+class ContainerManagerMountTests(unittest.TestCase):
+    def test_prepare_nested_data_mount_targets_creates_staged_paths(self):
+        from platform_api.runtime import SandboxMount
+        from server.core.container import ContainerManager
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            data_dir = root / "staged_data"
+            data_dir.mkdir()
+            mounted_dir = root / "lean_data"
+            mounted_dir.mkdir()
+            mounted_file = root / "universe.json"
+            mounted_file.write_text("{}", encoding="utf-8")
+
+            ContainerManager._prepare_nested_mount_targets(
+                (
+                    SandboxMount(str(mounted_dir), "/data/lean"),
+                    SandboxMount(str(mounted_file), "/data/meta/universe.json"),
+                ),
+                ((str(data_dir), "/data"),),
+            )
+
+            self.assertTrue((data_dir / "lean").is_dir())
+            self.assertTrue((data_dir / "meta" / "universe.json").is_file())
 
 
 class PersonaPinTests(unittest.TestCase):

--- a/bench/tests/unit/test_backfill.py
+++ b/bench/tests/unit/test_backfill.py
@@ -98,6 +98,47 @@ def test_backfill_populates_top_level_fields(tmp_path):
     validate_bundle_path(out)
 
 
+def test_backfill_prefers_sandbox_spec_digest_and_data_mounts(tmp_path):
+    task_id = "S01_ma_crossover"
+    run_state = _write_run_state(tmp_path / "result", _minimal_run_state(task_id=task_id))
+    bench = tmp_path / "bench"
+    task_dir = bench / "tasks" / "layer2" / "strategy"
+    task_dir.mkdir(parents=True)
+    image = "quanttutor/lean@sha256:" + "d" * 64
+    (task_dir / f"{task_id}.json").write_text(
+        json.dumps(
+            {
+                "task_id": task_id,
+                "version": "2.3",
+                "category": "strategy",
+                "environment": {
+                    "sandbox_image": "legacy:image",
+                    "sandbox_spec": {
+                        "image_uri": image,
+                        "resource_limits": {"cpu_count": 2, "memory_mb": 1024},
+                    },
+                    "data_mounts": [
+                        {
+                            "uri": "hf://Varsity-Tech/quant-tutor-bench-data@"
+                            + "a" * 40,
+                            "target_path": "/data/lean",
+                            "read_only": True,
+                        }
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = bundle_io.read(backfill(run_state, bench_root=bench))
+
+    assert bundle.sandbox_digest["sandbox_image"] == image
+    assert bundle.sandbox_digest["digest"] == "sha256:" + "d" * 64
+    assert bundle.sandbox_digest["resource_limits"]["cpu_count"] == 2
+    assert bundle.sandbox_digest["data_mounts"][0]["target_path"] == "/data/lean"
+
+
 def test_backfill_writes_bundle_next_to_run_state_by_default(tmp_path):
     run_state = _write_run_state(tmp_path / "result", _minimal_run_state())
     out = backfill(run_state, bench_root=_bench_root_with_task(tmp_path, "S01_ma_crossover"))

--- a/bench/tests/unit/test_platform_api.py
+++ b/bench/tests/unit/test_platform_api.py
@@ -5,6 +5,8 @@ from types import SimpleNamespace
 import pytest
 
 from platform_api import (
+    DataMount,
+    DataMountResolver,
     DockerSandboxRuntime,
     EvalItem,
     EvalSample,
@@ -19,6 +21,7 @@ from platform_api import (
     PluginLoader,
     SandboxCreateRequest,
     SandboxMount,
+    SandboxSpec,
     Score,
     TaskSuite,
     TelemetryRecord,
@@ -26,6 +29,7 @@ from platform_api import (
     ToolRequest,
     ToolRouter,
     TranscriptMessage,
+    build_sandbox_digest,
 )
 
 
@@ -78,6 +82,47 @@ def test_contract_abcs_and_models_round_trip():
     assert npc.respond(sample.transcript, (), {}, {}).terminate is True
     assert evaluator.evaluate(item, sample).value == 1.0
     assert evaluator.metadata().required_bundle_fields == frozenset({"conversation"})
+
+
+def test_task_suite_declares_data_mounts_and_sandbox_spec():
+    data_mount = DataMount(
+        uri="hf://Varsity-Tech/quant-tutor-bench-data@" + "a" * 40,
+        target_path="/data/lean",
+    )
+    spec = SandboxSpec(
+        image_uri="quanttutor/quant-tutor-lean@sha256:" + "a" * 64,
+        resource_limits={"cpu_count": 2, "memory_mb": 1024},
+    )
+
+    class Suite(StubTaskSuite):
+        def get_task(self, task_id: str) -> EvalItem:
+            return EvalItem(
+                task_id=task_id,
+                data_mounts=(data_mount,),
+                sandbox_spec=spec,
+            )
+
+    suite = Suite()
+
+    assert suite.data_mounts("T1") == (data_mount,)
+    assert suite.sandbox_spec("T1") == spec
+
+
+def test_data_mount_validates_stage_one_uri_policy():
+    DataMount(uri="file://./local-data", target_path="/data/local")
+    DataMount(uri="s3://bucket/key?versionId=abc", target_path="/data/s3")
+    DataMount(uri="hf://owner/dataset@" + "a" * 40, target_path="/data/hf")
+
+    with pytest.raises(ValueError, match="Unsupported data URI scheme"):
+        DataMount(uri="http://example.com/data.zip", target_path="/data/http")
+    with pytest.raises(ValueError, match="@commit"):
+        DataMount(uri="hf://owner/dataset", target_path="/data/hf")
+    with pytest.raises(ValueError, match="commit SHA"):
+        DataMount(uri="hf://owner/dataset@main", target_path="/data/hf")
+    with pytest.raises(ValueError, match="versionId"):
+        DataMount(uri="s3://bucket/key", target_path="/data/s3")
+    with pytest.raises(ValueError, match="absolute"):
+        DataMount(uri="file://./local-data", target_path="data/local")
 
 
 def test_plugin_loader_loads_json_config(tmp_path, monkeypatch):
@@ -244,6 +289,65 @@ def test_local_sandbox_exec_uses_request_env_and_counts_failed_records():
     assert telemetry.totals()["errors"] == 1
 
 
+def test_sandbox_create_request_from_spec_maps_limits_and_digest():
+    spec = SandboxSpec(
+        image_uri="example/image@sha256:" + "b" * 64,
+        resource_limits={
+            "cpu_count": 2,
+            "memory_mb": 1536,
+            "wall_timeout_seconds": 45,
+            "network_enabled": True,
+        },
+    )
+    mount = DataMount(uri="file://./data", target_path="/data/local")
+
+    request = SandboxCreateRequest.from_spec(spec, data_mounts=(mount,))
+
+    assert request.image_uri == spec.image_uri
+    assert request.cpus == "2"
+    assert request.memory == "1536m"
+    assert request.network_enabled is True
+    assert request.metadata["wall_timeout_seconds"] == 45
+    assert request.metadata["sandbox_digest"]["digest"] == "sha256:" + "b" * 64
+    assert request.metadata["sandbox_digest"]["data_mounts"] == [
+        {"uri": "file://./data", "target_path": "/data/local", "read_only": True}
+    ]
+
+
+def test_data_mount_resolver_materializes_file_mounts(tmp_path):
+    data_dir = tmp_path / "local-data"
+    data_dir.mkdir()
+    mount = DataMount(uri="file://./local-data", target_path="/data/local")
+    resolver = DataMountResolver(base_dir=tmp_path)
+
+    sandbox_mount = resolver.resolve(mount)
+
+    assert sandbox_mount.host_path == str(data_dir.resolve())
+    assert sandbox_mount.container_path == "/data/local"
+    assert sandbox_mount.to_docker_volume().endswith(":/data/local:ro")
+
+
+def test_data_mount_resolver_materializes_remote_mounts_with_fetcher(tmp_path):
+    fetched_dir = tmp_path / "fetched"
+    fetched_dir.mkdir()
+    mount = DataMount(
+        uri="hf://owner/dataset@" + "a" * 40,
+        target_path="/data/hf",
+    )
+
+    def fetcher(data_mount, cache_path):
+        assert data_mount == mount
+        assert cache_path.parent == tmp_path / "cache" / "hf"
+        return fetched_dir
+
+    resolver = DataMountResolver(cache_root=tmp_path / "cache", hf_fetcher=fetcher)
+
+    sandbox_mount = resolver.resolve(mount)
+
+    assert sandbox_mount.host_path == str(fetched_dir.resolve())
+    assert sandbox_mount.container_path == "/data/hf"
+
+
 def test_docker_runtime_builds_isolated_run_command():
     calls = []
 
@@ -288,6 +392,51 @@ def test_docker_runtime_builds_isolated_run_command():
     assert "A=B" in run_args
     assert handle.container_id == "container123"
     assert calls[-1] == ["docker", "rm", "-f", "container123"]
+
+
+def test_docker_runtime_resolves_data_mounts_and_records_digest(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(exist_ok=True)
+    calls = []
+
+    def runner(args, timeout=None):
+        calls.append(list(args))
+        if args[:3] == ["docker", "run", "-d"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                stdout="container456\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    runtime = DockerSandboxRuntime(
+        runner=runner,
+        data_mount_resolver=DataMountResolver(base_dir=tmp_path),
+    )
+    handle = runtime.create(
+        SandboxCreateRequest.from_spec(
+            SandboxSpec(
+                image_uri="example/image:v1",
+                resource_limits={"cpu_count": 2, "memory_mb": 1024},
+            ),
+            sandbox_id="case2",
+            data_mounts=(
+                DataMount(uri="file://./data", target_path="/data/custom"),
+            ),
+        )
+    )
+
+    run_args = calls[0]
+    assert f"{data_dir.resolve()}:/data/custom:ro" in run_args
+    assert handle.metadata["sandbox_digest"]["sandbox_image"] == "example/image:v1"
+    assert handle.metadata["resolved_data_mounts"][0]["target_path"] == "/data/custom"
+
+
+def test_build_sandbox_digest_extracts_image_digest():
+    digest = build_sandbox_digest("repo/image@sha256:" + "c" * 64)
+    assert digest["digest"] == "sha256:" + "c" * 64
+    assert digest["sandbox_policy"]["stage"] == "1"
 
 
 def test_telemetry_timer_records_errors_and_token_counts():

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,14 +56,24 @@ first on `sys.path`.
 
 - `contracts/` defines the three plugin ABCs: `TaskSuite`, `NPCProvider`, and
   `Evaluator`. Shared dataclasses include `EvalItem`, `EvalSample`,
-  `TranscriptMessage`, `ToolLog`, `FileArtifact`, `NPCReply`, `Score`, and
-  `EvaluatorMetadata`.
+  `TranscriptMessage`, `ToolLog`, `FileArtifact`, `NPCReply`, `Score`,
+  `EvaluatorMetadata`, `DataMount`, and `SandboxSpec`.
 - `runtime/` defines `SandboxRuntime`, `SandboxCreateRequest`, `SandboxMount`,
   `SandboxHandle`, `ExecResult`, `ToolRequest`, `ToolResult`, and `ToolRouter`.
   `DockerSandboxRuntime` owns image pulls, container creation with volume,
   CPU/memory, and network flags, process execution through `docker exec`, and
   routed tool calls. `LocalSandboxRuntime` covers unit tests and local
   development flows.
+- Stage 1 data-plane declarations use
+  `DataMount(uri, target_path, read_only=True)` with
+  `hf://owner/dataset@<40-char-commit-sha>`,
+  `s3://bucket/key?versionId=...`, and `file://...` URIs. `http://` and
+  `https://` sources stay outside Stage 1. Data mounts materialize to a local
+  cache or existing file path before bind mounting into the sandbox.
+- `SandboxSpec(image_uri, resource_limits)` is the TaskSuite-owned sandbox
+  declaration. Stage 1 records `cpu_count` or `cpus`, `memory_mb` or `memory`,
+  `wall_timeout_seconds`, and `network_enabled`. Reference base images are the
+  supported Stage 1 image policy; forked or untrusted images belong to Stage 2.
 - `plugins/loader.py` loads implementation triples from explicit
   `PluginSpec`s, JSON/TOML config files, and Python entry points under
   `quantagentbench.plugins`.

--- a/docs/bundle_v1_schema.md
+++ b/docs/bundle_v1_schema.md
@@ -90,7 +90,7 @@ Top-level fields in `1.0.0-alpha`:
 | `task_id` | string | Producer task identifier. |
 | `timestamps` | object | `created_at`, `started_at`, `completed_at`, `duration_seconds`. |
 | `agent_id` | string | Producer/harness/model identifier. |
-| `sandbox_digest` | object | Sandbox image, digest, and runtime metadata. |
+| `sandbox_digest` | object | Sandbox image URI, image digest when present, resource limits, data mounts, and runtime policy metadata. |
 | `telemetry` | object | Generic counters, costs, and timing metadata. |
 | `messages` | array | Generic conversation messages. |
 | `tool_calls` | array | Generic tool calls with arbitrary args/result JSON. |


### PR DESCRIPTION
## Summary
- Add `DataMount` and `SandboxSpec` contracts, exports, TaskSuite accessors, and Stage 1 URI validation.
- Add cache-first data mount materialization for `file`, pinned `hf`, and versioned `s3` sources across platform runtimes and container managers.
- Wire `sandbox_spec` image/resource policy and `data_mounts` through server, orchestrator, standalone MCP, QR eval, bundle digest, active snapshots, completed run_state, and backfill.
- Document the Platform API data-plane policy and sandbox digest envelope.

## Verification
- `python3 -m compileall -q bench/platform_api bench/eval/contracts bench/eval/backfill bench/eval/tracks/qr.py bench/server/api/session_api.py bench/server/core/container.py bench/server/core/session.py bench/server/storage/result_writer.py bench/orchestrator bench/mcp_servers/mcp_server.py`
- `pytest bench/tests/unit/test_platform_api.py bench/tests/unit/test_backfill.py bench/tests/test_server_session_runtime.py` -> 44 passed
- `git diff --cached --check`

## Tooling Notes
- `ruff` unavailable in this environment.
- `black` unavailable in this environment.
- Broader regression collection was blocked earlier by missing optional `deepeval`.

## Handoff
Reference TaskSuite Impl A manifest E2E remains the open checklist item from the issue.

Closes #154