### PR TITLE
fix: split platform background prompts

### DIFF
--- a/bench/client/runner.py
+++ b/bench/client/runner.py
@@ -25,6 +25,12 @@ from .transports.rest_transport import RESTTransport
 logger = logging.getLogger(__name__)
 
 
+def _format_background_for_agent(background) -> str:
+    if isinstance(background, (dict, list)):
+        return json.dumps(background, indent=2, sort_keys=True)
+    return str(background)
+
+
 # ---------------------------------------------------------------------------
 # Run flow: create run → claim/start → connect → session
 # ---------------------------------------------------------------------------
@@ -99,8 +105,12 @@ async def run_via_attach(
         # 6. Build initial conversation
         conversation = []
         if background:
+            background_content = _format_background_for_agent(background)
             conversation.append(
-                {"role": "user", "content": f"[Session Background]\n{background}"}
+                {
+                    "role": "user",
+                    "content": f"[Session Background]\n{background_content}",
+                }
             )
             conversation.append({"role": "assistant", "content": "Understood."})
         conversation.append({"role": "user", "content": opening})
@@ -317,10 +327,11 @@ async def run_single_task(
 
                 conversation = []
                 if background:
+                    background_content = _format_background_for_agent(background)
                     conversation.append(
                         {
                             "role": "user",
-                            "content": f"[Session Background]\n{background}",
+                            "content": f"[Session Background]\n{background_content}",
                         }
                     )
                     conversation.append({"role": "assistant", "content": "Understood."})

--- a/bench/server/api/protocol.py
+++ b/bench/server/api/protocol.py
@@ -70,7 +70,7 @@ REGISTER_SESSION_TOOL = Tool(
 START_SESSION_TOOL = Tool(
     name="start_session",
     description=(
-        "Start the tutoring session. Returns the session background, "
+        "Start the tutoring session. Returns structured session background, "
         "the user's first message, and the list of available tools. "
         "Precondition: register_session must have succeeded. "
         "Called out of order, returns "
@@ -134,9 +134,8 @@ GET_BACKGROUND_TOOL = Tool(
     name="get_background",
     description=(
         "Re-read the session background returned by start_session. "
-        "Contains the sandbox environment description, communication "
-        "constraints, and available systems (data directories, runtime "
-        "engines, mounted code). Returns a plain text string."
+        "Contains sandbox environment facts, available systems, mounted "
+        "paths, and tool discovery metadata. Returns a JSON object string."
     ),
     inputSchema={"type": "object", "properties": {}, "required": []},
 )

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -1289,7 +1289,7 @@ class SessionState:
             from server.core.session import build_background
 
             bg = build_background(self.task) if self.task else ""
-            return [TextContent(type="text", text=bg)]
+            return [TextContent(type="text", text=json.dumps(bg))]
 
         if name == "send_message":
             text = arguments.get("text", "")

--- a/bench/server/config/prompt_config.py
+++ b/bench/server/config/prompt_config.py
@@ -1,31 +1,16 @@
-"""Server-scoped prompt configuration for QuantTutorBench.
-
-Only prompt builders and constants used by bench/server/ live here.
-"""
+"""Server-scoped prompt configuration for QuantTutorBench."""
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
 from typing import TYPE_CHECKING
 
-from config.prompt_config import flatten_concepts
+from server.reference.prompts import (
+    EMOTIONAL_PROFILE_DESCRIPTIONS,
+    build_reference_user_description,
+)
 
 if TYPE_CHECKING:
     from eval.contracts.schemas import QuantTutorTask, UserPersona
-
-
-# ── Emotional Profile Expansion ───────────────────────────────
-# Loaded from personas/emotional_profiles.json at import time.
-
-_PROFILES_PATH = (
-    Path(__file__).resolve().parents[2] / "personas" / "emotional_profiles.json"
-)
-EMOTIONAL_PROFILE_DESCRIPTIONS: dict[str, str] = (
-    json.loads(_PROFILES_PATH.read_text(encoding="utf-8"))
-    if _PROFILES_PATH.exists()
-    else {}
-)
 
 
 # ── Dynamic Prompt Builders ───────────────────────────────────
@@ -35,61 +20,11 @@ def build_user_description(
     persona: UserPersona,
     has_incremental_tc: bool = False,
 ) -> str:
-    """Build user_description string for the user simulator LLM.
-
-    Combines the persona's background description, concept knowledge,
-    emotional profile, and behavioral rules into a structured prompt.
-
-    The ``has_incremental_tc`` parameter is accepted for API compatibility
-    and no longer changes the output.
-    """
-    parts = [
-        f"Your profile: {persona.description}",
-    ]
-
-    all_familiar = flatten_concepts(persona.familiar_concepts)
-    if all_familiar:
-        parts.append(f"- You are familiar with: {', '.join(all_familiar)}")
-    all_unfamiliar = flatten_concepts(persona.unfamiliar_concepts)
-    if all_unfamiliar:
-        parts.append(f"- You are not familiar with: {', '.join(all_unfamiliar)}")
-
-    if persona.emotional_profile:
-        expanded = EMOTIONAL_PROFILE_DESCRIPTIONS.get(
-            persona.emotional_profile,
-            persona.emotional_profile,
-        )
-        parts.append(f"\nEmotional profile ({persona.emotional_profile}):\n{expanded}")
-
-    if persona.behavioral_rules:
-        parts.append("\nBehavioral rules (follow strictly):")
-        for rule in persona.behavioral_rules:
-            parts.append(f"  - {rule}")
-
-    parts.append(
-        "\nInteraction rules:\n"
-        "- 【If the tutor asks you a question, ANSWER IT FIRST before "
-        "asking your next question.】\n"
-        "- Respond naturally to what the tutor just said — acknowledge "
-        "what was helpful, react to results or output they show you, "
-        "and continue asking if your question wasn't addressed.\n"
-        "- Do not ask about concepts you are already familiar with. "
-        "During the conversation you may encounter topics beyond your "
-        "familiar list — react naturally based on your profile.\n"
-        "- If the tutor drifts from your question, bring it back. If "
-        "explanations are at the wrong level, say so directly.\n"
-        "- 【NEVER fabricate data, code, or files. If the tutor asks "
-        "you to upload or share anything, say you have no files.】\n"
-        "- You interact through TEXT-ONLY chat. You cannot upload files "
-        "or transfer data — the tutor has their own sandbox.\n"
-        "- You see the tutor's chat replies plus structured tool-call logs "
-        "summarizing sandbox actions, arguments, success flags, and results. "
-        "If the tutor mentions files or outputs absent from both the chat "
-        "and visible tool logs, ask once for the key content to be pasted. "
-        "Do not repeat a request the tutor already fulfilled."
+    """Compatibility entry point for reference user simulator prompts."""
+    return build_reference_user_description(
+        persona,
+        has_incremental_tc=has_incremental_tc,
     )
-
-    return "\n".join(parts)
 
 
 def build_scenario(

--- a/bench/server/core/session.py
+++ b/bench/server/core/session.py
@@ -20,11 +20,13 @@ Session status semantics
 """
 
 import base64
+from dataclasses import asdict, is_dataclass
 import json
 import logging
 import os
 import time
-from typing import Optional
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional
 
 from server.core.artifact_digest import build_visible_artifact_digest
 from server.core.workspace_delta import scan_workspace_snapshot
@@ -46,69 +48,147 @@ def _is_failed_reason(reason: str | None) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Session background builder — factual environment description, no directives
+# Session background builder
 # ---------------------------------------------------------------------------
 
 
-def build_background(task) -> str:
-    """Build a factual background description of the session environment.
+def _field(obj: Any, name: str, default: Any = None) -> Any:
+    if obj is None:
+        return default
+    if isinstance(obj, Mapping):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
 
-    Content is determined by what the container actually provides — derived
-    from task definition fields, not hardcoded per category.  Contains NO
-    behavioural directives or scoring hints.
-    """
-    env = task.environment if task.environment else None
-    sandbox_image = (
-        getattr(env, "sandbox_image_uri", None) or getattr(env, "sandbox_image", "") or ""
-    ) if env else ""
-    is_lean = "lean" in sandbox_image
-    has_user_code = bool(task.sample_code)
-    has_docs = bool(env.docs_available) if env else False
-    has_data = bool(
-        (env.data_files if env else None)
-        or (getattr(env, "data_mounts", None) if env else None)
-        or getattr(task, "series", None)
-        or getattr(task, "custom_data_key", None)
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if hasattr(value, "model_dump"):
+        return _jsonable(value.model_dump(mode="json"))
+    if is_dataclass(value):
+        return _jsonable(asdict(value))
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_jsonable(item) for item in value]
+    return str(value)
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def _sandbox_image(env: Any) -> str:
+    if env is None:
+        return ""
+    return str(
+        _field(env, "sandbox_image_uri") or _field(env, "sandbox_image", "") or ""
     )
 
-    parts: list[str] = [
-        "You are operating inside a sandboxed tutoring environment for "
-        "quantitative finance. A Python runtime with common data-science "
-        "packages is available.",
-        "To communicate with the user, you MUST use the send_message "
-        "tool. This is the only way your words reach the user. Your "
-        "text output outside of send_message is NOT visible to them. "
-        "The user receives structured summaries of your tool calls, "
-        "file operations, and command output. If you generate charts, "
-        "code files, or other artifacts that require full inspection, "
-        "include their file paths in the 'attachments' parameter of "
-        "send_message.",
+
+def _resource_limits(env: Any) -> dict[str, Any]:
+    if env is None:
+        return {}
+
+    limits = _field(env, "sandbox_resource_limits")
+    if not limits:
+        spec = _field(env, "sandbox_spec")
+        limits = _field(spec, "resource_limits", {}) if spec else {}
+
+    jsonable_limits = _jsonable(limits or {})
+    result = dict(jsonable_limits) if isinstance(jsonable_limits, Mapping) else {}
+    if _field(env, "network_enabled", False):
+        result.setdefault("network_enabled", True)
+    return result
+
+
+def _data_mount_fact(item: Any) -> dict[str, Any]:
+    fact: dict[str, Any] = {}
+    target_path = _field(item, "target_path")
+    if target_path:
+        fact["target_path"] = str(target_path)
+    fact["read_only"] = bool(_field(item, "read_only", True))
+    return fact
+
+
+def build_background(task) -> dict[str, Any]:
+    """Build JSON-able platform facts for the session environment."""
+    env = _field(task, "environment")
+    sandbox_image = _sandbox_image(env)
+    data_files = [str(item) for item in _as_list(_field(env, "data_files"))]
+    data_mounts = [
+        fact
+        for item in _as_list(_field(env, "data_mounts"))
+        if (fact := _data_mount_fact(item)).get("target_path")
+    ]
+    docs_available = [str(item) for item in _as_list(_field(env, "docs_available"))]
+    sample_code = _field(task, "sample_code")
+    legacy_data_sources = {
+        key: str(value)
+        for key in ("series", "custom_data_key")
+        if (value := _field(task, key))
+    }
+
+    has_user_code = bool(sample_code)
+    has_docs = bool(docs_available)
+    has_data = bool(data_files or data_mounts or legacy_data_sources)
+    systems: list[dict[str, Any]] = [
+        {
+            "name": "python_runtime",
+            "package_profile": "common_data_science",
+        }
     ]
 
-    if is_lean:
-        parts.append(
-            "An algorithmic trading engine is available in this environment. "
-            "You can compile and execute C# trading algorithms, run backtests "
-            "against historical market data, and inspect detailed results "
-            "including trade logs and performance metrics. Backtest executions "
-            "are tracked and budget-limited."
+    if "lean" in sandbox_image.lower():
+        systems.append(
+            {
+                "name": "algorithmic_trading_engine",
+                "language": "csharp",
+                "capabilities": [
+                    "compile_algorithms",
+                    "run_backtests",
+                    "inspect_trade_logs",
+                    "inspect_performance_metrics",
+                ],
+                "max_backtest_trials": int(_field(env, "max_backtest_trials", 0) or 0),
+            }
         )
 
-    if has_user_code:
-        parts.append("The user's existing code is mounted at /user_code/.")
-
-    if has_docs:
-        parts.append("Reference documentation is mounted at /docs/.")
-
-    if has_data:
-        parts.append("Market data files are pre-loaded at /data/.")
-
-    parts.append(
-        "Call get_environment_info for detailed directory listings, "
-        "available packages, and session constraints."
-    )
-
-    return "\n\n".join(parts)
+    return {
+        "schema_version": "platform_background.v1",
+        "domain": "quantitative_finance",
+        "sandbox": {
+            "image": sandbox_image,
+            "resource_limits": _resource_limits(env),
+        },
+        "systems": systems,
+        "mounts": {
+            "workspace": {"path": "/workspace", "present": True},
+            "user_code": {
+                "path": "/user_code",
+                "present": has_user_code,
+            },
+            "docs": {
+                "path": "/docs",
+                "present": has_docs,
+            },
+            "data": {
+                "path": "/data",
+                "present": has_data,
+                "mounts": data_mounts,
+            },
+        },
+        "tooling": {
+            "discovery": "MCP list_tools",
+            "schema_source": "Tool inputSchema returned by MCP list_tools",
+        },
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -337,8 +417,8 @@ class TutoringSession:
     def handle_start_session(self) -> str:
         """Start the session — return background + user's first message.
 
-        Returns {background, user_message}.  ``background`` is a factual
-        description of the environment (no directives, no scoring hints).
+        Returns {background, user_message}. ``background`` is a structured
+        platform fact object describing the environment.
         The client decides how to present it to the agent.
 
         Can only be called once per session.

--- a/bench/server/reference/__init__.py
+++ b/bench/server/reference/__init__.py
@@ -1,0 +1,13 @@
+"""Reference business prompt helpers for the server runtime."""
+
+from server.reference.prompts import (
+    EMOTIONAL_PROFILE_DESCRIPTIONS,
+    RefSystemPrompt,
+    build_reference_user_description,
+)
+
+__all__ = [
+    "EMOTIONAL_PROFILE_DESCRIPTIONS",
+    "RefSystemPrompt",
+    "build_reference_user_description",
+]

--- a/bench/server/reference/prompts.py
+++ b/bench/server/reference/prompts.py
@@ -1,0 +1,93 @@
+"""Reference NPC/user simulator prompt construction."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from config.prompt_config import flatten_concepts
+
+if TYPE_CHECKING:
+    from eval.contracts.schemas import UserPersona
+
+
+_PROFILES_PATH = (
+    Path(__file__).resolve().parents[2] / "personas" / "emotional_profiles.json"
+)
+EMOTIONAL_PROFILE_DESCRIPTIONS: dict[str, str] = (
+    json.loads(_PROFILES_PATH.read_text(encoding="utf-8"))
+    if _PROFILES_PATH.exists()
+    else {}
+)
+
+
+class RefSystemPrompt:
+    """Reference NPC/user simulator system prompt builder."""
+
+    @staticmethod
+    def build_user_description(
+        persona: UserPersona,
+        has_incremental_tc: bool = False,
+    ) -> str:
+        """Build the reference user simulator persona and behavior prompt."""
+        parts = [
+            f"Your profile: {persona.description}",
+        ]
+
+        all_familiar = flatten_concepts(persona.familiar_concepts)
+        if all_familiar:
+            parts.append(f"- You are familiar with: {', '.join(all_familiar)}")
+        all_unfamiliar = flatten_concepts(persona.unfamiliar_concepts)
+        if all_unfamiliar:
+            parts.append(f"- You are not familiar with: {', '.join(all_unfamiliar)}")
+
+        if persona.emotional_profile:
+            expanded = EMOTIONAL_PROFILE_DESCRIPTIONS.get(
+                persona.emotional_profile,
+                persona.emotional_profile,
+            )
+            parts.append(
+                f"\nEmotional profile ({persona.emotional_profile}):\n{expanded}"
+            )
+
+        if persona.behavioral_rules:
+            parts.append("\nBehavioral rules (follow strictly):")
+            for rule in persona.behavioral_rules:
+                parts.append(f"  - {rule}")
+
+        parts.append(
+            "\nInteraction rules:\n"
+            "- [If the tutor asks you a question, ANSWER IT FIRST before "
+            "asking your next question.]\n"
+            "- Respond naturally to what the tutor just said - acknowledge "
+            "what was helpful, react to results or output they show you, "
+            "and continue asking if your question wasn't addressed.\n"
+            "- Do not ask about concepts you are already familiar with. "
+            "During the conversation you may encounter topics beyond your "
+            "familiar list - react naturally based on your profile.\n"
+            "- If the tutor drifts from your question, bring it back. If "
+            "explanations are at the wrong level, say so directly.\n"
+            "- [NEVER fabricate data, code, or files. If the tutor asks "
+            "you to upload or share anything, say you have no files.]\n"
+            "- You interact through TEXT-ONLY chat. You cannot upload files "
+            "or transfer data - the tutor has their own sandbox.\n"
+            "- You see the tutor's chat replies plus structured tool-call logs "
+            "summarizing sandbox actions, arguments, success flags, and results. "
+            "If the tutor mentions files or outputs absent from both the chat "
+            "and visible tool logs, ask once for the key content to be pasted. "
+            "Do not repeat a request the tutor already fulfilled."
+        )
+
+        return "\n".join(parts)
+
+
+def build_reference_user_description(
+    persona: UserPersona,
+    has_incremental_tc: bool = False,
+) -> str:
+    """Build the reference user simulator persona and behavior prompt."""
+    return RefSystemPrompt.build_user_description(
+        persona,
+        has_incremental_tc=has_incremental_tc,
+    )

--- a/bench/tests/test_server_session_runtime.py
+++ b/bench/tests/test_server_session_runtime.py
@@ -119,22 +119,75 @@ class SessionContextTests(unittest.TestCase):
         from server.core.session import build_background
 
         task = SimpleNamespace(
-            sample_code=None,
+            sample_code="user_code/alpha_conflict.cs",
             series=None,
             custom_data_key=None,
             environment=SimpleNamespace(
                 sandbox_image="legacy:image",
                 sandbox_image_uri="spec:image-lean",
-                docs_available=[],
+                docs_available=["alpha_conflict_guide.md"],
                 data_files=[],
-                data_mounts=[{"target_path": "/data/lean"}],
+                data_mounts=[
+                    {
+                        "uri": "file:///secret/alpha_conflict_source",
+                        "target_path": "/data/lean",
+                        "read_only": True,
+                    }
+                ],
             ),
         )
 
         background = build_background(task)
 
-        self.assertIn("algorithmic trading engine", background)
-        self.assertIn("Market data files are pre-loaded", background)
+        json.dumps(background)
+        self.assertEqual(background["schema_version"], "platform_background.v1")
+        self.assertEqual(background["sandbox"]["image"], "spec:image-lean")
+        self.assertTrue(background["mounts"]["user_code"]["present"])
+        self.assertNotIn("source", background["mounts"]["user_code"])
+        self.assertTrue(background["mounts"]["docs"]["present"])
+        self.assertNotIn("files", background["mounts"]["docs"])
+        self.assertTrue(background["mounts"]["data"]["present"])
+        self.assertNotIn("files", background["mounts"]["data"])
+        self.assertEqual(
+            background["mounts"]["data"]["mounts"][0]["target_path"],
+            "/data/lean",
+        )
+        self.assertNotIn("uri", background["mounts"]["data"]["mounts"][0])
+        self.assertIn(
+            "algorithmic_trading_engine",
+            {system["name"] for system in background["systems"]},
+        )
+
+        raw = json.dumps(background)
+        for phrase in (
+            "If the tutor asks",
+            "send_message",
+            "MUST",
+            "Call get_environment_info",
+            "only way your words reach the user",
+            "alpha_conflict",
+            "file://",
+            "secret",
+        ):
+            self.assertNotIn(phrase, raw)
+
+    def test_reference_prompt_owns_user_behavior_rules(self):
+        from server.config.prompt_config import build_user_description
+        from server.reference.prompts import RefSystemPrompt
+
+        persona = SimpleNamespace(
+            description="Comfortable with Python and basic quant workflows.",
+            familiar_concepts=["returns"],
+            unfamiliar_concepts=["slippage"],
+            emotional_profile="",
+            behavioral_rules=["Ask for clarification when confused."],
+        )
+
+        prompt = build_user_description(persona)
+
+        self.assertEqual(prompt, RefSystemPrompt.build_user_description(persona))
+        self.assertIn("[If the tutor asks you a question", prompt)
+        self.assertIn("Ask for clarification when confused.", prompt)
 
     def test_sandbox_digest_preserves_legacy_network_flag(self):
         digest = _environment_sandbox_digest(

--- a/bench/tests/unit/test_mcp_tool_routing.py
+++ b/bench/tests/unit/test_mcp_tool_routing.py
@@ -180,8 +180,9 @@ class TestMCPGetBackground:
         await _register(session_state)
         await _start(session_state)
         results = await session_state.handle_tool_call("get_background", {})
-        text = results[0].text
-        assert "tutoring environment" in text.lower() or "send_message" in text
+        background = json.loads(results[0].text)
+        assert background["schema_version"] == "platform_background.v1"
+        assert background["mounts"]["workspace"]["path"] == "/workspace"
 
     @pytest.mark.asyncio
     async def test_get_background_before_start_denied(self, session_state):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,19 @@ first on `sys.path`.
   reference opening field, and `TUTOR_SYSTEM_PROMPT` as reference-internal
   prompt configuration.
 
+## Reference Prompt Boundary
+
+`bench/server/reference/` owns reference NPC/user-simulator prompt behavior.
+`RefSystemPrompt` builds persona, interaction, and visible tool-log behavior
+text for the reference simulator. `server.config.prompt_config` keeps existing
+server call sites stable through compatibility wrappers.
+
+`server.core.session.build_background()` returns a JSON-able
+`platform_background.v1` fact object for sandbox image, resource limits,
+systems, mounts, and MCP tool discovery metadata. Agent communication rules
+live in MCP tool descriptions such as `send_message`; reference persona
+behavior lives in `bench/server/reference/`.
+
 This v0 surface is internal and source-level. Stage 2 owns public SDK/docs,
 multi-tenant BYO image security, and formal schema/deprecation policy.
 


### PR DESCRIPTION
## Summary

- Replace prompt-text `build_background()` with sanitized `platform_background.v1` infra facts.
- Move reference user-simulator behavior text into `server.reference.RefSystemPrompt`.
- Keep server prompt config and client runner compatibility for the structured background shape.
- Document the reference prompt boundary.

## Verification

- `pytest bench/tests/api/test_session_lifecycle.py bench/tests/unit/test_protocol.py bench/tests/unit/test_mcp_tool_routing.py bench/tests/test_server_session_runtime.py -q`
- `.venv/bin/python -m py_compile bench/client/runner.py bench/server/core/session.py bench/server/reference/prompts.py`
- `git diff --check`

Closes #155
