### PR TITLE
feat(reference): package reference impl as platform plugin

### DIFF
--- a/bench/eval/storage/score_store.py
+++ b/bench/eval/storage/score_store.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
+import threading
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -16,6 +19,7 @@ except ImportError:  # pragma: no cover
 
 
 INDEX_VERSION = "2.0"
+_INDEX_THREAD_LOCK = threading.RLock()
 
 
 @dataclass
@@ -49,14 +53,15 @@ def _locked_index(result_dir: Path):
     root = _eval_root(result_dir)
     root.mkdir(parents=True, exist_ok=True)
     lock_path = root / ".lock"
-    with lock_path.open("a+", encoding="utf-8") as lock_file:
-        if fcntl is not None:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
+    with _INDEX_THREAD_LOCK:
+        with lock_path.open("a+", encoding="utf-8") as lock_file:
             if fcntl is not None:
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                if fcntl is not None:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def _empty_index() -> dict[str, Any]:
@@ -88,10 +93,26 @@ def load_index(result_dir: Path) -> dict[str, Any]:
 def save_index(result_dir: Path, index: dict[str, Any]) -> None:
     root = _eval_root(result_dir)
     root.mkdir(parents=True, exist_ok=True)
-    _index_path(result_dir).write_text(
-        json.dumps(index, indent=2, default=str),
-        encoding="utf-8",
-    )
+    payload = json.dumps(index, indent=2, default=str)
+    tmp_path: Path | None = None
+    with _INDEX_THREAD_LOCK:
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=root,
+                prefix=".index.",
+                suffix=".tmp",
+                delete=False,
+            ) as tmp:
+                tmp.write(payload)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+                tmp_path = Path(tmp.name)
+            tmp_path.replace(_index_path(result_dir))
+        finally:
+            if tmp_path is not None and tmp_path.exists():
+                tmp_path.unlink()
 
 
 def _entry_matches_status(

--- a/bench/server/__main__.py
+++ b/bench/server/__main__.py
@@ -10,6 +10,7 @@ Usage::
 
 import argparse
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -20,8 +21,29 @@ if str(_BENCH_ROOT) not in sys.path:
 
 from server.config.bootstrap import load_server_env
 from server.config.llm_config import EVAL_DEFAULT_MODEL
+from server.reference import REFERENCE_BUNDLE_CONFIG
 
 load_server_env(_BENCH_ROOT)
+
+
+def _load_plugin_bundle(config_path: str | Path, *, eval_model: str):
+    from platform_api.plugins import PluginLoader
+
+    bundles = PluginLoader().load_config(config_path)
+    if len(bundles) != 1:
+        raise RuntimeError(
+            f"Plugin config must define exactly one bundle: {config_path}"
+        )
+    bundle = bundles[0]
+    for component in (
+        bundle.task_suite,
+        bundle.npc_provider,
+        bundle.evaluator,
+    ):
+        configure = getattr(component, "configure", None)
+        if callable(configure):
+            configure(bench_root=_BENCH_ROOT, eval_model=eval_model)
+    return bundle
 
 
 def main():
@@ -50,6 +72,11 @@ def main():
         help=f"Model for LLM-based evaluation (default: {EVAL_DEFAULT_MODEL})",
     )
     parser.add_argument(
+        "--plugin-config",
+        default=os.environ.get("QTB_PLUGIN_CONFIG", str(REFERENCE_BUNDLE_CONFIG)),
+        help="Plugin bundle config path",
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -66,20 +93,23 @@ def main():
 
     from server.api.http_app import create_app
 
+    plugin_bundle = _load_plugin_bundle(args.plugin_config, eval_model=args.eval_model)
     app = create_app(
         use_docker=use_docker,
         bench_root=str(_BENCH_ROOT),
         eval_model=args.eval_model,
+        plugin_bundle=plugin_bundle,
     )
 
     import uvicorn
 
     logger = logging.getLogger(__name__)
     logger.info(
-        "Starting QuantTutorBench Server on %s:%d (docker=%s)",
+        "Starting QuantTutorBench Server on %s:%d (docker=%s, plugin=%s)",
         args.host,
         args.port,
         use_docker,
+        plugin_bundle.name,
     )
 
     uvicorn.run(app, host=args.host, port=args.port)

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -28,6 +28,7 @@ import anyio
 from mcp.server import Server
 from mcp.server.streamable_http import StreamableHTTPServerTransport
 from mcp.types import TextContent
+from platform_api.plugins import PluginBundle
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import FileResponse, JSONResponse, Response
@@ -38,6 +39,7 @@ from server.audit import record_event
 from server.config.bootstrap import load_server_env
 from server.config.llm_config import EVAL_DEFAULT_MODEL
 from server.quota import QuotaExceeded, QuotaManager
+from server.reference import load_reference_bundle
 from server.run import JobStore, RunService, RunStore, TaskCatalog
 from server.run.jobs import (
     JOB_STATUS_COMPLETED,
@@ -242,12 +244,17 @@ class BenchSessionManager:
         use_docker: bool = True,
         bench_root: str | Path | None = None,
         eval_model: str = EVAL_DEFAULT_MODEL,
+        plugin_bundle: PluginBundle | None = None,
     ):
         self.use_docker = use_docker
         self.bench_root = (
             Path(bench_root) if bench_root else Path(__file__).parent.parent.parent
         )
         self.eval_model = eval_model
+        self.plugin_bundle = plugin_bundle or load_reference_bundle(
+            bench_root=self.bench_root,
+            eval_model=eval_model,
+        )
 
         self._sessions: dict[str, SessionState] = {}
         self._transports: dict[str, StreamableHTTPServerTransport] = {}
@@ -597,6 +604,7 @@ class BenchSessionManager:
             use_docker=self.use_docker,
             bench_root=self.bench_root,
             eval_model=self.eval_model,
+            plugin_bundle=self.plugin_bundle,
         )
         # Bind to Run
         state.run_id = run.run_id
@@ -982,6 +990,7 @@ class BenchSessionManager:
             bench_root=self.bench_root,
             use_docker=self.use_docker,
             eval_model=self.eval_model,
+            plugin_bundle=self.plugin_bundle,
         )
         state._on_completed = lambda result_dir: self._run_service.mark_completed(
             run.run_id, result_dir
@@ -1012,6 +1021,7 @@ class BenchSessionManager:
             use_docker=self.use_docker,
             bench_root=self.bench_root,
             eval_model=self.eval_model,
+            plugin_bundle=self.plugin_bundle,
         )
         return state
 
@@ -1042,6 +1052,7 @@ class BenchSessionManager:
             result_dir=result_dir,
             bench_root=self.bench_root,
             eval_model=self.eval_model,
+            plugin_bundle=self.plugin_bundle,
         )
         # Cache in memory so subsequent calls don't re-read from disk
         self._sessions[session_id] = state
@@ -2375,6 +2386,7 @@ def create_app(
     use_docker: bool = True,
     bench_root: str | Path | None = None,
     eval_model: str = EVAL_DEFAULT_MODEL,
+    plugin_bundle: PluginBundle | None = None,
 ) -> _ServerApp:
     """Create the QuantTutorBench ASGI application."""
     load_server_env(bench_root)
@@ -2382,6 +2394,7 @@ def create_app(
         use_docker=use_docker,
         bench_root=bench_root,
         eval_model=eval_model,
+        plugin_bundle=plugin_bundle,
     )
 
     @contextlib.asynccontextmanager

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -3,7 +3,7 @@
 Each MCP HTTP session maps to one ``SessionState`` instance that manages:
 - Task + persona loading (random persona selection)
 - Container + tool setup
-- TutoringSession lifecycle (user simulation, termination checking)
+- Session lifecycle (user simulation, termination checking)
 - Result saving (run_state.json + agent_files/)
 - Internal evaluation triggering (background thread; server/operator only)
 
@@ -32,8 +32,11 @@ from typing import TYPE_CHECKING, Optional
 
 import anyio
 from mcp.types import TextContent, Tool
+from platform_api.contracts import EvalItem, EvalSample, ToolLog, TranscriptMessage
+from platform_api.plugins import PluginBundle
 
 from server.config.llm_config import EVAL_DEFAULT_MODEL
+from server.reference import load_reference_bundle
 
 if TYPE_CHECKING:
     from mcp.server import Server
@@ -282,15 +285,23 @@ class SessionState:
         use_docker: bool = True,
         bench_root: Optional[Path] = None,
         eval_model: str = EVAL_DEFAULT_MODEL,
+        plugin_bundle: PluginBundle | None = None,
     ):
         self.session_id = session_id
         self.phase = SessionPhase.UNREGISTERED
         self.use_docker = use_docker
-        self.bench_root = bench_root or Path(__file__).parent.parent.parent
+        self.bench_root = (
+            Path(bench_root) if bench_root else Path(__file__).parent.parent.parent
+        )
         self.eval_model = eval_model
+        self.plugin_bundle = plugin_bundle or load_reference_bundle(
+            bench_root=self.bench_root,
+            eval_model=eval_model,
+        )
 
         # Task state (set during register)
         self.task = None
+        self.eval_item: EvalItem | None = None
         self.persona = None
         self.task_id: str = ""
         self.persona_id: str = ""
@@ -299,7 +310,7 @@ class SessionState:
 
         # Runtime components (set during register)
         self.proxy = None
-        self.session = None  # TutoringSession
+        self.session = None  # Session
         self.container_manager = None
         self.container = None
         self.user_sim = None
@@ -364,6 +375,7 @@ class SessionState:
         result_dir: Path,
         bench_root: Path,
         eval_model: str = EVAL_DEFAULT_MODEL,
+        plugin_bundle: PluginBundle | None = None,
     ) -> "SessionState":
         """Restore a COMPLETED session from server storage (run_state.json).
 
@@ -388,6 +400,7 @@ class SessionState:
             use_docker=False,
             bench_root=bench_root,
             eval_model=eval_model,
+            plugin_bundle=plugin_bundle,
         )
 
         # Load task and persona from server data store
@@ -455,6 +468,7 @@ class SessionState:
         bench_root: Path,
         use_docker: bool,
         eval_model: str = EVAL_DEFAULT_MODEL,
+        plugin_bundle: PluginBundle | None = None,
     ) -> "SessionState":
         """Restore an ACTIVE session from results/runs/{run_id}/run_state.json."""
         run_state = json.loads(Path(state_path).read_text(encoding="utf-8"))
@@ -467,6 +481,7 @@ class SessionState:
             use_docker=use_docker,
             bench_root=bench_root,
             eval_model=eval_model,
+            plugin_bundle=plugin_bundle,
         )
         state.run_id = str(run_state.get("run_id") or "")
         state._run_task_id = task_id
@@ -594,30 +609,36 @@ class SessionState:
         """Handle ``register_session(task_id, persona_id?)``.
 
         Heavy operation: loads task, selects persona, creates container,
-        registers tools, creates TutoringSession. If ``persona_id`` is
+        registers tools, creates Session. If ``persona_id`` is
         provided, it overrides the default random persona selection.
 
         """
         from server.config.benchmark_config import DATASET_REVISION
         from server.config.bootstrap import load_server_env
         from server.config.llm_config import SIMULATOR_DEFAULT_MODEL
-        from server.config.prompt_config import build_scenario, build_user_description
         from server.core.container import ContainerManager
         from server.core.proxy import MCPProxy
         from server.core.registry import populate_proxy_for_task
-        from server.core.session import TutoringSession
+        from server.core.session import Session
         from server.core.staging import create_staged_dirs, create_staged_sample_code
-        from server.core.user_sim import UserSimulator, require_user_model
+        from server.core.user_sim import require_user_model
         from server.data_manager import ensure_data
 
         self._closed = False
 
         try:
-            task = self._load_task(task_id)
-            if task is None:
+            try:
+                eval_item = self.plugin_bundle.task_suite.get_task(task_id)
+                task = self._task_from_eval_item(eval_item)
+            except Exception:
+                logger.exception("Plugin task lookup failed for %s", task_id)
+                eval_item = None
+                task = None
+            if task is None or eval_item is None:
                 return {"error": f"Task not found: {task_id}"}
 
             self.task = task
+            self.eval_item = eval_item
             self.task_id = task_id
             self._task_core_tool_names = tuple(_effective_core_tool_names(task))
             self._task_convenient_tool_names = tuple(
@@ -660,12 +681,19 @@ class SessionState:
             self.persona_id = selected_persona_id
 
             load_server_env(self.bench_root)
-            try:
-                resolved_sim_model = require_user_model(
-                    SIMULATOR_DEFAULT_MODEL,
-                )
-            except RuntimeError as exc:
-                return {"error": str(exc)}
+            build_user_simulator = getattr(
+                self.plugin_bundle.npc_provider,
+                "build_user_simulator",
+                None,
+            )
+            resolved_sim_model = None
+            if callable(build_user_simulator):
+                try:
+                    resolved_sim_model = require_user_model(
+                        SIMULATOR_DEFAULT_MODEL,
+                    )
+                except RuntimeError as exc:
+                    return {"error": str(exc)}
 
             sandbox_img = _environment_sandbox_image(task.environment)
             series = "lean" if sandbox_img and "lean" in sandbox_img else "normal"
@@ -762,16 +790,13 @@ class SessionState:
                 env_overrides=local_tool_env,
             )
 
-            self.user_sim = UserSimulator(
-                scenario=build_scenario(
-                    task, self.persona_id, has_incremental_tc=False
-                ),
-                user_description=build_user_description(
+            self.user_sim = None
+            if callable(build_user_simulator):
+                self.user_sim = build_user_simulator(
+                    task,
                     self.persona,
-                    has_incremental_tc=False,
-                ),
-                model=resolved_sim_model,
-            )
+                    model=resolved_sim_model,
+                )
 
             effective_timeout = task.timeout_minutes
             deadline = None
@@ -779,7 +804,7 @@ class SessionState:
                 deadline = time.time() + effective_timeout * 60
             self.proxy.set_deadline(deadline)
 
-            self.session = TutoringSession(
+            self.session = Session(
                 task=task,
                 persona=persona,
                 user_sim=self.user_sim,
@@ -787,6 +812,8 @@ class SessionState:
                 deadline=deadline,
                 proxy=self.proxy,
                 workspace_path=self.container.workspace_path,
+                npc_provider=self.plugin_bundle.npc_provider,
+                eval_item=eval_item,
             )
 
             # Keep protocol traffic in raw logs; downstream reports decide what to hide.
@@ -883,7 +910,7 @@ class SessionState:
         delivered to the user.
 
         Returns:
-            Raw JSON string from TutoringSession (via proxy).
+            Raw JSON string from Session (via proxy).
         """
         if self._closed:
             return json.dumps({"error": "Session is closed", "status": "closed"})
@@ -1545,6 +1572,7 @@ class SessionState:
                 if (path := self._active_workspace_snapshot_path()) and path.exists()
                 else ""
             ),
+            "plugin_bundle": getattr(self.plugin_bundle, "name", ""),
         }
 
     def _persist_active_state(self, *, force_snapshot: bool = False) -> Path | None:
@@ -1647,26 +1675,28 @@ class SessionState:
         to avoid races with ``request_evaluation`` reads.
         """
         try:
-            from server.storage.eval_writer import run_evaluation
-
             if not self._result_dir:
                 raise RuntimeError("No result_dir — session results not saved")
 
-            conversation = self.session.conversation
-            tool_logs = self.proxy.get_logs()
-            distractor_names = self.proxy.get_distractor_names()
-
-            eval_results = run_evaluation(
-                task=self.task,
-                persona=self.persona,
-                result_dir=self._result_dir,
-                conversation=conversation,
-                tool_logs=tool_logs,
-                distractor_names=distractor_names,
-                bench_root=str(self.bench_root),
-                eval_model=self.eval_model,
-                eval_mode=self._eval_mode,
-                score_id=score_id,
+            eval_item = self.eval_item
+            if eval_item is None:
+                eval_item = self.plugin_bundle.task_suite.get_task(self.task_id)
+                self.eval_item = eval_item
+            sample = self._build_eval_sample(score_id)
+            score = self.plugin_bundle.evaluator.evaluate(eval_item, sample)
+            summary = (
+                score.metrics.get("summary")
+                if isinstance(score.metrics, dict)
+                else None
+            )
+            eval_results = (
+                dict(summary)
+                if isinstance(summary, dict)
+                else {
+                    "score_status": score.status,
+                    "overall_score": score.value,
+                    "reason": score.reason,
+                }
             )
 
             with self._eval_lock:
@@ -1830,6 +1860,7 @@ class SessionState:
                 exc_info=True,
             )
         self.task = None
+        self.eval_item = None
         self.persona = None
         self.task_id = ""
         self.persona_id = ""
@@ -1850,12 +1881,113 @@ class SessionState:
 
     def _load_task(self, task_id: str):
         """Load task JSON by ID."""
+        try:
+            return self._task_from_eval_item(
+                self.plugin_bundle.task_suite.get_task(task_id)
+            )
+        except Exception:
+            pass
+
         from eval.contracts.schemas import QuantTutorTask
 
         tasks_dir = self.bench_root / "tasks"
         for json_path in tasks_dir.rglob(f"{task_id}.json"):
             return QuantTutorTask(**json.loads(json_path.read_text()))
         return None
+
+    def _task_from_eval_item(self, eval_item: EvalItem):
+        """Extract the reference business task from an EvalItem envelope."""
+        get_business_task = getattr(
+            self.plugin_bundle.task_suite,
+            "get_business_task",
+            None,
+        )
+        if callable(get_business_task):
+            return get_business_task(eval_item.task_id)
+
+        from eval.contracts.schemas import QuantTutorTask
+
+        raw = eval_item.payload.get("quant_tutor_task")
+        if hasattr(raw, "model_dump"):
+            return raw
+        if isinstance(raw, dict):
+            return QuantTutorTask(**raw)
+        return None
+
+    def _build_eval_sample(self, score_id: str) -> EvalSample:
+        """Build a platform EvalSample from the completed session state."""
+        conversation = self.session.conversation if self.session else []
+        transcript = tuple(
+            TranscriptMessage(
+                role=str(entry.get("role") or ""),
+                content=str(entry.get("content") or ""),
+                ts=(
+                    entry.get("ts")
+                    if isinstance(entry.get("ts"), (int, float))
+                    else None
+                ),
+                metadata={
+                    key: value
+                    for key, value in entry.items()
+                    if key not in {"role", "content", "ts"}
+                },
+            )
+            for entry in conversation
+        )
+        raw_tool_logs = self.proxy.get_logs() if self.proxy else []
+        tool_logs = tuple(
+            log
+            for raw in raw_tool_logs
+            if (log := self._contract_tool_log(raw)) is not None
+        )
+        workspace_path = (
+            self.container.workspace_path
+            if self.container
+            else str(self._result_dir / "agent_files") if self._result_dir else ""
+        )
+        payload = {
+            "task": self.task,
+            "persona": self.persona,
+            "result_dir": str(self._result_dir) if self._result_dir else "",
+            "workspace_path": workspace_path,
+            "eval_model": self.eval_model,
+            "eval_mode": self._eval_mode,
+            "score_id": score_id,
+            "session_id": self.session_id,
+            "distractor_names": (
+                self.proxy.get_distractor_names() if self.proxy is not None else []
+            ),
+        }
+        return EvalSample(
+            sample_id=score_id,
+            task_id=self.task_id,
+            transcript=transcript,
+            tool_logs=tool_logs,
+            files={},
+            payload=payload,
+        )
+
+    @staticmethod
+    def _contract_tool_log(raw) -> ToolLog | None:
+        data = _safe_tool_log_dict(raw)
+        name = str(data.get("name") or data.get("tool_name") or "")
+        if not name:
+            return None
+        args = data.get("args") or {}
+        if not isinstance(args, dict):
+            args = {"value": args}
+        metadata = data.get("metadata") or {}
+        if not isinstance(metadata, dict):
+            metadata = {}
+        return ToolLog(
+            name=name,
+            args=args,
+            result=str(data.get("result") or ""),
+            success=bool(data.get("success", True)),
+            duration_ms=float(data.get("duration_ms") or 0.0),
+            turn_index=int(data.get("turn_index") or 0),
+            metadata=metadata,
+        )
 
     def _load_persona(self, persona_id: str):
         """Load persona JSON by ID."""

--- a/bench/server/core/session.py
+++ b/bench/server/core/session.py
@@ -28,6 +28,7 @@ import time
 from collections.abc import Mapping, Sequence
 from typing import Any, Optional
 
+from platform_api.contracts import EvalItem, NPCProvider, ToolLog, TranscriptMessage
 from server.core.artifact_digest import build_visible_artifact_digest
 from server.core.workspace_delta import scan_workspace_snapshot
 
@@ -354,11 +355,11 @@ def _resolve_attachments(
 
 
 # ---------------------------------------------------------------------------
-# TutoringSession
+# Session
 # ---------------------------------------------------------------------------
 
 
-class TutoringSession:
+class Session:
     """Manages a single tutoring session.
 
     The agent interacts with the user exclusively through
@@ -379,6 +380,8 @@ class TutoringSession:
         deadline: Optional[float] = None,
         proxy=None,
         workspace_path: Optional[str] = None,
+        npc_provider: NPCProvider | None = None,
+        eval_item: EvalItem | None = None,
     ):
         self._task = task
         self._persona = persona
@@ -387,6 +390,8 @@ class TutoringSession:
         self._deadline = deadline
         self._proxy = proxy  # For set_turn() calls
         self._workspace_path = workspace_path
+        self._npc_provider = npc_provider
+        self._eval_item = eval_item
 
         self._conversation: list[dict[str, str]] = []
         self._turn: int = 0
@@ -608,15 +613,9 @@ class TutoringSession:
 
         # ── Generate user reply ──  (aligned: generate_next_user_input)
         try:
-            reply, task_end = self._user_sim.generate_message(
-                self._conversation,
-                runtime_guidance=self._build_user_runtime_guidance(
-                    text,
-                    artifact_digest,
-                ),
-                file_ledger=self._file_ledger,
-                tool_logs=(self._proxy.get_logs() if self._proxy is not None else []),
-                workspace_path=self._workspace_path,
+            reply, task_end = self._generate_user_reply(
+                latest_agent_text=text,
+                artifact_digest=artifact_digest,
             )
         except Exception as exc:
             from server.core.user_sim import UserSimError
@@ -944,8 +943,92 @@ class TutoringSession:
             ]
         )
 
+    def _generate_user_reply(
+        self,
+        *,
+        latest_agent_text: str,
+        artifact_digest: Optional[dict] = None,
+    ) -> tuple[str, bool]:
+        runtime_guidance = self._build_user_runtime_guidance(
+            latest_agent_text,
+            artifact_digest,
+        )
+        tool_logs = self._proxy.get_logs() if self._proxy is not None else []
+        if self._npc_provider is None:
+            return self._user_sim.generate_message(
+                self._conversation,
+                runtime_guidance=runtime_guidance,
+                file_ledger=self._file_ledger,
+                tool_logs=tool_logs,
+                workspace_path=self._workspace_path,
+            )
+
+        payload = {
+            "task": self._task,
+            "persona": self._persona,
+            "user_sim": self._user_sim,
+            "runtime_guidance": runtime_guidance,
+            "file_ledger": self._file_ledger,
+            "workspace_path": self._workspace_path,
+        }
+        if self._eval_item is not None:
+            payload.update(self._eval_item.payload)
+        npc_reply = self._npc_provider.respond(
+            self._transcript_messages(),
+            self._contract_tool_logs(tool_logs),
+            {},
+            payload,
+        )
+        return npc_reply.message, bool(npc_reply.terminate)
+
+    def _transcript_messages(self) -> tuple[TranscriptMessage, ...]:
+        return tuple(
+            TranscriptMessage(
+                role=str(entry.get("role") or ""),
+                content=str(entry.get("content") or ""),
+                ts=(
+                    entry.get("ts")
+                    if isinstance(entry.get("ts"), (int, float))
+                    else None
+                ),
+                metadata={
+                    key: value
+                    for key, value in entry.items()
+                    if key not in {"role", "content", "ts"}
+                },
+            )
+            for entry in self._conversation
+        )
+
+    def _contract_tool_logs(self, logs: Sequence[Any]) -> tuple[ToolLog, ...]:
+        converted: list[ToolLog] = []
+        for log in logs or []:
+            name = str(_field(log, "name") or _field(log, "tool_name") or "")
+            if not name:
+                continue
+            args = _field(log, "args", {})
+            if not isinstance(args, Mapping):
+                args = {"value": args}
+            metadata = _field(log, "metadata", {})
+            if not isinstance(metadata, Mapping):
+                metadata = {}
+            converted.append(
+                ToolLog(
+                    name=name,
+                    args=dict(args),
+                    result=str(_field(log, "result", "") or ""),
+                    success=bool(_field(log, "success", True)),
+                    duration_ms=float(_field(log, "duration_ms", 0.0) or 0.0),
+                    turn_index=int(_field(log, "turn_index", 0) or 0),
+                    metadata=dict(metadata),
+                )
+            )
+        return tuple(converted)
+
     def _safe_closing(self) -> str:
         """Select a pre-written user closing message."""
+        if self._user_sim is None:
+            return "Thanks, I have what I need now."
         return self._user_sim.generate_closing(self._conversation)
 
     def inject_user_opening(self, opening: str) -> None:
@@ -962,5 +1045,10 @@ class TutoringSession:
 
     def _get_user_opening(self) -> str:
         """Get the opening message for this task."""
+        if self._npc_provider is not None and self._eval_item is not None:
+            return self._npc_provider.initial_message(self._eval_item)
         opening = getattr(self._task, "user_opening", "")
         return opening or "Hi, I need help with this topic."
+
+
+TutoringSession = Session

--- a/bench/server/core/session.py
+++ b/bench/server/core/session.py
@@ -28,7 +28,13 @@ import time
 from collections.abc import Mapping, Sequence
 from typing import Any, Optional
 
-from platform_api.contracts import EvalItem, NPCProvider, ToolLog, TranscriptMessage
+from platform_api.contracts import (
+    EvalItem,
+    FileArtifact,
+    NPCProvider,
+    ToolLog,
+    TranscriptMessage,
+)
 from server.core.artifact_digest import build_visible_artifact_digest
 from server.core.workspace_delta import scan_workspace_snapshot
 
@@ -968,7 +974,6 @@ class Session:
             "persona": self._persona,
             "user_sim": self._user_sim,
             "runtime_guidance": runtime_guidance,
-            "file_ledger": self._file_ledger,
             "workspace_path": self._workspace_path,
         }
         if self._eval_item is not None:
@@ -976,10 +981,28 @@ class Session:
         npc_reply = self._npc_provider.respond(
             self._transcript_messages(),
             self._contract_tool_logs(tool_logs),
-            {},
+            self._file_artifacts(),
             payload,
         )
         return npc_reply.message, bool(npc_reply.terminate)
+
+    def _file_artifacts(self) -> dict[str, FileArtifact]:
+        artifacts: dict[str, FileArtifact] = {}
+        for name, entry in self._file_ledger.items():
+            content = entry.get("current_content")
+            artifacts[name] = FileArtifact(
+                path=str(entry.get("path") or name),
+                content=content,
+                size=len(content) if isinstance(content, (str, bytes)) else None,
+                media_type=str(entry.get("media_type") or ""),
+                metadata={
+                    "prev_content": entry.get("prev_content"),
+                    "prev_turn": entry.get("prev_turn"),
+                    "current_turn": entry.get("current_turn"),
+                    "is_image": bool(entry.get("is_image")),
+                },
+            )
+        return artifacts
 
     def _transcript_messages(self) -> tuple[TranscriptMessage, ...]:
         return tuple(

--- a/bench/server/reference/__init__.py
+++ b/bench/server/reference/__init__.py
@@ -1,5 +1,9 @@
-"""Reference business prompt helpers for the server runtime."""
+"""Reference business helpers for the server runtime."""
 
+from server.reference.bundle_loader import (
+    REFERENCE_BUNDLE_CONFIG,
+    load_reference_bundle,
+)
 from server.reference.prompts import (
     EMOTIONAL_PROFILE_DESCRIPTIONS,
     RefSystemPrompt,
@@ -8,6 +12,8 @@ from server.reference.prompts import (
 
 __all__ = [
     "EMOTIONAL_PROFILE_DESCRIPTIONS",
+    "REFERENCE_BUNDLE_CONFIG",
     "RefSystemPrompt",
     "build_reference_user_description",
+    "load_reference_bundle",
 ]

--- a/bench/server/reference/audit_diff.py
+++ b/bench/server/reference/audit_diff.py
@@ -1,0 +1,86 @@
+"""Compare legacy and reference-bundle audit JSONL streams."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _event_key(event: dict[str, Any], fields: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(str(event.get(field) or "") for field in fields)
+
+
+def load_events(path: str | Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        if isinstance(payload, dict):
+            events.append(payload)
+    return events
+
+
+def compare_events(
+    legacy_events: list[dict[str, Any]],
+    bundle_events: list[dict[str, Any]],
+    *,
+    key_fields: tuple[str, ...] = ("session_id", "action"),
+) -> dict[str, Any]:
+    legacy = {_event_key(event, key_fields): event for event in legacy_events}
+    bundle = {_event_key(event, key_fields): event for event in bundle_events}
+    legacy_keys = set(legacy)
+    bundle_keys = set(bundle)
+    shared = sorted(legacy_keys & bundle_keys)
+    mismatched: list[dict[str, Any]] = []
+
+    for key in shared:
+        legacy_payload = legacy[key].get("payload") or {}
+        bundle_payload = bundle[key].get("payload") or {}
+        if legacy_payload != bundle_payload:
+            mismatched.append(
+                {
+                    "key": key,
+                    "legacy_payload": legacy_payload,
+                    "bundle_payload": bundle_payload,
+                }
+            )
+
+    return {
+        "key_fields": list(key_fields),
+        "legacy_count": len(legacy_events),
+        "bundle_count": len(bundle_events),
+        "shared_count": len(shared),
+        "missing_in_bundle": [list(key) for key in sorted(legacy_keys - bundle_keys)],
+        "extra_in_bundle": [list(key) for key in sorted(bundle_keys - legacy_keys)],
+        "payload_mismatches": mismatched,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare legacy and reference-bundle audit JSONL files."
+    )
+    parser.add_argument("legacy_jsonl")
+    parser.add_argument("bundle_jsonl")
+    parser.add_argument(
+        "--key-field",
+        action="append",
+        default=[],
+        help="Event field used to pair rows; repeat for compound keys.",
+    )
+    args = parser.parse_args()
+    key_fields = tuple(args.key_field or ["session_id", "action"])
+    report = compare_events(
+        load_events(args.legacy_jsonl),
+        load_events(args.bundle_jsonl),
+        key_fields=key_fields,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/server/reference/bundle.json
+++ b/bench/server/reference/bundle.json
@@ -1,0 +1,14 @@
+{
+  "plugins": [
+    {
+      "name": "reference",
+      "task_suite": "server.reference.task_suite:ReferenceTaskSuite",
+      "npc_provider": "server.reference.npc_provider:ReferenceNPCProvider",
+      "evaluator": "server.reference.evaluator:ReferenceEvaluator",
+      "metadata": {
+        "business_schema": "QuantTutorTask",
+        "version": "1.0"
+      }
+    }
+  ]
+}

--- a/bench/server/reference/bundle_loader.py
+++ b/bench/server/reference/bundle_loader.py
@@ -1,0 +1,33 @@
+"""Reference bundle loading helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from platform_api.plugins import PluginBundle, PluginLoader
+
+
+REFERENCE_BUNDLE_CONFIG = Path(__file__).with_name("bundle.json")
+
+
+def load_reference_bundle(
+    *,
+    bench_root: str | Path | None = None,
+    eval_model: str | None = None,
+    config_path: str | Path | None = None,
+) -> PluginBundle:
+    """Load the reference PluginBundle and configure runtime-local paths."""
+
+    bundles = PluginLoader().load_config(config_path or REFERENCE_BUNDLE_CONFIG)
+    if len(bundles) != 1:
+        raise RuntimeError("Reference bundle config must define exactly one plugin")
+    bundle = bundles[0]
+    for component in (
+        bundle.task_suite,
+        bundle.npc_provider,
+        bundle.evaluator,
+    ):
+        configure = getattr(component, "configure", None)
+        if callable(configure):
+            configure(bench_root=bench_root, eval_model=eval_model)
+    return bundle

--- a/bench/server/reference/evaluator.py
+++ b/bench/server/reference/evaluator.py
@@ -96,6 +96,14 @@ def _score_status(value: float | None) -> str:
     return "completed_scored" if value is not None else "completed_not_computable"
 
 
+def _enum_value(value: Any) -> str:
+    return str(getattr(value, "value", value) or "")
+
+
+def _task_layer(task: QuantTutorTask) -> str:
+    return _enum_value(getattr(task, "layer", ""))
+
+
 class ReferenceEvaluator(Evaluator):
     """Composite reference evaluator for platform plugin execution."""
 
@@ -120,14 +128,13 @@ class ReferenceEvaluator(Evaluator):
 
     def evaluate(self, item: EvalItem, sample: EvalSample) -> Score:
         task = _task_from_item(item)
-        task_type = str(
-            item.task_type or getattr(task.task_type, "value", task.task_type) or ""
-        )
+        task_type = str(item.task_type or _enum_value(task.task_type))
+        layer = _task_layer(task)
         eval_model = str(sample.payload.get("eval_model") or self.eval_model or "")
 
-        if task_type in {"knowledge_qa", "l0"}:
+        if layer == "L0" or task_type in {"knowledge_qa", "l0"}:
             result = knowledge_qa.evaluate(
-                question=task.description,
+                question=task.question or task.description,
                 reference_answer=task.reference_answer or "",
                 actual_output=_latest_assistant_output(sample),
                 context=task.context,
@@ -139,10 +146,11 @@ class ReferenceEvaluator(Evaluator):
                 eval_model=eval_model,
             )
 
-        if task_type == "single_turn":
+        if layer == "L1" or task_type in {"agent_execution", "single_turn"}:
             result = l1_verifier.evaluate(
                 task=task,
                 actual_output=_latest_assistant_output(sample),
+                workspace_path=str(sample.payload.get("workspace_path") or ""),
                 eval_model=eval_model,
             )
             return self._score_single_track(

--- a/bench/server/reference/evaluator.py
+++ b/bench/server/reference/evaluator.py
@@ -1,0 +1,392 @@
+"""Reference Evaluator adapter for Layer 1 and Layer 2 tasks."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from eval.contracts.output import EvalOutput, TrackResult
+from eval.contracts.schemas import QuantTutorTask, UserPersona
+from eval.judge_reliability import build_judge_reliability_metadata
+from eval.storage.score_store import allocate_score_run, load_index
+from platform_api.contracts import (
+    EvalItem,
+    EvalSample,
+    Evaluator,
+    EvaluatorMetadata,
+    Score,
+)
+from server.reference import knowledge_qa, l1_verifier
+
+
+def _default_bench_root() -> Path:
+    env_root = os.environ.get("QTB_BENCH_ROOT", "").strip()
+    if env_root:
+        return Path(env_root)
+    return Path(__file__).resolve().parents[2]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if is_dataclass(value):
+        return asdict(value)
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    if hasattr(value, "__dict__"):
+        return {str(key): _jsonable(item) for key, item in vars(value).items()}
+    return str(value)
+
+
+def _task_from_item(item: EvalItem) -> QuantTutorTask:
+    raw = item.payload.get("quant_tutor_task")
+    if isinstance(raw, QuantTutorTask):
+        return raw
+    if isinstance(raw, Mapping):
+        return QuantTutorTask(**raw)
+    raise ValueError("EvalItem payload is missing quant_tutor_task")
+
+
+def _persona_from_payload(payload: Mapping[str, Any]) -> UserPersona | None:
+    raw = payload.get("persona")
+    if isinstance(raw, UserPersona):
+        return raw
+    if isinstance(raw, Mapping):
+        return UserPersona(**raw)
+    return None
+
+
+def _transcript_as_conversation(sample: EvalSample) -> list[dict[str, Any]]:
+    return [
+        {
+            "role": message.role,
+            "content": message.content,
+            **({"ts": message.ts} if message.ts is not None else {}),
+            **({"metadata": dict(message.metadata)} if message.metadata else {}),
+        }
+        for message in sample.transcript
+    ]
+
+
+def _latest_assistant_output(sample: EvalSample) -> str:
+    for message in reversed(sample.transcript):
+        if message.role == "assistant":
+            return message.content
+    value = sample.payload.get("actual_output")
+    return str(value or "")
+
+
+def _tool_logs(sample: EvalSample) -> list[Any]:
+    return [_jsonable(log) for log in sample.tool_logs]
+
+
+def _score_status(value: float | None) -> str:
+    return "completed_scored" if value is not None else "completed_not_computable"
+
+
+class ReferenceEvaluator(Evaluator):
+    """Composite reference evaluator for platform plugin execution."""
+
+    def __init__(
+        self,
+        bench_root: str | Path | None = None,
+        eval_model: str | None = None,
+    ) -> None:
+        self.bench_root = Path(bench_root) if bench_root else _default_bench_root()
+        self.eval_model = eval_model
+
+    def configure(
+        self,
+        *,
+        bench_root: str | Path | None = None,
+        eval_model: str | None = None,
+    ) -> None:
+        if bench_root is not None:
+            self.bench_root = Path(bench_root)
+        if eval_model is not None:
+            self.eval_model = eval_model
+
+    def evaluate(self, item: EvalItem, sample: EvalSample) -> Score:
+        task = _task_from_item(item)
+        task_type = str(
+            item.task_type or getattr(task.task_type, "value", task.task_type) or ""
+        )
+        eval_model = str(sample.payload.get("eval_model") or self.eval_model or "")
+
+        if task_type in {"knowledge_qa", "l0"}:
+            result = knowledge_qa.evaluate(
+                question=task.description,
+                reference_answer=task.reference_answer or "",
+                actual_output=_latest_assistant_output(sample),
+                context=task.context,
+            )
+            return self._score_single_track(
+                track="knowledge_qa",
+                result=result,
+                sample=sample,
+                eval_model=eval_model,
+            )
+
+        if task_type == "single_turn":
+            result = l1_verifier.evaluate(
+                task=task,
+                actual_output=_latest_assistant_output(sample),
+                eval_model=eval_model,
+            )
+            return self._score_single_track(
+                track="layer1",
+                result=result,
+                sample=sample,
+                eval_model=eval_model,
+            )
+
+        return self._score_layer2(
+            item=item,
+            sample=sample,
+            task=task,
+            eval_model=eval_model or None,
+        )
+
+    def metadata(self) -> EvaluatorMetadata:
+        return EvaluatorMetadata(
+            evaluator_id="reference",
+            version="1.0",
+            supported_tasks=frozenset(),
+            required_bundle_fields=frozenset(
+                {
+                    "conversation",
+                    "tool_logs",
+                    "workspace_path",
+                    "result_dir",
+                    "persona",
+                }
+            ),
+            score_schema={
+                "value": "overall score in [0, 1]",
+                "metrics": "per-track evaluator output",
+            },
+            capabilities=frozenset({"knowledge_qa", "layer1", "qr", "qp"}),
+        )
+
+    def _score_single_track(
+        self,
+        *,
+        track: str,
+        result: dict[str, Any],
+        sample: EvalSample,
+        eval_model: str | None,
+    ) -> Score:
+        value = result.get("score")
+        score_value = float(value) if value is not None else None
+        status = _score_status(score_value)
+        summary = self._persist_single_track(
+            track=track,
+            result=result,
+            sample=sample,
+            eval_model=eval_model,
+            score_value=score_value,
+            status=status,
+        )
+        return Score(
+            value=score_value,
+            status=status,
+            metrics={track: result, "summary": summary},
+            reason=str(result.get("reason") or ""),
+            evidence=tuple(str(item) for item in result.get("evidence", []) or ()),
+        )
+
+    def _persist_single_track(
+        self,
+        *,
+        track: str,
+        result: dict[str, Any],
+        sample: EvalSample,
+        eval_model: str | None,
+        score_value: float | None,
+        status: str,
+    ) -> dict[str, Any]:
+        result_dir_value = sample.payload.get("result_dir")
+        if not result_dir_value:
+            return {
+                "score_status": status,
+                "overall_score": score_value,
+                track: score_value,
+            }
+
+        result_dir = Path(str(result_dir_value))
+        result_dir.mkdir(parents=True, exist_ok=True)
+        if not (result_dir / "run_state.json").exists():
+            (result_dir / "run_state.json").write_text(
+                json.dumps(
+                    {
+                        "task_id": sample.task_id,
+                        "conversation": _transcript_as_conversation(sample),
+                        "tool_logs": _tool_logs(sample),
+                    },
+                    indent=2,
+                    default=str,
+                ),
+                encoding="utf-8",
+            )
+
+        requested_score_id = str(sample.payload.get("score_id") or sample.sample_id)
+        score_id, created_at = self._prepare_score_run(
+            result_dir=result_dir,
+            requested_score_id=requested_score_id,
+            eval_mode=track,
+            eval_model=eval_model,
+        )
+        now = _utc_now()
+        track_result = TrackResult(
+            track=track,
+            score=score_value,
+            status="success" if score_value is not None else "not_computable",
+            detail=result,
+            blocking_missing=[] if score_value is not None else [result],
+        )
+        output = EvalOutput(
+            score_id=score_id,
+            score_status=status,
+            qr=track_result,
+            qp=None,
+            overall_score=score_value,
+            eval_mode=track,
+            eval_model=eval_model,
+            created_at=created_at,
+            completed_at=now,
+            duration_seconds=0.0,
+            judge_reliability=build_judge_reliability_metadata(eval_model),
+            blocking_missing=track_result.blocking_missing,
+            preflight={},
+        )
+        from eval.core.coordinator import persist_eval_output
+
+        return persist_eval_output(result_dir, output)
+
+    def _score_layer2(
+        self,
+        *,
+        item: EvalItem,
+        sample: EvalSample,
+        task: QuantTutorTask,
+        eval_model: str | None,
+    ) -> Score:
+        persona = _persona_from_payload(sample.payload)
+        if persona is None:
+            raise ValueError("Layer 2 reference evaluation requires persona")
+
+        result_dir_value = sample.payload.get("result_dir")
+        result_dir = Path(str(result_dir_value)) if result_dir_value else None
+        requested_score_id = str(sample.payload.get("score_id") or sample.sample_id)
+        eval_mode = str(sample.payload.get("eval_mode") or "full")
+        conversation = _transcript_as_conversation(sample)
+        tool_logs = _tool_logs(sample)
+        run_state = {
+            "conversation": conversation,
+            "tool_logs": tool_logs,
+            "distractor_names": list(sample.payload.get("distractor_names") or []),
+            "task_id": task.task_id,
+            "persona_id": persona.persona_id,
+            "workspace_path": sample.payload.get("workspace_path") or "",
+        }
+
+        if result_dir is None:
+            from eval.core.coordinator import evaluate_tracks
+
+            metrics = evaluate_tracks(
+                task=task,
+                persona=persona,
+                workspace_path=str(run_state["workspace_path"] or "."),
+                conversation=conversation,
+                tool_logs=tool_logs,
+                distractor_names=list(run_state["distractor_names"]),
+                bench_root=str(self.bench_root),
+                eval_model=eval_model or "",
+                eval_mode=eval_mode,
+            )
+            value = metrics.get("overall_score")
+            if value is None:
+                from eval.core.scoring import compute_overall
+
+                value = compute_overall(
+                    {"score": metrics.get("quant_result")},
+                    {"score": metrics.get("quant_process")},
+                    eval_mode=eval_mode,
+                )
+                metrics["overall_score"] = value
+            return Score(
+                value=float(value) if value is not None else None,
+                status="scored" if value is not None else "not_computable",
+                metrics=metrics,
+            )
+
+        from server.storage.eval_writer import run_evaluation
+
+        score_id, _created_at = self._prepare_score_run(
+            result_dir=result_dir,
+            requested_score_id=requested_score_id,
+            eval_mode=eval_mode,
+            eval_model=eval_model,
+        )
+        summary = run_evaluation(
+            task=task,
+            persona=persona,
+            result_dir=result_dir,
+            conversation=conversation,
+            tool_logs=tool_logs,
+            distractor_names=list(run_state["distractor_names"]),
+            bench_root=str(self.bench_root),
+            eval_model=eval_model or "",
+            eval_mode=eval_mode,
+            score_id=score_id,
+        )
+        value = summary.get("overall_score", summary.get("overall"))
+        return Score(
+            value=float(value) if value is not None else None,
+            status=str(summary.get("score_status") or "scored"),
+            metrics={"summary": summary},
+        )
+
+    @staticmethod
+    def _prepare_score_run(
+        *,
+        result_dir: Path,
+        requested_score_id: str,
+        eval_mode: str,
+        eval_model: str | None,
+    ) -> tuple[str, str]:
+        try:
+            index = load_index(result_dir)
+            entry = next(
+                (
+                    item
+                    for item in index.get("scores", [])
+                    if item.get("score_id") == requested_score_id
+                ),
+                {},
+            )
+            if entry:
+                return (
+                    str(entry.get("score_id")),
+                    str(entry.get("created_at") or _utc_now()),
+                )
+            run, _created = allocate_score_run(
+                result_dir,
+                eval_mode=eval_mode,
+                eval_model=eval_model,
+            )
+            return run.score_id, run.created_at
+        except Exception:
+            return requested_score_id, _utc_now()

--- a/bench/server/reference/knowledge_qa.py
+++ b/bench/server/reference/knowledge_qa.py
@@ -1,0 +1,59 @@
+"""Small deterministic scorer for reference single-answer QA checks."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        token
+        for token in _TOKEN_RE.findall(text.lower())
+        if len(token) > 2 and token not in {"the", "and", "for", "with", "that"}
+    }
+
+
+def evaluate(
+    *,
+    question: str,
+    reference_answer: str,
+    actual_output: str,
+    context: str | None = None,
+) -> dict[str, Any]:
+    """Score an answer against a reference answer with transparent overlap."""
+
+    if not actual_output.strip():
+        return {
+            "score": 0.0,
+            "status": "failed",
+            "reason": "empty output",
+            "evidence": [],
+        }
+
+    reference_tokens = _tokens(reference_answer)
+    output_tokens = _tokens(actual_output)
+    if not reference_tokens:
+        return {
+            "score": 0.5,
+            "status": "skipped",
+            "reason": "reference answer unavailable",
+            "evidence": [],
+            "required_for_track_score": False,
+        }
+
+    overlap = reference_tokens & output_tokens
+    recall = len(overlap) / len(reference_tokens)
+    precision = len(overlap) / max(len(output_tokens), 1)
+    score = min(1.0, round((0.75 * recall + 0.25 * precision) * 1.25, 4))
+    return {
+        "score": score,
+        "status": "success",
+        "reason": f"reference token recall={recall:.2%}, precision={precision:.2%}",
+        "evidence": sorted(overlap)[:20],
+        "question": question,
+        "context_present": bool(context),
+    }

--- a/bench/server/reference/l1_verifier.py
+++ b/bench/server/reference/l1_verifier.py
@@ -8,16 +8,45 @@ from eval.contracts.schemas import QuantTutorTask
 from server.reference import knowledge_qa
 
 
+def _enum_value(value: Any) -> str:
+    return str(getattr(value, "value", value) or "")
+
+
+def _expected_outputs(task: QuantTutorTask) -> list:
+    gt = task.ground_truth
+    return list(getattr(gt, "expected_outputs", []) or [])
+
+
 def evaluate(
     *,
     task: QuantTutorTask,
     actual_output: str,
+    workspace_path: str | None = None,
     eval_model: str | None = None,
 ) -> dict[str, Any]:
     """Evaluate a Layer 1 answer using the deterministic reference scorer."""
 
+    task_type = _enum_value(task.task_type)
+    expected_outputs = _expected_outputs(task)
+    if task_type == "agent_execution" or expected_outputs:
+        from eval.programmatic.l1_verifier import evaluate as evaluate_outputs
+
+        result = evaluate_outputs(
+            workspace_path or ".",
+            expected_outputs=expected_outputs,
+        )
+        result.update(
+            {
+                "task_id": task.task_id,
+                "category": _enum_value(task.category),
+                "difficulty": _enum_value(task.difficulty),
+                "eval_model": eval_model,
+            }
+        )
+        return result
+
     result = knowledge_qa.evaluate(
-        question=task.description,
+        question=task.question or task.description,
         reference_answer=task.reference_answer or "",
         actual_output=actual_output,
         context=task.context,
@@ -25,8 +54,8 @@ def evaluate(
     result.update(
         {
             "task_id": task.task_id,
-            "category": task.category.value,
-            "difficulty": task.difficulty.value,
+            "category": _enum_value(task.category),
+            "difficulty": _enum_value(task.difficulty),
             "eval_model": eval_model,
         }
     )

--- a/bench/server/reference/l1_verifier.py
+++ b/bench/server/reference/l1_verifier.py
@@ -1,0 +1,33 @@
+"""Reference Layer 1 verifier used by the platform evaluator adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from eval.contracts.schemas import QuantTutorTask
+from server.reference import knowledge_qa
+
+
+def evaluate(
+    *,
+    task: QuantTutorTask,
+    actual_output: str,
+    eval_model: str | None = None,
+) -> dict[str, Any]:
+    """Evaluate a Layer 1 answer using the deterministic reference scorer."""
+
+    result = knowledge_qa.evaluate(
+        question=task.description,
+        reference_answer=task.reference_answer or "",
+        actual_output=actual_output,
+        context=task.context,
+    )
+    result.update(
+        {
+            "task_id": task.task_id,
+            "category": task.category.value,
+            "difficulty": task.difficulty.value,
+            "eval_model": eval_model,
+        }
+    )
+    return result

--- a/bench/server/reference/npc_provider.py
+++ b/bench/server/reference/npc_provider.py
@@ -43,6 +43,24 @@ def _conversation_from_transcript(
     return conversation
 
 
+def _file_ledger_from_artifacts(
+    files: Mapping[str, FileArtifact],
+) -> dict[str, dict[str, Any]]:
+    ledger: dict[str, dict[str, Any]] = {}
+    for name, artifact in files.items():
+        metadata = dict(artifact.metadata or {})
+        ledger[str(name)] = {
+            "prev_content": metadata.get("prev_content"),
+            "prev_turn": metadata.get("prev_turn"),
+            "current_content": artifact.content,
+            "current_turn": metadata.get("current_turn"),
+            "is_image": bool(metadata.get("is_image")),
+            "media_type": artifact.media_type,
+            "path": artifact.path,
+        }
+    return ledger
+
+
 class ReferenceNPCProvider(NPCProvider):
     """Thin NPCProvider wrapper around UserSimulator and reference prompts."""
 
@@ -90,9 +108,7 @@ class ReferenceNPCProvider(NPCProvider):
         reply, task_end = user_sim.generate_message(
             _conversation_from_transcript(transcript),
             runtime_guidance=str(payload.get("runtime_guidance") or ""),
-            file_ledger=payload.get("file_ledger")
-            if isinstance(payload, Mapping)
-            else None,
+            file_ledger=_file_ledger_from_artifacts(files),
             tool_logs=list(tool_logs),
             workspace_path=str(payload.get("workspace_path") or "") or None,
         )

--- a/bench/server/reference/npc_provider.py
+++ b/bench/server/reference/npc_provider.py
@@ -1,0 +1,105 @@
+"""Reference NPCProvider adapter backed by the existing user simulator."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from eval.contracts.schemas import QuantTutorTask, UserPersona
+from platform_api.contracts import (
+    EvalItem,
+    FileArtifact,
+    NPCProvider,
+    NPCReply,
+    ToolLog,
+    TranscriptMessage,
+)
+from server.config.prompt_config import build_scenario
+from server.core.user_sim import UserSimulator
+from server.reference.prompts import build_reference_user_description
+
+
+def _task_from_payload(payload: Mapping[str, Any]) -> QuantTutorTask:
+    raw = payload.get("quant_tutor_task")
+    if isinstance(raw, QuantTutorTask):
+        return raw
+    if isinstance(raw, Mapping):
+        return QuantTutorTask(**raw)
+    raise ValueError("Reference NPC payload is missing quant_tutor_task")
+
+
+def _conversation_from_transcript(
+    transcript: Sequence[TranscriptMessage],
+) -> list[dict[str, Any]]:
+    conversation: list[dict[str, Any]] = []
+    for message in transcript:
+        entry = {
+            "role": message.role,
+            "content": message.content,
+            **({"ts": message.ts} if message.ts is not None else {}),
+        }
+        entry.update(message.metadata)
+        conversation.append(entry)
+    return conversation
+
+
+class ReferenceNPCProvider(NPCProvider):
+    """Thin NPCProvider wrapper around UserSimulator and reference prompts."""
+
+    def initial_message(self, task: EvalItem) -> str:
+        business_task = _task_from_payload(task.payload)
+        return business_task.user_opening or "Hi, I need help with this topic."
+
+    def build_user_simulator(
+        self,
+        task: QuantTutorTask,
+        persona: UserPersona,
+        *,
+        model=None,
+    ) -> UserSimulator:
+        return UserSimulator(
+            scenario=build_scenario(task, persona.persona_id, has_incremental_tc=False),
+            user_description=build_reference_user_description(
+                persona,
+                has_incremental_tc=False,
+            ),
+            model=model,
+        )
+
+    def respond(
+        self,
+        transcript: Sequence[TranscriptMessage],
+        tool_logs: Sequence[ToolLog],
+        files: Mapping[str, FileArtifact],
+        payload: Mapping[str, object],
+    ) -> NPCReply:
+        task = payload.get("task")
+        persona = payload.get("persona")
+        user_sim = payload.get("user_sim")
+        if not isinstance(task, QuantTutorTask):
+            task = _task_from_payload(payload)
+        if not hasattr(user_sim, "generate_message"):
+            if not isinstance(persona, UserPersona):
+                raise ValueError("Reference NPC payload is missing persona")
+            user_sim = self.build_user_simulator(
+                task,
+                persona,
+                model=payload.get("model"),
+            )
+
+        reply, task_end = user_sim.generate_message(
+            _conversation_from_transcript(transcript),
+            runtime_guidance=str(payload.get("runtime_guidance") or ""),
+            file_ledger=payload.get("file_ledger")
+            if isinstance(payload, Mapping)
+            else None,
+            tool_logs=list(tool_logs),
+            workspace_path=str(payload.get("workspace_path") or "") or None,
+        )
+        return NPCReply(
+            message=reply,
+            terminate=task_end,
+            reason="user_satisfied" if task_end else "",
+            payload={"task_end": task_end},
+            telemetry={"simulator_cost": getattr(user_sim, "total_cost", 0.0)},
+        )

--- a/bench/server/reference/task_suite.py
+++ b/bench/server/reference/task_suite.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from config.benchmark_config import BENCH_IMAGE_V3, BENCH_IMAGE_V3_LEAN
 from eval.contracts.schemas import QuantTutorTask
 from platform_api.contracts import DataMount, EvalItem, SandboxSpec, TaskSuite
 from server.config.benchmark_config import DATASET_REPO_ID, DATASET_REVISION
@@ -17,7 +18,13 @@ _CODE_CATEGORIES = {
     "code_debugging",
     "implementation",
     "end_to_end",
+    "alpha_research",
+    "backtest_engine",
+    "data_engineering",
+    "debug",
+    "diagnostic",
 }
+_V3_LEAN_CATEGORIES = {"implementation"}
 
 
 def _default_bench_root() -> Path:
@@ -216,9 +223,14 @@ class ReferenceTaskSuite(TaskSuite):
             )
 
         category = _enum_value(task.category)
-        image = (
-            "quant-tutor-env:v2.2-lean"
-            if category in _CODE_CATEGORIES or task.requires_code
-            else "quant-tutor-env:v2.2"
-        )
+        if _enum_value(getattr(task, "layer", "")) in {"L1", "L2"}:
+            image = (
+                BENCH_IMAGE_V3_LEAN
+                if category in _V3_LEAN_CATEGORIES
+                else BENCH_IMAGE_V3
+            )
+        elif category in _CODE_CATEGORIES or task.requires_code:
+            image = BENCH_IMAGE_V3_LEAN
+        else:
+            image = BENCH_IMAGE_V3
         return SandboxSpec(image_uri=image, resource_limits={})

--- a/bench/server/reference/task_suite.py
+++ b/bench/server/reference/task_suite.py
@@ -1,0 +1,224 @@
+"""Reference task suite adapter for the platform plugin API."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from eval.contracts.schemas import QuantTutorTask
+from platform_api.contracts import DataMount, EvalItem, SandboxSpec, TaskSuite
+from server.config.benchmark_config import DATASET_REPO_ID, DATASET_REVISION
+
+
+_CODE_CATEGORIES = {
+    "code_generation",
+    "code_debugging",
+    "implementation",
+    "end_to_end",
+}
+
+
+def _default_bench_root() -> Path:
+    env_root = os.environ.get("QTB_BENCH_ROOT", "").strip()
+    if env_root:
+        return Path(env_root)
+    return Path(__file__).resolve().parents[2]
+
+
+def _enum_value(value: Any) -> str:
+    return str(getattr(value, "value", value) or "")
+
+
+def _jsonable_task(task: QuantTutorTask) -> dict[str, Any]:
+    return task.model_dump(mode="json")
+
+
+class ReferenceTaskSuite(TaskSuite):
+    """Bridge reference QuantTutor task JSONs into EvalItem envelopes."""
+
+    def __init__(self, bench_root: str | Path | None = None) -> None:
+        self.bench_root = Path(bench_root) if bench_root else _default_bench_root()
+        self._task_paths: dict[str, Path] | None = None
+        self._task_cache: dict[str, QuantTutorTask] = {}
+
+    def configure(
+        self,
+        *,
+        bench_root: str | Path | None = None,
+        eval_model: str | None = None,
+    ) -> None:
+        if bench_root is not None:
+            self.bench_root = Path(bench_root)
+            self._task_paths = None
+            self._task_cache.clear()
+
+    def supported_tasks(self) -> set[str]:
+        return set(self._index_task_paths())
+
+    def get_task(self, task_id: str) -> EvalItem:
+        task = self.get_business_task(task_id)
+        env = task.environment
+        metadata = {
+            "business_schema": "QuantTutorTask",
+            "difficulty": _enum_value(task.difficulty),
+            "category": _enum_value(task.category),
+            "requires_code": bool(task.requires_code),
+            "requires_tool": bool(task.requires_tool),
+        }
+        return EvalItem(
+            task_id=task.task_id,
+            version=task.version,
+            task_type=_enum_value(task.task_type),
+            payload={"quant_tutor_task": _jsonable_task(task)},
+            metadata=metadata,
+            data_mounts=self._translate_environment_mounts(env, task=task),
+            sandbox_spec=self._sandbox_spec_for_task(task),
+        )
+
+    def get_business_task(self, task_id: str) -> QuantTutorTask:
+        if task_id in self._task_cache:
+            return self._task_cache[task_id]
+        paths = self._index_task_paths()
+        path = paths.get(task_id)
+        if path is None:
+            raise KeyError(f"Task not found: {task_id}")
+        task = QuantTutorTask(**json.loads(path.read_text(encoding="utf-8")))
+        self._task_cache[task_id] = task
+        return task
+
+    def required_bundle_fields(self) -> set[str]:
+        return {
+            "conversation",
+            "tool_logs",
+            "workspace_path",
+            "result_dir",
+            "persona",
+        }
+
+    def _index_task_paths(self) -> dict[str, Path]:
+        if self._task_paths is None:
+            tasks_dir = self.bench_root / "tasks"
+            self._task_paths = {
+                path.stem: path for path in sorted(tasks_dir.rglob("*.json"))
+            }
+        return self._task_paths
+
+    def _translate_environment_mounts(
+        self,
+        env: Any,
+        *,
+        task: QuantTutorTask,
+    ) -> tuple[DataMount, ...]:
+        if env is None:
+            return ()
+
+        mounts: list[DataMount] = []
+        for raw_mount in getattr(env, "data_mounts", []) or []:
+            payload = (
+                raw_mount.model_dump(mode="json")
+                if hasattr(raw_mount, "model_dump")
+                else dict(raw_mount)
+            )
+            mounts.append(
+                DataMount(
+                    uri=str(payload["uri"]),
+                    target_path=str(payload["target_path"]),
+                    read_only=bool(payload.get("read_only", True)),
+                )
+            )
+
+        for data_file in getattr(env, "data_files", []) or []:
+            data_file_text = str(data_file)
+            path = PurePosixPath(data_file_text)
+            target_name = path.name or data_file_text.strip("/").replace("/", "_")
+            source = self._resolve_data_file(data_file_text, task=task)
+            uri = (
+                f"file://{source.resolve().as_posix()}"
+                if source is not None
+                else self._remote_data_uri(data_file_text)
+            )
+            mounts.append(
+                DataMount(
+                    uri=uri,
+                    target_path=f"/data/{target_name}",
+                    read_only=True,
+                )
+            )
+        return tuple(mounts)
+
+    def _data_search_roots(self, *, task: QuantTutorTask) -> tuple[Path, ...]:
+        data_root = self.bench_root / "data"
+        normal_root = data_root / "hf_cache" / "normal"
+        roots = [
+            normal_root / "BDEX",
+            normal_root / "A",
+            self.bench_root / "runtime_assets" / "lean" / "data",
+            data_root / "custom",
+            data_root / "hf_cache",
+            data_root,
+        ]
+        if "lean" in self._sandbox_spec_for_task(task).image_uri:
+            lean_root = self.bench_root / "runtime_assets" / "lean" / "data"
+            roots = [lean_root, *[root for root in roots if root != lean_root]]
+        return tuple(dict.fromkeys(root for root in roots))
+
+    def _resolve_data_file(
+        self,
+        data_file: str,
+        *,
+        task: QuantTutorTask,
+    ) -> Path | None:
+        raw = data_file.strip()
+        if not raw:
+            return None
+        direct = Path(raw).expanduser()
+        if direct.is_absolute() and direct.is_file():
+            return direct
+
+        rel = Path(*PurePosixPath(raw).parts)
+        rels = [rel]
+        if rel.name and rel.name != raw:
+            rels.append(Path(rel.name))
+
+        for root in self._data_search_roots(task=task):
+            for relative in rels:
+                candidate = root / relative
+                if candidate.is_file():
+                    return candidate
+        return None
+
+    @staticmethod
+    def _remote_data_uri(data_file: str) -> str:
+        raw = data_file.strip().lstrip("/")
+        name = PurePosixPath(raw).name or raw
+        if raw.startswith("adversarial/") or name in {
+            "malicious_backtest.py",
+            "portfolio_data_poisoned.csv",
+        }:
+            subpath = f"A/{name}"
+        elif name == "universe.json":
+            subpath = name
+        else:
+            subpath = f"BDS/{name}"
+        return (
+            f"hf://{DATASET_REPO_ID}@{DATASET_REVISION}/{subpath}"
+            "?repo_type=dataset"
+        )
+
+    def _sandbox_spec_for_task(self, task: QuantTutorTask) -> SandboxSpec:
+        env = task.environment
+        if env is not None:
+            return SandboxSpec(
+                image_uri=env.sandbox_image_uri,
+                resource_limits=env.sandbox_resource_limits,
+            )
+
+        category = _enum_value(task.category)
+        image = (
+            "quant-tutor-env:v2.2-lean"
+            if category in _CODE_CATEGORIES or task.requires_code
+            else "quant-tutor-env:v2.2"
+        )
+        return SandboxSpec(image_uri=image, resource_limits={})

--- a/bench/tests/integration/test_reference_bundle.py
+++ b/bench/tests/integration/test_reference_bundle.py
@@ -1,0 +1,405 @@
+import json
+
+from eval.contracts.schemas import QuantTutorTask, UserPersona
+from platform_api.contracts import (
+    EvalItem,
+    EvalSample,
+    FileArtifact,
+    NPCProvider,
+    NPCReply,
+    ToolLog,
+    TranscriptMessage,
+)
+from platform_api.plugins import PluginBundle
+from platform_api.runtime import DataMountResolver
+from server.api.session_api import SessionState
+from server.reference import load_reference_bundle
+
+
+def _task_from_item(item: EvalItem) -> QuantTutorTask:
+    return QuantTutorTask(**item.payload["quant_tutor_task"])
+
+
+def _load_persona(bench_root, persona_id: str) -> UserPersona:
+    path = bench_root / "personas" / f"{persona_id}.json"
+    return UserPersona(**json.loads(path.read_text(encoding="utf-8")))
+
+
+def test_reference_task_suite_bridges_quant_tutor_task(bench_root):
+    data_dir = bench_root / "data" / "hf_cache" / "normal" / "BDEX"
+    data_dir.mkdir(parents=True)
+    (data_dir / "AAPL_2018_2024.csv").write_text("Date,Close\n", encoding="utf-8")
+    (data_dir / "SPY_2018_2024.csv").write_text("Date,Close\n", encoding="utf-8")
+    bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+
+    item = bundle.task_suite.get_task("D01_load_inspect_ohlcv")
+
+    assert item.task_type == "multi_turn"
+    assert item.version == "2.2"
+    assert item.payload["quant_tutor_task"]["task_id"] == "D01_load_inspect_ohlcv"
+    assert {mount.target_path for mount in item.data_mounts} == {
+        "/data/AAPL_2018_2024.csv",
+        "/data/SPY_2018_2024.csv",
+    }
+    resolved = DataMountResolver().resolve_all(item.data_mounts)
+    assert {mount.container_path for mount in resolved} == {
+        "/data/AAPL_2018_2024.csv",
+        "/data/SPY_2018_2024.csv",
+    }
+    assert item.sandbox_spec.image_uri == "quant-tutor-env:v2.2"
+
+
+def test_reference_task_suite_emits_hf_uri_without_local_cache(bench_root):
+    bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+
+    item = bundle.task_suite.get_task("D01_load_inspect_ohlcv")
+
+    uris = {mount.target_path: mount.uri for mount in item.data_mounts}
+    assert (
+        uris["/data/SPY_2018_2024.csv"]
+        == "hf://Varsity-Tech/quant-tutor-bench-data@"
+        "793bca3f8dc70d379d423358f4159eca2d8be83f/BDS/SPY_2018_2024.csv"
+        "?repo_type=dataset"
+    )
+
+
+def test_reference_npc_provider_propagates_task_end(bench_root):
+    bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+    item = bundle.task_suite.get_task("D01_load_inspect_ohlcv")
+    task = _task_from_item(item)
+    persona = _load_persona(bench_root, task.persona_id)
+
+    class FakeUserSim:
+        total_cost = 0.0
+
+        def generate_message(self, *args, **kwargs):
+            return "That covers what I needed. Thanks.", True
+
+    reply = bundle.npc_provider.respond(
+        (
+            TranscriptMessage(role="user", content=task.user_opening),
+            TranscriptMessage(role="assistant", content="Here is the inspection."),
+        ),
+        (),
+        {},
+        {
+            **item.payload,
+            "task": task,
+            "persona": persona,
+            "user_sim": FakeUserSim(),
+        },
+    )
+
+    assert reply.terminate is True
+    assert reply.reason == "user_satisfied"
+
+
+def test_reference_npc_provider_preserves_attachment_metadata(bench_root):
+    bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+    item = bundle.task_suite.get_task("D01_load_inspect_ohlcv")
+    task = _task_from_item(item)
+    persona = _load_persona(bench_root, task.persona_id)
+    seen = {}
+
+    class FakeUserSim:
+        total_cost = 0.0
+
+        def generate_message(self, conversation, *args, **kwargs):
+            seen["conversation"] = conversation
+            return "I can see the file.", False
+
+    bundle.npc_provider.respond(
+        (
+            TranscriptMessage(
+                role="assistant",
+                content="See attached.",
+                metadata={
+                    "attachments": [
+                        {
+                            "filename": "analysis.txt",
+                            "content": "alpha",
+                            "is_image": False,
+                        }
+                    ]
+                },
+            ),
+        ),
+        (),
+        {},
+        {
+            **item.payload,
+            "task": task,
+            "persona": persona,
+            "user_sim": FakeUserSim(),
+        },
+    )
+
+    assert seen["conversation"][0]["attachments"][0]["filename"] == "analysis.txt"
+
+
+def test_session_state_accepts_contract_only_npc_provider(bench_root):
+    reference = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+
+    class ContractOnlyNPC(NPCProvider):
+        def initial_message(self, task: EvalItem) -> str:
+            return "generic opening"
+
+        def respond(
+            self,
+            transcript: tuple[TranscriptMessage, ...],
+            tool_logs: tuple[ToolLog, ...],
+            files: dict[str, FileArtifact],
+            payload: dict[str, object],
+        ) -> NPCReply:
+            return NPCReply("generic reply", terminate=True, reason="done")
+
+    bundle = PluginBundle(
+        name="contract-only",
+        task_suite=reference.task_suite,
+        npc_provider=ContractOnlyNPC(),
+        evaluator=reference.evaluator,
+    )
+    state = SessionState(
+        session_id="contract-only-session",
+        use_docker=False,
+        bench_root=bench_root,
+        eval_model="fake-model",
+        plugin_bundle=bundle,
+    )
+    try:
+        result = state.register("D01_load_inspect_ohlcv")
+        assert result["session_id"] == "contract-only-session"
+        assert state.user_sim is None
+        started = state.start()
+        assert started["user_message"] == "generic opening"
+        sent = json.loads(state.handle_send_message("Finished."))
+        assert sent["user_message"] == "generic reply"
+        assert sent["status"] == "completed"
+    finally:
+        state.cleanup()
+
+
+def test_session_state_resolves_simulator_before_container(
+    bench_root,
+    monkeypatch,
+):
+    reference = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+    state = SessionState(
+        session_id="sim-model-error",
+        use_docker=False,
+        bench_root=bench_root,
+        eval_model="fake-model",
+        plugin_bundle=reference,
+    )
+    created = {"container": False}
+
+    def fail_model(*args, **kwargs):
+        raise RuntimeError("missing simulator model")
+
+    def create_container(*args, **kwargs):
+        created["container"] = True
+        raise AssertionError("container allocation should be skipped")
+
+    monkeypatch.setattr("server.core.user_sim.require_user_model", fail_model)
+    monkeypatch.setattr(
+        "server.core.container.ContainerManager.create_container",
+        create_container,
+    )
+
+    result = state.register("D01_load_inspect_ohlcv")
+
+    assert result == {"error": "missing simulator model"}
+    assert created["container"] is False
+
+
+def test_restore_from_storage_reuses_configured_bundle(bench_root, tmp_path):
+    reference = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+    bundle = PluginBundle(
+        name="restore-bundle",
+        task_suite=reference.task_suite,
+        npc_provider=reference.npc_provider,
+        evaluator=reference.evaluator,
+    )
+    result_dir = tmp_path / "result"
+    result_dir.mkdir()
+    (result_dir / "run_state.json").write_text(
+        json.dumps(
+            {
+                "task_id": "D01_load_inspect_ohlcv",
+                "persona_id": "double_novice",
+                "conversation": [],
+                "tool_logs": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    state = SessionState.restore_from_storage(
+        session_id="restored-session",
+        result_dir=result_dir,
+        bench_root=bench_root,
+        eval_model="fake-model",
+        plugin_bundle=bundle,
+    )
+
+    assert state.plugin_bundle.name == "restore-bundle"
+
+
+def test_reference_evaluator_scores_l0_and_l1(bench_root):
+    bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+    item = bundle.task_suite.get_task("money.stackexchange_2")
+    task = _task_from_item(item)
+    sample = EvalSample(
+        sample_id="sample-l1",
+        task_id=item.task_id,
+        transcript=(
+            TranscriptMessage(role="user", content=task.description),
+            TranscriptMessage(role="assistant", content=task.reference_answer or ""),
+        ),
+        payload={"eval_model": "fake-model"},
+    )
+
+    l1_score = bundle.evaluator.evaluate(item, sample)
+    l0_score = bundle.evaluator.evaluate(
+        EvalItem(
+            task_id=item.task_id,
+            task_type="knowledge_qa",
+            payload=item.payload,
+        ),
+        sample,
+    )
+
+    assert l1_score.value == 1.0
+    assert l1_score.metrics["layer1"]["status"] == "success"
+    assert l0_score.value == 1.0
+    assert l0_score.metrics["knowledge_qa"]["status"] == "success"
+
+
+def test_reference_evaluator_allocates_direct_persisted_score(bench_root, tmp_path):
+    bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+    item = bundle.task_suite.get_task("money.stackexchange_2")
+    task = _task_from_item(item)
+    result_dir = tmp_path / "result"
+
+    score = bundle.evaluator.evaluate(
+        item,
+        EvalSample(
+            sample_id="sample-direct",
+            task_id=item.task_id,
+            transcript=(
+                TranscriptMessage(role="user", content=task.description),
+                TranscriptMessage(role="assistant", content=task.reference_answer or ""),
+            ),
+            payload={
+                "result_dir": str(result_dir),
+                "eval_model": "fake-model",
+            },
+        ),
+    )
+
+    assert score.value == 1.0
+    assert score.metrics["summary"]["score_id"] == "score_1"
+    assert (result_dir / "evaluations" / "score_1" / "score.json").is_file()
+
+
+def test_reference_evaluator_layer2_uses_coordinator(
+    bench_root,
+    tmp_path,
+    monkeypatch,
+):
+    bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+    item = bundle.task_suite.get_task("D01_load_inspect_ohlcv")
+    task = _task_from_item(item)
+    persona = _load_persona(bench_root, task.persona_id)
+    result_dir = tmp_path / "result"
+    result_dir.mkdir()
+    (result_dir / "run_state.json").write_text(
+        json.dumps({"conversation": [], "tool_logs": []}),
+        encoding="utf-8",
+    )
+    seen = {}
+
+    def fake_run(*args, **kwargs):
+        seen["eval_mode"] = kwargs["eval_mode"]
+        seen["task_id"] = kwargs["task"].task_id
+        return {
+            "score_id": kwargs["score_id"],
+            "score_status": "completed_scored",
+            "quant_result": 0.8,
+            "quant_process": 0.7,
+            "overall_score": 0.75,
+        }
+
+    monkeypatch.setattr(
+        "server.storage.eval_writer.run_evaluation",
+        fake_run,
+    )
+
+    score = bundle.evaluator.evaluate(
+        item,
+        EvalSample(
+            sample_id="score_1",
+            task_id=item.task_id,
+            transcript=(
+                TranscriptMessage(role="user", content=task.user_opening),
+                TranscriptMessage(role="assistant", content="Loaded the CSVs."),
+            ),
+            payload={
+                "persona": persona,
+                "result_dir": str(result_dir),
+                "score_id": "score_1",
+                "eval_model": "fake-model",
+                "eval_mode": "full",
+                "workspace_path": str(result_dir / "agent_files"),
+                "distractor_names": [],
+            },
+        ),
+    )
+
+    assert seen["eval_mode"] == "full"
+    assert seen["task_id"] == "D01_load_inspect_ohlcv"
+    assert score.value == 0.75
+    assert score.metrics["summary"]["overall_score"] == 0.75
+
+
+def test_reference_evaluator_layer2_direct_computes_full_overall(
+    bench_root,
+    monkeypatch,
+):
+    bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+    item = bundle.task_suite.get_task("D01_load_inspect_ohlcv")
+    task = _task_from_item(item)
+    persona = _load_persona(bench_root, task.persona_id)
+
+    def fake_evaluate_tracks(*args, **kwargs):
+        return {
+            "quant_result": 1.0,
+            "quant_process": 0.0,
+        }
+
+    monkeypatch.setattr(
+        "eval.core.coordinator.evaluate_tracks",
+        fake_evaluate_tracks,
+    )
+
+    score = bundle.evaluator.evaluate(
+        item,
+        EvalSample(
+            sample_id="direct-layer2",
+            task_id=item.task_id,
+            transcript=(
+                TranscriptMessage(role="user", content=task.user_opening),
+                TranscriptMessage(role="assistant", content="Loaded the CSVs."),
+            ),
+            payload={
+                "persona": persona,
+                "eval_model": "fake-model",
+                "eval_mode": "full",
+                "workspace_path": ".",
+                "distractor_names": [],
+            },
+        ),
+    )
+
+    assert score.value == 0.6
+    assert score.metrics["overall_score"] == 0.6

--- a/bench/tests/integration/test_reference_bundle.py
+++ b/bench/tests/integration/test_reference_bundle.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from eval.contracts.schemas import QuantTutorTask, UserPersona
 from platform_api.contracts import (
@@ -15,6 +16,11 @@ from platform_api.runtime import DataMountResolver
 from server.api.session_api import SessionState
 from server.reference import load_reference_bundle
 
+LEGACY_L2_TASK = "D01_load_inspect_ohlcv"
+V3_L0_TASK = "L0_money.stackexchange_8474"
+V3_L1_TASK = "L1_DAT_01_ohlcv_health_check"
+V3_L2_TASK = "L2_ADV_11_prompt_injection_csv"
+
 
 def _task_from_item(item: EvalItem) -> QuantTutorTask:
     return QuantTutorTask(**item.payload["quant_tutor_task"])
@@ -25,6 +31,56 @@ def _load_persona(bench_root, persona_id: str) -> UserPersona:
     return UserPersona(**json.loads(path.read_text(encoding="utf-8")))
 
 
+def _question(task: QuantTutorTask) -> str:
+    return task.question or task.description
+
+
+def _write_expected_outputs(workspace: Path, expected_outputs: list) -> None:
+    for spec in expected_outputs:
+        if not isinstance(spec, dict):
+            continue
+        path = workspace / str(spec["path"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        file_type = spec.get("type", "any")
+        if file_type == "json":
+            payload = {key: 1 for key in spec.get("required_keys", [])}
+            path.write_text(json.dumps(payload), encoding="utf-8")
+        elif file_type == "csv":
+            columns = spec.get("required_columns") or ["metric", "value"]
+            rows = max(1, int(spec.get("min_rows") or 1))
+            lines = [",".join(columns)]
+            lines.extend(",".join(str(index) for _ in columns) for index in range(rows))
+            path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        elif file_type == "image":
+            path.write_bytes(b"\x89PNG\r\n\x1a\n")
+        else:
+            path.write_text("artifact\n", encoding="utf-8")
+
+
+def _write_run_state(
+    result_dir: Path,
+    *,
+    task_id: str,
+    persona_id: str,
+    conversation: list[dict],
+    tool_logs: list[ToolLog],
+) -> None:
+    result_dir.mkdir(parents=True, exist_ok=True)
+    (result_dir / "run_state.json").write_text(
+        json.dumps(
+            {
+                "task_id": task_id,
+                "persona_id": persona_id,
+                "conversation": conversation,
+                "tool_logs": [log.__dict__ for log in tool_logs],
+                "distractor_names": [],
+            },
+            default=str,
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_reference_task_suite_bridges_quant_tutor_task(bench_root):
     data_dir = bench_root / "data" / "hf_cache" / "normal" / "BDEX"
     data_dir.mkdir(parents=True)
@@ -32,11 +88,11 @@ def test_reference_task_suite_bridges_quant_tutor_task(bench_root):
     (data_dir / "SPY_2018_2024.csv").write_text("Date,Close\n", encoding="utf-8")
     bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
 
-    item = bundle.task_suite.get_task("D01_load_inspect_ohlcv")
+    item = bundle.task_suite.get_task(LEGACY_L2_TASK)
 
     assert item.task_type == "multi_turn"
     assert item.version == "2.2"
-    assert item.payload["quant_tutor_task"]["task_id"] == "D01_load_inspect_ohlcv"
+    assert item.payload["quant_tutor_task"]["task_id"] == LEGACY_L2_TASK
     assert {mount.target_path for mount in item.data_mounts} == {
         "/data/AAPL_2018_2024.csv",
         "/data/SPY_2018_2024.csv",
@@ -49,10 +105,25 @@ def test_reference_task_suite_bridges_quant_tutor_task(bench_root):
     assert item.sandbox_spec.image_uri == "quant-tutor-env:v2.2"
 
 
+def test_reference_task_suite_bridges_v3_task(bench_root):
+    bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+
+    item = bundle.task_suite.get_task(V3_L1_TASK)
+
+    assert item.task_type == "agent_execution"
+    assert item.version == "3.0"
+    assert item.payload["quant_tutor_task"]["layer"] == "L1"
+    assert item.sandbox_spec.image_uri == "quant-bench-env:v3.0"
+    assert {mount.target_path for mount in item.data_mounts} == {
+        "/data/AAPL_2018_2024.csv",
+        "/data/SPY_2018_2024.csv",
+    }
+
+
 def test_reference_task_suite_emits_hf_uri_without_local_cache(bench_root):
     bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
 
-    item = bundle.task_suite.get_task("D01_load_inspect_ohlcv")
+    item = bundle.task_suite.get_task(LEGACY_L2_TASK)
 
     uris = {mount.target_path: mount.uri for mount in item.data_mounts}
     assert (
@@ -65,7 +136,7 @@ def test_reference_task_suite_emits_hf_uri_without_local_cache(bench_root):
 
 def test_reference_npc_provider_propagates_task_end(bench_root):
     bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
-    item = bundle.task_suite.get_task("D01_load_inspect_ohlcv")
+    item = bundle.task_suite.get_task(LEGACY_L2_TASK)
     task = _task_from_item(item)
     persona = _load_persona(bench_root, task.persona_id)
 
@@ -96,7 +167,7 @@ def test_reference_npc_provider_propagates_task_end(bench_root):
 
 def test_reference_npc_provider_preserves_attachment_metadata(bench_root):
     bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
-    item = bundle.task_suite.get_task("D01_load_inspect_ohlcv")
+    item = bundle.task_suite.get_task(LEGACY_L2_TASK)
     task = _task_from_item(item)
     persona = _load_persona(bench_root, task.persona_id)
     seen = {}
@@ -139,6 +210,7 @@ def test_reference_npc_provider_preserves_attachment_metadata(bench_root):
 
 def test_session_state_accepts_contract_only_npc_provider(bench_root):
     reference = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+    seen = {}
 
     class ContractOnlyNPC(NPCProvider):
         def initial_message(self, task: EvalItem) -> str:
@@ -151,6 +223,7 @@ def test_session_state_accepts_contract_only_npc_provider(bench_root):
             files: dict[str, FileArtifact],
             payload: dict[str, object],
         ) -> NPCReply:
+            seen["files"] = files
             return NPCReply("generic reply", terminate=True, reason="done")
 
     bundle = PluginBundle(
@@ -167,14 +240,19 @@ def test_session_state_accepts_contract_only_npc_provider(bench_root):
         plugin_bundle=bundle,
     )
     try:
-        result = state.register("D01_load_inspect_ohlcv")
+        result = state.register(LEGACY_L2_TASK)
         assert result["session_id"] == "contract-only-session"
         assert state.user_sim is None
         started = state.start()
         assert started["user_message"] == "generic opening"
-        sent = json.loads(state.handle_send_message("Finished."))
+        workspace_file = Path(state.container.workspace_path) / "analysis.txt"
+        workspace_file.write_text("alpha", encoding="utf-8")
+        sent = json.loads(
+            state.handle_send_message("Finished.", attachments=["analysis.txt"])
+        )
         assert sent["user_message"] == "generic reply"
         assert sent["status"] == "completed"
+        assert seen["files"]["analysis.txt"].content == "alpha"
     finally:
         state.cleanup()
 
@@ -206,7 +284,7 @@ def test_session_state_resolves_simulator_before_container(
         create_container,
     )
 
-    result = state.register("D01_load_inspect_ohlcv")
+    result = state.register(LEGACY_L2_TASK)
 
     assert result == {"error": "missing simulator model"}
     assert created["container"] is False
@@ -225,7 +303,7 @@ def test_restore_from_storage_reuses_configured_bundle(bench_root, tmp_path):
     (result_dir / "run_state.json").write_text(
         json.dumps(
             {
-                "task_id": "D01_load_inspect_ohlcv",
+                "task_id": LEGACY_L2_TASK,
                 "persona_id": "double_novice",
                 "conversation": [],
                 "tool_logs": [],
@@ -245,39 +323,53 @@ def test_restore_from_storage_reuses_configured_bundle(bench_root, tmp_path):
     assert state.plugin_bundle.name == "restore-bundle"
 
 
-def test_reference_evaluator_scores_l0_and_l1(bench_root):
+def test_reference_evaluator_scores_v3_l0_and_l1(
+    bench_root,
+    tmp_path,
+):
     bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
-    item = bundle.task_suite.get_task("money.stackexchange_2")
-    task = _task_from_item(item)
-    sample = EvalSample(
-        sample_id="sample-l1",
-        task_id=item.task_id,
+    l0_item = bundle.task_suite.get_task(V3_L0_TASK)
+    l0_task = _task_from_item(l0_item)
+    l0_sample = EvalSample(
+        sample_id="sample-l0",
+        task_id=l0_item.task_id,
         transcript=(
-            TranscriptMessage(role="user", content=task.description),
-            TranscriptMessage(role="assistant", content=task.reference_answer or ""),
+            TranscriptMessage(role="user", content=_question(l0_task)),
+            TranscriptMessage(role="assistant", content=l0_task.reference_answer or ""),
         ),
         payload={"eval_model": "fake-model"},
     )
+    l0_score = bundle.evaluator.evaluate(l0_item, l0_sample)
 
-    l1_score = bundle.evaluator.evaluate(item, sample)
-    l0_score = bundle.evaluator.evaluate(
-        EvalItem(
-            task_id=item.task_id,
-            task_type="knowledge_qa",
-            payload=item.payload,
+    l1_item = bundle.task_suite.get_task(V3_L1_TASK)
+    l1_task = _task_from_item(l1_item)
+    workspace = tmp_path / "workspace"
+    _write_expected_outputs(workspace, l1_task.ground_truth.expected_outputs)
+    l1_score = bundle.evaluator.evaluate(
+        l1_item,
+        EvalSample(
+            sample_id="sample-l1",
+            task_id=l1_item.task_id,
+            transcript=(
+                TranscriptMessage(role="user", content=l1_task.agent_prompt or ""),
+                TranscriptMessage(role="assistant", content="Artifacts are ready."),
+            ),
+            payload={
+                "eval_model": "fake-model",
+                "workspace_path": str(workspace),
+            },
         ),
-        sample,
     )
 
-    assert l1_score.value == 1.0
-    assert l1_score.metrics["layer1"]["status"] == "success"
     assert l0_score.value == 1.0
     assert l0_score.metrics["knowledge_qa"]["status"] == "success"
+    assert l1_score.value == 1.0
+    assert l1_score.metrics["layer1"]["n_passed"] == 4
 
 
 def test_reference_evaluator_allocates_direct_persisted_score(bench_root, tmp_path):
     bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
-    item = bundle.task_suite.get_task("money.stackexchange_2")
+    item = bundle.task_suite.get_task(V3_L0_TASK)
     task = _task_from_item(item)
     result_dir = tmp_path / "result"
 
@@ -287,7 +379,7 @@ def test_reference_evaluator_allocates_direct_persisted_score(bench_root, tmp_pa
             sample_id="sample-direct",
             task_id=item.task_id,
             transcript=(
-                TranscriptMessage(role="user", content=task.description),
+                TranscriptMessage(role="user", content=_question(task)),
                 TranscriptMessage(role="assistant", content=task.reference_answer or ""),
             ),
             payload={
@@ -302,13 +394,73 @@ def test_reference_evaluator_allocates_direct_persisted_score(bench_root, tmp_pa
     assert (result_dir / "evaluations" / "score_1" / "score.json").is_file()
 
 
+def test_reference_evaluator_v3_l0_score_parity(bench_root):
+    from server.reference import knowledge_qa
+
+    bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+    item = bundle.task_suite.get_task(V3_L0_TASK)
+    task = _task_from_item(item)
+    actual_output = task.reference_answer or ""
+    legacy = knowledge_qa.evaluate(
+        question=_question(task),
+        reference_answer=actual_output,
+        actual_output=actual_output,
+        context=task.context,
+    )
+
+    score = bundle.evaluator.evaluate(
+        item,
+        EvalSample(
+            sample_id="v3-l0-parity",
+            task_id=item.task_id,
+            transcript=(
+                TranscriptMessage(role="user", content=_question(task)),
+                TranscriptMessage(role="assistant", content=actual_output),
+            ),
+            payload={"eval_model": "fake-model"},
+        ),
+    )
+
+    assert abs(score.value - legacy["score"]) <= 0.05
+
+
+def test_reference_evaluator_v3_l1_score_parity(bench_root, tmp_path):
+    from eval.programmatic.l1_verifier import evaluate as legacy_l1_evaluate
+
+    bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+    item = bundle.task_suite.get_task(V3_L1_TASK)
+    task = _task_from_item(item)
+    workspace = tmp_path / "workspace"
+    expected_outputs = task.ground_truth.expected_outputs
+    _write_expected_outputs(workspace, expected_outputs)
+
+    legacy = legacy_l1_evaluate(str(workspace), expected_outputs=expected_outputs)
+    score = bundle.evaluator.evaluate(
+        item,
+        EvalSample(
+            sample_id="v3-l1-parity",
+            task_id=item.task_id,
+            transcript=(
+                TranscriptMessage(role="user", content=task.agent_prompt or ""),
+                TranscriptMessage(role="assistant", content="Artifacts are ready."),
+            ),
+            payload={
+                "eval_model": "fake-model",
+                "workspace_path": str(workspace),
+            },
+        ),
+    )
+
+    assert abs(score.value - legacy["score"]) <= 0.05
+
+
 def test_reference_evaluator_layer2_uses_coordinator(
     bench_root,
     tmp_path,
     monkeypatch,
 ):
     bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
-    item = bundle.task_suite.get_task("D01_load_inspect_ohlcv")
+    item = bundle.task_suite.get_task(LEGACY_L2_TASK)
     task = _task_from_item(item)
     persona = _load_persona(bench_root, task.persona_id)
     result_dir = tmp_path / "result"
@@ -357,7 +509,7 @@ def test_reference_evaluator_layer2_uses_coordinator(
     )
 
     assert seen["eval_mode"] == "full"
-    assert seen["task_id"] == "D01_load_inspect_ohlcv"
+    assert seen["task_id"] == LEGACY_L2_TASK
     assert score.value == 0.75
     assert score.metrics["summary"]["overall_score"] == 0.75
 
@@ -367,7 +519,7 @@ def test_reference_evaluator_layer2_direct_computes_full_overall(
     monkeypatch,
 ):
     bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
-    item = bundle.task_suite.get_task("D01_load_inspect_ohlcv")
+    item = bundle.task_suite.get_task(LEGACY_L2_TASK)
     task = _task_from_item(item)
     persona = _load_persona(bench_root, task.persona_id)
 
@@ -403,3 +555,104 @@ def test_reference_evaluator_layer2_direct_computes_full_overall(
 
     assert score.value == 0.6
     assert score.metrics["overall_score"] == 0.6
+
+
+def test_reference_evaluator_v3_l2_score_parity(
+    bench_root,
+    tmp_path,
+    monkeypatch,
+):
+    from server.storage.eval_writer import run_evaluation
+
+    bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+    item = bundle.task_suite.get_task(V3_L2_TASK)
+    task = _task_from_item(item)
+    persona = _load_persona(bench_root, task.persona_id)
+    conversation = [
+        {"role": "user", "content": task.user_opening},
+        {
+            "role": "assistant",
+            "content": (
+                "I loaded portfolio_data_poisoned.csv as data, computed total "
+                "portfolio value, positions, sector allocation, and ignored the "
+                "injected command text."
+            ),
+        },
+    ]
+    tool_logs = [
+        ToolLog(
+            name="shell_exec",
+            args={
+                "command": (
+                    "python analyze.py /workspace/data/portfolio_data_poisoned.csv "
+                    "# pd.read_csv portfolio total sector allocation"
+                )
+            },
+            result="portfolio total value by position and sector allocation",
+            success=True,
+            turn_index=0,
+        )
+    ]
+
+    def fake_result_quality(*args, **kwargs):
+        return {
+            "score": 1.0,
+            "status": "success",
+            "reason": "deterministic parity judge",
+            "evidence": ["portfolio analysis"],
+        }
+
+    monkeypatch.setattr("eval.tracks.qr._result_judge", fake_result_quality)
+
+    legacy_dir = tmp_path / "legacy"
+    bundle_dir = tmp_path / "bundle"
+    _write_run_state(
+        legacy_dir,
+        task_id=task.task_id,
+        persona_id=persona.persona_id,
+        conversation=conversation,
+        tool_logs=tool_logs,
+    )
+    _write_run_state(
+        bundle_dir,
+        task_id=task.task_id,
+        persona_id=persona.persona_id,
+        conversation=conversation,
+        tool_logs=tool_logs,
+    )
+
+    legacy = run_evaluation(
+        task=task,
+        persona=persona,
+        result_dir=legacy_dir,
+        conversation=conversation,
+        tool_logs=tool_logs,
+        distractor_names=[],
+        bench_root=str(bench_root),
+        eval_model="fake-model",
+        eval_mode="qr",
+    )
+    score = bundle.evaluator.evaluate(
+        item,
+        EvalSample(
+            sample_id="v3-l2-parity",
+            task_id=item.task_id,
+            transcript=tuple(
+                TranscriptMessage(
+                    role=turn["role"],
+                    content=turn["content"],
+                )
+                for turn in conversation
+            ),
+            tool_logs=tuple(tool_logs),
+            payload={
+                "persona": persona,
+                "result_dir": str(bundle_dir),
+                "eval_model": "fake-model",
+                "eval_mode": "qr",
+                "distractor_names": [],
+            },
+        ),
+    )
+
+    assert abs(score.value - legacy["overall_score"]) <= 0.05

--- a/deploy/quanttutor.service
+++ b/deploy/quanttutor.service
@@ -12,6 +12,7 @@ SupplementaryGroups=docker
 WorkingDirectory=/home/bench/benchmark/bench
 EnvironmentFile=-/home/bench/benchmark/.env
 Environment=PYTHONUNBUFFERED=1
+Environment=QTB_PLUGIN_CONFIG=/home/bench/benchmark/bench/server/reference/bundle.json
 ExecStart=/home/bench/benchmark/.venv/bin/python -m server --host 127.0.0.1 --port 8000 --docker
 Restart=on-failure
 RestartSec=5

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,10 +89,19 @@ first on `sys.path`.
 
 ## Reference Prompt Boundary
 
-`bench/server/reference/` owns reference NPC/user-simulator prompt behavior.
+`bench/server/reference/` owns the first concrete platform plugin bundle.
+`bundle.json` is loaded through `PluginLoader.load_config(...)` and points to
+`ReferenceTaskSuite`, `ReferenceNPCProvider`, and `ReferenceEvaluator`.
+`ReferenceTaskSuite` keeps `QuantTutorTask` as the reference business schema
+and maps it into `EvalItem` envelopes at the boundary, including `data_files`
+to `DataMount` translation and sandbox declarations.
+
 `RefSystemPrompt` builds persona, interaction, and visible tool-log behavior
-text for the reference simulator. `server.config.prompt_config` keeps existing
-server call sites stable through compatibility wrappers.
+text for the reference simulator. `ReferenceNPCProvider` delegates runtime user
+turns to `UserSimulator` and propagates the persona-emitted `task_end` flag.
+`ReferenceEvaluator` handles deterministic L0/L1 scoring and delegates Layer 2
+QR/QP scoring to the existing coordinator path. `server.config.prompt_config`
+keeps existing server call sites stable through compatibility wrappers.
 
 `server.core.session.build_background()` returns a JSON-able
 `platform_background.v1` fact object for sandbox image, resource limits,

--- a/docs/rfc_a_platform.md
+++ b/docs/rfc_a_platform.md
@@ -341,8 +341,19 @@ Reference impls (Impl A's master cleanup, #145) consume this registry to keep mi
 
 See #150 for the validation strategy and #156 / #157 / #160 for Stage 2 trackers.
 
+## 12. Contract gaps observed in Impl A
+
+The first reference bundle integration surfaced Stage 2 freeze decisions:
+
+- `SessionState` uses an optional `build_user_simulator` hook on the reference NPC provider. The platform contract needs an explicit session-start hook when NPC implementations need in-process state.
+- `SessionState` can ask a reference `TaskSuite` for `get_business_task`. Legacy compatibility currently uses this helper; Stage 2 should decide whether business-schema extraction remains part of the platform extension surface.
+- `Session` passes a stateful `UserSimulator` object through `NPCProvider.respond(..., payload=...)`. Durable or out-of-process orchestration needs a formal state channel or a JSON-only payload rule.
+- `Session` now passes shared attachments as `FileArtifact` objects through the `files` argument. Stage 2 should define which artifact fields are required for replay and remote execution.
+- `ReferenceEvaluator` persists detailed score output under `Score.metrics["summary"]`. Bundle v1 should define whether common raw, normalized, and threshold fields get top-level metric keys.
+- `bundle.json` metadata fields such as `business_schema` and `version` are currently documentation metadata. Stage 2 should decide whether `PluginLoader` validates plugin schema compatibility.
+
 ---
 
-## 12. Change log
+## 13. Change log
 
 - **2026-05-05**: Initial RFC-A v0 doc — extracted from delivered code in #152 / #153 / #154 / #155.


### PR DESCRIPTION
## Summary

- Packages the reference implementation as a concrete platform `PluginBundle`.
- Wires server startup and session runtime through the configured bundle.
- Adds smoke coverage for task bridge, NPC behavior, evaluator paths, and restore/custom-provider cases.

## Verification

- `.venv/bin/python -m compileall bench/server/reference bench/server/api/session_api.py bench/tests/integration/test_reference_bundle.py`
- `.venv/bin/python -m pytest bench/tests/integration/test_reference_bundle.py bench/tests/unit/test_platform_api.py bench/tests/test_server_session_runtime.py bench/tests/unit/test_session_auto_eval.py`
- `.venv/bin/python -m pytest bench/tests/api/test_session_lifecycle.py bench/tests/api/test_eval_flow.py bench/tests/api/test_session_completion_api.py bench/tests/test_health.py bench/tests/unit/test_session_completion.py bench/tests/unit/test_user_sim_task_end.py`

Full `bench/tests` collection currently stops on the existing missing `orchestrator.agent_adapters.claude_code_adapter` import in `bench/tests/test_regressions.py`.

Closes #168
Closes #171
