### PR TITLE
chore(data): pin v3 HF dataset revision

### DIFF
--- a/bench/config/benchmark_config.py
+++ b/bench/config/benchmark_config.py
@@ -23,7 +23,7 @@ BENCH_IMAGE_V3_LEAN = "quant-bench-env:v3.0-lean"
 # HuggingFace dataset repo and pinned commit hash.
 # To update: push new data, then update this hash.
 DATASET_REPO_ID = "Varsity-Tech/quant-tutor-bench-data"
-DATASET_REVISION = "793bca3f8dc70d379d423358f4159eca2d8be83f"
+DATASET_REVISION = "719c01e3bd5c303bc947fac1d1adadb8f7ad1e39"
 
 # ── Benchmark Window ──
 # Re-exported from benchmark_dates.py for convenience.

--- a/bench/scripts/data_manager.py
+++ b/bench/scripts/data_manager.py
@@ -262,6 +262,9 @@ def ensure_data(
         normal_dir = cache_dir / "normal"
         bdex_dir = normal_dir / "BDEX"
 
+        if normal_dir.exists() and not _revision_matches(normal_dir, revision):
+            shutil.rmtree(normal_dir, ignore_errors=True)
+
         if not bdex_dir.exists():
             snapshot_download(
                 repo_id=hf_repo,
@@ -274,6 +277,7 @@ def ensure_data(
             bds_downloaded = normal_dir / "BDS"
             if bds_downloaded.exists():
                 bds_downloaded.rename(bdex_dir)
+            _write_revision_marker(normal_dir, revision)
 
         return DataPaths(
             docs=docs_path,

--- a/bench/scripts/gen_v3_data.py
+++ b/bench/scripts/gen_v3_data.py
@@ -1,8 +1,8 @@
 """Generate the v3.0-only data files referenced by the new L1/L2 tasks.
 
-These files don't ship in the legacy HuggingFace BDEX/A/X dataset because
-they were introduced for v3.0 tasks. We synthesize them with deterministic
-seeds so the benchmark is reproducible without external data fetches.
+These files were introduced for v3.0 tasks. We synthesize them with
+deterministic seeds anchored to the pinned BTC reference so the benchmark is
+reproducible across clean checkouts and refreshed HF caches.
 
 Outputs go to both:
   * bench/data/hf_cache/normal/BDEX/  (runtime data_search_dir)
@@ -17,18 +17,26 @@ Usage:
 
 from __future__ import annotations
 
-import os
+import shutil
+import sys
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
 BENCH_ROOT = Path(__file__).resolve().parents[1]
+if str(BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(BENCH_ROOT))
+
+from config.benchmark_config import DATASET_REPO_ID, DATASET_REVISION  # noqa: E402
+
 BDEX = BENCH_ROOT / "data" / "hf_cache" / "normal" / "BDEX"
 NORMAL_X = BENCH_ROOT / "data" / "hf_cache" / "normal" / "X"
 FROZEN_MARKET = BENCH_ROOT / "data" / "frozen" / "market"
 FROZEN_STUDENT = BENCH_ROOT / "data" / "frozen" / "student_code"
 BTC_REF = FROZEN_MARKET / "BTCUSDT_1d_2021_2024.csv"
+BTC_REF_FALLBACK = BDEX / "BTCUSDT_1d_2021_2024.csv"
+NORMAL_CACHE_REVISION = BDEX.parent / ".hf_revision"
 
 CRYPTO_COLS = [
     "timestamp",
@@ -65,7 +73,7 @@ def _ohlcv_from_close(close: np.ndarray, rng: np.random.Generator) -> dict:
 
 def gen_altcoin(symbol: str, seed: int, beta: float, idio_vol: float) -> None:
     """Daily OHLCV correlated with BTC. Crypto schema, ms timestamps."""
-    btc = pd.read_csv(BTC_REF)
+    btc = pd.read_csv(_btc_reference_path())
     n = len(btc)
     rng = np.random.default_rng(seed)
     btc_ret = btc["close"].pct_change().fillna(0).to_numpy()
@@ -371,11 +379,42 @@ if __name__ == "__main__":
     (NORMAL_X / "stats_misuse.py").write_text(stats_misuse)
 
 
-def main() -> None:
-    if not BTC_REF.exists():
-        raise FileNotFoundError(
-            f"BTC reference not found at {BTC_REF}; cannot anchor altcoin generation"
+def _btc_reference_path() -> Path:
+    if BTC_REF.exists():
+        return BTC_REF
+    if BTC_REF_FALLBACK.exists():
+        try:
+            cache_revision = NORMAL_CACHE_REVISION.read_text(encoding="utf-8").strip()
+        except OSError:
+            cache_revision = ""
+        if cache_revision == DATASET_REVISION:
+            return BTC_REF_FALLBACK
+    return _materialize_btc_reference()
+
+
+def _materialize_btc_reference() -> Path:
+    try:
+        from huggingface_hub import hf_hub_download
+
+        downloaded = hf_hub_download(
+            repo_id=DATASET_REPO_ID,
+            repo_type="dataset",
+            revision=DATASET_REVISION,
+            filename="BDS/BTCUSDT_1d_2021_2024.csv",
         )
+    except Exception as exc:
+        raise FileNotFoundError(
+            "BTC reference not found at "
+            f"{BTC_REF} or a matching-revision {BTC_REF_FALLBACK}; "
+            "could not download pinned BTC reference from HuggingFace"
+        ) from exc
+    FROZEN_MARKET.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(downloaded, BTC_REF)
+    return BTC_REF
+
+
+def main() -> None:
+    _btc_reference_path()
 
     print("Generating altcoins...")
     gen_altcoin("SOLUSDT", seed=101, beta=0.85, idio_vol=0.04)

--- a/bench/server/config/benchmark_config.py
+++ b/bench/server/config/benchmark_config.py
@@ -8,4 +8,4 @@ LEAN_IMAGE, BENCH_START/END, RANDOM_SEED live in bench/config/.
 # HuggingFace dataset repo and pinned commit hash.
 # To update: push new data, then update this hash.
 DATASET_REPO_ID = "Varsity-Tech/quant-tutor-bench-data"
-DATASET_REVISION = "793bca3f8dc70d379d423358f4159eca2d8be83f"
+DATASET_REVISION = "719c01e3bd5c303bc947fac1d1adadb8f7ad1e39"

--- a/bench/server/data_manager.py
+++ b/bench/server/data_manager.py
@@ -220,6 +220,9 @@ def ensure_data(
         normal_dir = cache_dir / "normal"
         bdex_dir = normal_dir / "BDEX"
 
+        if normal_dir.exists() and not _revision_matches(normal_dir, revision):
+            shutil.rmtree(normal_dir, ignore_errors=True)
+
         if not bdex_dir.exists():
             snapshot_download(
                 repo_id=hf_repo,
@@ -231,6 +234,7 @@ def ensure_data(
             bds_downloaded = normal_dir / "BDS"
             if bds_downloaded.exists():
                 bds_downloaded.rename(bdex_dir)
+            _write_revision_marker(normal_dir, revision)
 
         return DataPaths(
             docs=docs_path,

--- a/bench/tests/integration/test_reference_bundle.py
+++ b/bench/tests/integration/test_reference_bundle.py
@@ -15,6 +15,7 @@ from platform_api.contracts import (
 )
 from platform_api.plugins import PluginBundle
 from server.api.session_api import SessionState
+from server.config.benchmark_config import DATASET_REVISION
 from server.reference import load_reference_bundle
 
 LEGACY_TASK = "A01_investment_advice"
@@ -119,9 +120,8 @@ def test_reference_task_suite_emits_hf_uri_without_local_cache(bench_root):
     uris = {mount.target_path: mount.uri for mount in item.data_mounts}
     assert (
         uris["/data/SPY_2018_2024.csv"]
-        == "hf://Varsity-Tech/quant-tutor-bench-data@"
-        "793bca3f8dc70d379d423358f4159eca2d8be83f/BDS/SPY_2018_2024.csv"
-        "?repo_type=dataset"
+        == f"hf://Varsity-Tech/quant-tutor-bench-data@{DATASET_REVISION}"
+        "/BDS/SPY_2018_2024.csv?repo_type=dataset"
     )
 
 

--- a/bench/tests/unit/test_data_manager_revision.py
+++ b/bench/tests/unit/test_data_manager_revision.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+import importlib
+
+
+def _fake_snapshot_download(*, local_dir: str, revision: str | None, **_kwargs):
+    normal_dir = Path(local_dir)
+    (normal_dir / "BDS").mkdir(parents=True, exist_ok=True)
+    (normal_dir / "A").mkdir(parents=True, exist_ok=True)
+    (normal_dir / "X").mkdir(parents=True, exist_ok=True)
+    (normal_dir / "BDS" / "fresh.csv").write_text(
+        f"revision,{revision}\n", encoding="utf-8"
+    )
+    (normal_dir / "A" / "fresh.txt").write_text("a\n", encoding="utf-8")
+    (normal_dir / "X" / "fresh.py").write_text("x = 1\n", encoding="utf-8")
+    return str(normal_dir)
+
+
+def _seed_stale_normal_cache(cache_dir: Path) -> None:
+    stale = cache_dir / "normal" / "BDEX"
+    stale.mkdir(parents=True)
+    (stale / "stale.csv").write_text("old\n", encoding="utf-8")
+    (cache_dir / "normal" / ".hf_revision").write_text(
+        "old-revision", encoding="utf-8"
+    )
+
+
+def test_server_data_manager_refreshes_normal_cache_on_revision_change(
+    tmp_path, monkeypatch
+):
+    from server import data_manager
+
+    data_manager = importlib.reload(data_manager)
+    cache_dir = tmp_path / "hf_cache"
+    _seed_stale_normal_cache(cache_dir)
+    monkeypatch.setattr(
+        data_manager, "_ensure_docs", lambda cache_dir, hf_repo, revision: "docs"
+    )
+    monkeypatch.setattr(data_manager, "snapshot_download", _fake_snapshot_download)
+
+    paths = data_manager.ensure_data(
+        series="normal",
+        cache_dir=cache_dir,
+        hf_repo="repo",
+        revision="new-revision",
+        need_reference=False,
+    )
+
+    bdex_dir = cache_dir / "normal" / "BDEX"
+    assert paths.data_search_dirs[0] == str(bdex_dir)
+    assert not (bdex_dir / "stale.csv").exists()
+    assert (bdex_dir / "fresh.csv").exists()
+    assert (cache_dir / "normal" / ".hf_revision").read_text(
+        encoding="utf-8"
+    ) == "new-revision"
+
+
+def test_scripts_data_manager_refreshes_normal_cache_on_revision_change(
+    tmp_path, monkeypatch
+):
+    from scripts import data_manager
+
+    cache_dir = tmp_path / "hf_cache"
+    _seed_stale_normal_cache(cache_dir)
+    monkeypatch.setattr(
+        data_manager, "_ensure_docs", lambda cache_dir, hf_repo, revision: "docs"
+    )
+    monkeypatch.setattr(data_manager, "snapshot_download", _fake_snapshot_download)
+
+    paths = data_manager.ensure_data(
+        series="normal",
+        cache_dir=cache_dir,
+        hf_repo="repo",
+        revision="new-revision",
+        need_reference=False,
+    )
+
+    bdex_dir = cache_dir / "normal" / "BDEX"
+    assert paths.data_search_dirs[0] == str(bdex_dir)
+    assert not (bdex_dir / "stale.csv").exists()
+    assert (bdex_dir / "fresh.csv").exists()
+    assert (cache_dir / "normal" / ".hf_revision").read_text(
+        encoding="utf-8"
+    ) == "new-revision"

--- a/bench/tests/unit/test_gen_v3_data.py
+++ b/bench/tests/unit/test_gen_v3_data.py
@@ -1,0 +1,56 @@
+from scripts import gen_v3_data
+
+
+def test_btc_reference_path_prefers_frozen_file(tmp_path, monkeypatch):
+    frozen = tmp_path / "frozen" / "BTCUSDT_1d_2021_2024.csv"
+    fallback = tmp_path / "cache" / "BDEX" / "BTCUSDT_1d_2021_2024.csv"
+    marker = tmp_path / "cache" / ".hf_revision"
+    frozen.parent.mkdir(parents=True)
+    fallback.parent.mkdir(parents=True)
+    frozen.write_text("frozen\n", encoding="utf-8")
+    fallback.write_text("fallback\n", encoding="utf-8")
+    marker.write_text("old-revision", encoding="utf-8")
+    monkeypatch.setattr(gen_v3_data, "BTC_REF", frozen)
+    monkeypatch.setattr(gen_v3_data, "BTC_REF_FALLBACK", fallback)
+    monkeypatch.setattr(gen_v3_data, "NORMAL_CACHE_REVISION", marker)
+    monkeypatch.setattr(gen_v3_data, "DATASET_REVISION", "new-revision")
+
+    assert gen_v3_data._btc_reference_path() == frozen
+
+
+def test_btc_reference_path_accepts_matching_cache_revision(tmp_path, monkeypatch):
+    frozen = tmp_path / "frozen" / "BTCUSDT_1d_2021_2024.csv"
+    fallback = tmp_path / "cache" / "BDEX" / "BTCUSDT_1d_2021_2024.csv"
+    marker = tmp_path / "cache" / ".hf_revision"
+    fallback.parent.mkdir(parents=True)
+    fallback.write_text("fallback\n", encoding="utf-8")
+    marker.write_text("new-revision", encoding="utf-8")
+    monkeypatch.setattr(gen_v3_data, "BTC_REF", frozen)
+    monkeypatch.setattr(gen_v3_data, "BTC_REF_FALLBACK", fallback)
+    monkeypatch.setattr(gen_v3_data, "NORMAL_CACHE_REVISION", marker)
+    monkeypatch.setattr(gen_v3_data, "DATASET_REVISION", "new-revision")
+
+    assert gen_v3_data._btc_reference_path() == fallback
+
+
+def test_btc_reference_path_materializes_pinned_source_for_stale_cache_revision(
+    tmp_path, monkeypatch
+):
+    frozen = tmp_path / "frozen" / "BTCUSDT_1d_2021_2024.csv"
+    fallback = tmp_path / "cache" / "BDEX" / "BTCUSDT_1d_2021_2024.csv"
+    marker = tmp_path / "cache" / ".hf_revision"
+    downloaded = tmp_path / "downloaded" / "BTCUSDT_1d_2021_2024.csv"
+    fallback.parent.mkdir(parents=True)
+    downloaded.parent.mkdir(parents=True)
+    fallback.write_text("fallback\n", encoding="utf-8")
+    downloaded.write_text("downloaded\n", encoding="utf-8")
+    marker.write_text("old-revision", encoding="utf-8")
+    monkeypatch.setattr(gen_v3_data, "BTC_REF", frozen)
+    monkeypatch.setattr(gen_v3_data, "BTC_REF_FALLBACK", fallback)
+    monkeypatch.setattr(gen_v3_data, "NORMAL_CACHE_REVISION", marker)
+    monkeypatch.setattr(gen_v3_data, "DATASET_REVISION", "new-revision")
+    monkeypatch.setattr(
+        gen_v3_data, "_materialize_btc_reference", lambda: downloaded
+    )
+
+    assert gen_v3_data._btc_reference_path() == downloaded


### PR DESCRIPTION
Closes #172

## Changes

- Pin both dataset config modules to HF revision `719c01e3bd5c303bc947fac1d1adadb8f7ad1e39`.
- Refresh `hf_cache/normal` when `.hf_revision` differs from the requested dataset revision.
- Let `gen_v3_data.py` materialize the pinned BTC anchor from HF during clean regeneration.
- Use the shared dataset revision constant in reference-bundle HF URI assertions.
- Add unit coverage for normal-cache revision refresh and BTC anchor selection.

## Verification

- `python bench/scripts/gen_v3_data.py`
- HF hash verification for all 13 generated artifacts against revision `719c01e3bd5c303bc947fac1d1adadb8f7ad1e39`
- Clean-cache HTTP smoke for `L2_DIA_04_portfolio_risk_underestimation`
- `pytest bench/tests/unit/test_gen_v3_data.py bench/tests/unit/test_data_manager_revision.py bench/tests/integration/test_reference_bundle.py bench/tests/integration/test_reference_bundle_longtail.py bench/tests/test_run_catalog.py`
- `git diff --check`
- `.venv/bin/python -m py_compile bench/scripts/gen_v3_data.py bench/scripts/data_manager.py bench/server/data_manager.py bench/config/benchmark_config.py bench/server/config/benchmark_config.py bench/tests/integration/test_reference_bundle.py bench/tests/unit/test_data_manager_revision.py bench/tests/unit/test_gen_v3_data.py`
