### PR TITLE
fix(deploy): verify v3 sandbox images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,6 +123,13 @@ jobs:
           docker image prune -f
           docker builder prune -f
 
+      - name: Ensure v3 Docker image aliases
+        run: |
+          docker image inspect quant-tutor-env:v2.2 >/dev/null
+          docker tag quant-tutor-env:v2.2 quant-bench-env:v3.0
+          docker image inspect quant-tutor-env:v2.2-lean >/dev/null
+          docker tag quant-tutor-env:v2.2-lean quant-bench-env:v3.0-lean
+
       - name: Install Python deps (if requirements changed)
         if: steps.changes.outputs.deps == 'true' || steps.runtime.outputs.venv_created == 'true'
         run: |

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -1068,16 +1068,7 @@ _HEALTH_DISK_MIN_GB = 5.0
 _HEALTH_LEAN_IMAGE_DEFAULT = "quant-tutor-env:v2.2-lean"
 
 
-def _health_check_docker() -> dict:
-    try:
-        proc = subprocess.run(["docker", "info"], capture_output=True, timeout=3)
-        return {"ok": proc.returncode == 0}
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
-        return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
-
-
-def _health_check_lean_image() -> dict:
-    image = os.environ.get("QTB_LEAN_IMAGE", _HEALTH_LEAN_IMAGE_DEFAULT)
+def _health_check_image(image: str) -> dict:
     try:
         proc = subprocess.run(
             ["docker", "image", "inspect", image],
@@ -1091,6 +1082,32 @@ def _health_check_lean_image() -> dict:
             "image": image,
             "error": f"{type(exc).__name__}: {exc}",
         }
+
+
+def _health_check_docker() -> dict:
+    try:
+        proc = subprocess.run(["docker", "info"], capture_output=True, timeout=3)
+        return {"ok": proc.returncode == 0}
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
+
+def _health_check_lean_image() -> dict:
+    return _health_check_image(
+        os.environ.get("QTB_LEAN_IMAGE", _HEALTH_LEAN_IMAGE_DEFAULT)
+    )
+
+
+def _health_check_bench_images() -> dict:
+    from config.benchmark_config import BENCH_IMAGE_V3, BENCH_IMAGE_V3_LEAN
+
+    full = _health_check_image(BENCH_IMAGE_V3)
+    lean = _health_check_image(BENCH_IMAGE_V3_LEAN)
+    return {
+        "ok": full.get("ok") is True and lean.get("ok") is True,
+        "full": full,
+        "lean": lean,
+    }
 
 
 def _health_check_disk() -> dict:
@@ -1114,7 +1131,7 @@ def _health_check_disk() -> dict:
 async def rest_health(request: Request) -> JSONResponse:
     """``GET /health`` — deep liveness probe.
 
-    In Docker mode validates Docker daemon, LEAN backtest image, and disk
+    In Docker mode validates Docker daemon, sandbox images, and disk
     headroom. In no-docker mode only disk is checked so a supported local
     deployment is not reported unhealthy for a missing Docker daemon.
     Returns 200 when all applicable checks pass, 503 otherwise so uptime
@@ -1123,13 +1140,15 @@ async def rest_health(request: Request) -> JSONResponse:
     manager: BenchSessionManager = request.app.state.manager
     checks: dict[str, dict] = {}
     if manager.use_docker:
-        docker, image, disk = await asyncio.gather(
+        docker, image, bench_images, disk = await asyncio.gather(
             anyio.to_thread.run_sync(_health_check_docker),
             anyio.to_thread.run_sync(_health_check_lean_image),
+            anyio.to_thread.run_sync(_health_check_bench_images),
             anyio.to_thread.run_sync(_health_check_disk),
         )
         checks["docker"] = docker
         checks["lean_image"] = image
+        checks["bench_images"] = bench_images
         checks["disk"] = disk
     else:
         checks["mode"] = {"ok": True, "docker": False}

--- a/bench/tests/test_health.py
+++ b/bench/tests/test_health.py
@@ -62,6 +62,7 @@ class TestHealth:
         assert body["status"] == "ok"
         assert body["checks"]["docker"]["ok"] is True
         assert body["checks"]["lean_image"]["ok"] is True
+        assert body["checks"]["bench_images"]["ok"] is True
         assert body["checks"]["disk"]["ok"] is True
 
     @pytest.mark.asyncio
@@ -104,6 +105,7 @@ class TestHealth:
         body = resp.json()
         assert body["checks"]["docker"]["ok"] is True
         assert body["checks"]["lean_image"]["ok"] is False
+        assert body["checks"]["bench_images"]["ok"] is False
 
     @pytest.mark.asyncio
     async def test_down_when_disk_low(self, client):
@@ -153,6 +155,7 @@ class TestHealth:
         assert body["status"] == "ok"
         assert "docker" not in body["checks"]
         assert "lean_image" not in body["checks"]
+        assert "bench_images" not in body["checks"]
         assert body["checks"]["disk"]["ok"] is True
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,11 +140,16 @@ cd /home/bench/benchmark/bench
 /home/bench/benchmark/.venv/bin/python -m server --host 127.0.0.1 --port 8000 --docker
 ```
 
+The unit sets
+`QTB_PLUGIN_CONFIG=/home/bench/benchmark/bench/server/reference/bundle.json`,
+so production uses the reference plugin bundle as the default platform path.
+
 GitHub Actions deploys through a self-hosted runner installed on the VPS with
 labels `production,bench-vps`. The workflow in `.github/workflows/deploy.yml`
 syncs the checkout into `/home/bench/benchmark`, maintains the virtualenv,
-rebuilds sandbox Docker images when Dockerfiles change, restarts `quanttutor`,
-and verifies `/health`.
+rebuilds sandbox Docker images when Dockerfiles change, maintains v3 sandbox
+aliases (`quant-bench-env:v3.0` and `quant-bench-env:v3.0-lean`), restarts
+`quanttutor`, and verifies `/health`.
 
 The `bench` SSH IP allowlist stays in `/etc/security/access.conf`. The
 self-hosted runner keeps deployment local to the VPS and preserves that SSH


### PR DESCRIPTION
## Changes

- Ensure deploy creates the v3 sandbox image tags used by v3 tasks:
  - `quant-bench-env:v3.0`
  - `quant-bench-env:v3.0-lean`
- Extend `/health` to verify both v3 sandbox tags in Docker mode.
- Document the production `QTB_PLUGIN_CONFIG` reference-bundle path and v3 image aliases in `docs/architecture.md`.

## Verification

- Production smoke after manual tag repair:
  - `/health` returned 200
  - `/client/runs/start` for `L2_DIA_04_portfolio_risk_underestimation` returned 200
  - `/session/register` returned 200
  - smoke run was cancelled
- `pytest bench/tests/test_health.py`
- `git diff --check`
- `.venv/bin/python -m py_compile bench/server/api/http_app.py bench/tests/test_health.py`
- `.venv/bin/python -c 'import yaml, pathlib; yaml.safe_load(pathlib.Path(".github/workflows/deploy.yml").read_text()); print("yaml ok")'`
- `codex exec review --uncommitted`
