### PR TITLE
feat: add Impl B programmatic plugin

### DIFF
--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -262,7 +262,10 @@ class BenchSessionManager:
         self._task_group: anyio.abc.TaskGroup | None = None
 
         # Run layer
-        self._catalog = TaskCatalog(self.bench_root)
+        self._catalog = TaskCatalog(
+            self.bench_root,
+            plugin_task_suites=(self.plugin_bundle.task_suite,),
+        )
         self._run_store = RunStore(self.bench_root / "results" / "runs")
         self._run_service = RunService(self._catalog, self._run_store)
 

--- a/bench/server/impl_b/__init__.py
+++ b/bench/server/impl_b/__init__.py
@@ -1,0 +1,30 @@
+"""Impl B plugin bundle helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from platform_api.plugins import PluginBundle, PluginLoader
+
+IMPL_B_BUNDLE_CONFIG = Path(__file__).with_name("bundle.json")
+
+
+def load_impl_b_bundle(
+    *,
+    bench_root: str | Path | None = None,
+    eval_model: str | None = None,
+    config_path: str | Path | None = None,
+) -> PluginBundle:
+    """Load the programmatic-only Impl B plugin bundle."""
+    bundles = PluginLoader().load_config(config_path or IMPL_B_BUNDLE_CONFIG)
+    if len(bundles) != 1:
+        raise RuntimeError("Impl B config must define exactly one bundle")
+    bundle = bundles[0]
+    for component in (bundle.task_suite, bundle.npc_provider, bundle.evaluator):
+        configure = getattr(component, "configure", None)
+        if callable(configure):
+            configure(bench_root=bench_root, eval_model=eval_model)
+    return bundle
+
+
+__all__ = ["IMPL_B_BUNDLE_CONFIG", "load_impl_b_bundle"]

--- a/bench/server/impl_b/bundle.json
+++ b/bench/server/impl_b/bundle.json
@@ -1,0 +1,15 @@
+{
+  "plugins": [
+    {
+      "name": "impl_b_programmatic",
+      "task_suite": "server.impl_b.task_suite:ImplBTaskSuite",
+      "npc_provider": "server.impl_b.npc_provider:TrivialNPCProvider",
+      "evaluator": "server.impl_b.evaluator:ProgrammaticEvaluator",
+      "metadata": {
+        "business_schema": "ImplBTask",
+        "version": "1.0",
+        "llm_judge_used": false
+      }
+    }
+  ]
+}

--- a/bench/server/impl_b/evaluator.py
+++ b/bench/server/impl_b/evaluator.py
@@ -1,0 +1,253 @@
+"""Programmatic-only Impl B evaluator."""
+
+from __future__ import annotations
+
+import base64
+import shutil
+import tempfile
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from eval.contracts.output import EvalOutput, TrackResult
+from eval.programmatic.l1_verifier import verify_l1
+from eval.storage.score_store import allocate_score_run, load_index
+from platform_api.contracts import (
+    EvalItem,
+    EvalSample,
+    Evaluator,
+    EvaluatorMetadata,
+    FileArtifact,
+    Score,
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if hasattr(value, "model_dump"):
+        return _jsonable(value.model_dump(mode="json"))
+    if is_dataclass(value):
+        return _jsonable(asdict(value))
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return str(value)
+
+
+class ProgrammaticEvaluator(Evaluator):
+    """Score Impl B outputs with the existing structured L1 verifier."""
+
+    def __init__(self, bench_root: str | Path | None = None) -> None:
+        self.bench_root = Path(bench_root) if bench_root else None
+
+    def configure(
+        self,
+        *,
+        bench_root: str | Path | None = None,
+        eval_model: str | None = None,
+    ) -> None:
+        if bench_root is not None:
+            self.bench_root = Path(bench_root)
+
+    def evaluate(self, item: EvalItem, sample: EvalSample) -> Score:
+        expected_outputs = item.payload.get("expected_outputs")
+        if not isinstance(expected_outputs, list) or not expected_outputs:
+            return Score(
+                value=None,
+                status="completed_not_computable",
+                reason="Impl B task is missing expected_outputs",
+                metrics={"programmatic": {"error": "expected_outputs missing"}},
+            )
+
+        workspace_path = str(sample.payload.get("workspace_path") or "").strip()
+        temp_dir: tempfile.TemporaryDirectory[str] | None = None
+        if not workspace_path and sample.files:
+            temp_dir = tempfile.TemporaryDirectory(prefix="impl_b_eval_")
+            workspace_path = temp_dir.name
+            self._materialize_files(Path(workspace_path), sample.files)
+
+        try:
+            if not workspace_path:
+                result = {
+                    "score": None,
+                    "error": "workspace_path missing",
+                    "n_total": len(expected_outputs),
+                    "n_passed": 0,
+                    "per_spec": [],
+                }
+            else:
+                result = verify_l1(workspace_path, expected_outputs)
+        finally:
+            if temp_dir is not None:
+                temp_dir.cleanup()
+
+        raw_score = result.get("score")
+        score_value = (
+            float(raw_score) if isinstance(raw_score, (int, float)) else None
+        )
+        status = (
+            "completed_scored"
+            if score_value is not None
+            else "completed_not_computable"
+        )
+        summary = self._persist_if_requested(
+            result=result,
+            sample=sample,
+            score_value=score_value,
+            status=status,
+        )
+        metrics = {
+            "programmatic": result,
+            "summary": summary
+            or {
+                "score_status": status,
+                "overall_score": score_value,
+                "quant_result": score_value,
+                "quant_process": None,
+            },
+        }
+        return Score(
+            value=score_value,
+            status=status,
+            metrics=metrics,
+            reason=str(result.get("error") or ""),
+            evidence=tuple(
+                str(spec.get("path"))
+                for spec in expected_outputs
+                if isinstance(spec, dict) and spec.get("path")
+            ),
+            telemetry={"llm_judge_used": False},
+        )
+
+    def metadata(self) -> EvaluatorMetadata:
+        return EvaluatorMetadata(
+            evaluator_id="impl_b_programmatic",
+            version="1.0",
+            supported_tasks=frozenset(),
+            required_bundle_fields=frozenset({"workspace_path", "expected_outputs"}),
+            score_schema={
+                "value": "fraction of expected output specs satisfied in [0, 1]",
+                "metrics.programmatic": "raw l1_verifier output",
+            },
+            capabilities=frozenset({"programmatic_l1", "no_llm_judge"}),
+            metadata={"llm_judge_used": False},
+        )
+
+    def _persist_if_requested(
+        self,
+        *,
+        result: dict[str, Any],
+        sample: EvalSample,
+        score_value: float | None,
+        status: str,
+    ) -> dict[str, Any] | None:
+        result_dir_value = sample.payload.get("result_dir")
+        if not result_dir_value:
+            return None
+
+        result_dir = Path(str(result_dir_value))
+        result_dir.mkdir(parents=True, exist_ok=True)
+        score_id, created_at = self._prepare_score_run(
+            result_dir=result_dir,
+            requested_score_id=str(sample.payload.get("score_id") or sample.sample_id),
+            eval_mode=str(sample.payload.get("eval_mode") or "programmatic"),
+            eval_model=(
+                str(sample.payload.get("eval_model"))
+                if sample.payload.get("eval_model") is not None
+                else None
+            ),
+        )
+        now = _utc_now()
+        qr = TrackResult(
+            track="qr",
+            score=score_value,
+            status="success" if score_value is not None else "not_computable",
+            detail={"programmatic": result},
+            blocking_missing=[] if score_value is not None else [result],
+        )
+        output = EvalOutput(
+            score_id=score_id,
+            score_status=status,
+            qr=qr,
+            qp=None,
+            overall_score=score_value,
+            eval_mode=str(sample.payload.get("eval_mode") or "programmatic"),
+            eval_model=(
+                str(sample.payload.get("eval_model"))
+                if sample.payload.get("eval_model") is not None
+                else None
+            ),
+            created_at=created_at,
+            completed_at=now,
+            duration_seconds=0.0,
+            judge_reliability={"mode": "programmatic_only", "llm_judge_used": False},
+            blocking_missing=[] if score_value is not None else [result],
+            preflight={},
+        )
+        from eval.core.coordinator import persist_eval_output
+
+        return persist_eval_output(result_dir, output)
+
+    @staticmethod
+    def _prepare_score_run(
+        *,
+        result_dir: Path,
+        requested_score_id: str,
+        eval_mode: str,
+        eval_model: str | None,
+    ) -> tuple[str, str]:
+        try:
+            index = load_index(result_dir)
+            entry = next(
+                (
+                    item
+                    for item in index.get("scores", [])
+                    if item.get("score_id") == requested_score_id
+                ),
+                {},
+            )
+            if entry:
+                return (
+                    str(entry.get("score_id")),
+                    str(entry.get("created_at") or _utc_now()),
+                )
+            run, _created = allocate_score_run(
+                result_dir,
+                eval_mode=eval_mode,
+                eval_model=eval_model,
+            )
+            return run.score_id, run.created_at
+        except Exception:
+            return requested_score_id, _utc_now()
+
+    @staticmethod
+    def _materialize_files(
+        workspace: Path,
+        files: Mapping[str, FileArtifact],
+    ) -> None:
+        workspace.mkdir(parents=True, exist_ok=True)
+        for artifact in files.values():
+            rel = Path(artifact.path)
+            if rel.is_absolute() or ".." in rel.parts:
+                continue
+            target = workspace / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            content = artifact.content
+            encoding = str(artifact.metadata.get("encoding") or "")
+            if isinstance(content, bytes):
+                target.write_bytes(content)
+            elif encoding == "base64":
+                target.write_bytes(base64.b64decode(str(content or "")))
+            elif content is not None:
+                target.write_text(str(content), encoding="utf-8")
+            elif artifact.path:
+                source = Path(artifact.path)
+                if source.is_file():
+                    shutil.copyfile(source, target)

--- a/bench/server/impl_b/npc_provider.py
+++ b/bench/server/impl_b/npc_provider.py
@@ -1,0 +1,37 @@
+"""Trivial Impl B NPC provider."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from platform_api.contracts import (
+    EvalItem,
+    FileArtifact,
+    NPCProvider,
+    NPCReply,
+    ToolLog,
+    TranscriptMessage,
+)
+
+
+class TrivialNPCProvider(NPCProvider):
+    """Single-turn NPC that closes after the agent's first response."""
+
+    def initial_message(self, task: EvalItem) -> str:
+        return str(task.payload.get("prompt") or "")
+
+    def respond(
+        self,
+        transcript: Sequence[TranscriptMessage],
+        tool_logs: Sequence[ToolLog],
+        files: Mapping[str, FileArtifact],
+        payload: Mapping[str, object],
+    ) -> NPCReply:
+        agent_turns = sum(1 for message in transcript if message.role == "assistant")
+        return NPCReply(
+            message="continue",
+            terminate=agent_turns >= 1,
+            reason="impl_b_single_turn" if agent_turns >= 1 else "",
+            payload={"agent_turns": agent_turns},
+            telemetry={"llm_judge_used": False},
+        )

--- a/bench/server/impl_b/task_suite.py
+++ b/bench/server/impl_b/task_suite.py
@@ -1,0 +1,195 @@
+"""Programmatic-only Impl B task suite."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote
+
+from eval.contracts.schemas import QuantTutorTask
+from platform_api.contracts import DataMount, EvalItem, SandboxSpec, TaskSuite
+
+_CORE_TOOLS = (
+    "shell_exec",
+    "file_write",
+    "file_read",
+    "file_list",
+    "get_environment_info",
+)
+_TASK_DIR = "impl_b"
+_DEFAULT_SANDBOX_IMAGE = "quant-bench-env:v3.0"
+_DEFAULT_RESOURCE_LIMITS = {
+    "cpu_count": 1,
+    "memory_mb": 512,
+    "wall_timeout_seconds": 120,
+    "network_enabled": False,
+}
+
+
+def _default_bench_root() -> Path:
+    env_root = os.environ.get("QTB_BENCH_ROOT", "").strip()
+    if env_root:
+        return Path(env_root)
+    return Path(__file__).resolve().parents[2]
+
+
+class ImplBTaskSuite(TaskSuite):
+    """Small deterministic task corpus for framework swappability checks."""
+
+    def __init__(self, bench_root: str | Path | None = None) -> None:
+        self.bench_root = Path(bench_root) if bench_root else _default_bench_root()
+        self._task_paths: dict[str, Path] | None = None
+        self._task_cache: dict[str, dict[str, Any]] = {}
+
+    def configure(
+        self,
+        *,
+        bench_root: str | Path | None = None,
+        eval_model: str | None = None,
+    ) -> None:
+        if bench_root is not None:
+            self.bench_root = Path(bench_root)
+            self._task_paths = None
+            self._task_cache.clear()
+
+    def supported_tasks(self) -> set[str]:
+        return set(self._index_task_paths())
+
+    def get_task(self, task_id: str) -> EvalItem:
+        raw = self._load_task_payload(task_id)
+        expected_outputs = list(raw.get("expected_outputs") or [])
+        sandbox_spec = self._sandbox_spec(raw)
+        data_mounts = self._data_mounts(raw)
+        return EvalItem(
+            task_id=str(raw["task_id"]),
+            version=str(raw.get("version") or "1.0"),
+            task_type="agent_execution",
+            payload={
+                "impl_b_task": raw,
+                "expected_outputs": expected_outputs,
+                "prompt": self._prompt(raw),
+            },
+            metadata={
+                "business_schema": "ImplBTask",
+                "public_run_task": True,
+                "programmatic_only": True,
+                "npc_optional": True,
+                "requires_llm_judge": False,
+            },
+            data_mounts=data_mounts,
+            sandbox_spec=sandbox_spec,
+        )
+
+    def get_business_task(self, task_id: str) -> QuantTutorTask:
+        """Return a server-compatible task object for existing session runtime."""
+        raw = self._load_task_payload(task_id)
+        sandbox_spec = self._sandbox_spec(raw)
+        return QuantTutorTask(
+            task_id=str(raw["task_id"]),
+            version=str(raw.get("version") or "1.0"),
+            layer="L1",
+            category=str(raw.get("category") or "data_engineering"),
+            subcategory=str(raw.get("subcategory") or "impl_b"),
+            task_type="agent_execution",
+            difficulty=str(raw.get("difficulty") or "easy"),
+            description=str(raw.get("description") or self._prompt(raw)),
+            agent_prompt=self._prompt(raw),
+            persona_id=str(raw.get("persona_id") or "double_novice"),
+            user_opening=self._prompt(raw),
+            environment={
+                "data_files": [],
+                "data_mounts": [
+                    self._json_data_mount(mount) for mount in self._data_mounts(raw)
+                ],
+                "core_mcp_tools": list(raw.get("core_mcp_tools") or _CORE_TOOLS),
+                "docs_available": [],
+                "sandbox_image": sandbox_spec.image_uri,
+                "sandbox_spec": {
+                    "image_uri": sandbox_spec.image_uri,
+                    "resource_limits": dict(sandbox_spec.resource_limits),
+                },
+                "network_enabled": False,
+            },
+            ground_truth={
+                "required_capabilities": list(raw.get("required_capabilities") or []),
+                "expected_outputs": list(raw.get("expected_outputs") or []),
+                "expected_outcome": str(raw.get("expected_outcome") or ""),
+            },
+            requires_code=True,
+            requires_tool=True,
+            max_turns=int(raw.get("max_turns") or 2),
+            timeout_minutes=int(raw.get("timeout_minutes") or 5),
+            seed=int(raw["seed"]) if raw.get("seed") is not None else None,
+        )
+
+    def required_bundle_fields(self) -> set[str]:
+        return {"conversation", "tool_logs", "workspace_path", "result_dir"}
+
+    def _index_task_paths(self) -> dict[str, Path]:
+        if self._task_paths is None:
+            tasks_dir = self.bench_root / "tasks" / _TASK_DIR
+            self._task_paths = {
+                path.stem: path
+                for path in sorted(tasks_dir.glob("*.json"))
+                if path.is_file()
+            }
+        return self._task_paths
+
+    def _load_task_payload(self, task_id: str) -> dict[str, Any]:
+        if task_id in self._task_cache:
+            return self._task_cache[task_id]
+        paths = self._index_task_paths()
+        path = paths.get(task_id)
+        if path is None:
+            raise KeyError(f"Task not found: {task_id}")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        self._task_cache[task_id] = payload
+        return payload
+
+    def _data_mounts(self, raw: dict[str, Any]) -> tuple[DataMount, ...]:
+        mounts: list[DataMount] = []
+        for item in raw.get("data_mounts") or []:
+            uri = str(item["uri"])
+            mounts.append(
+                DataMount(
+                    uri=self._resolve_file_uri(uri),
+                    target_path=str(item["target_path"]),
+                    read_only=bool(item.get("read_only", True)),
+                )
+            )
+        return tuple(mounts)
+
+    def _resolve_file_uri(self, uri: str) -> str:
+        if not uri.startswith("file://"):
+            return uri
+        raw = uri.removeprefix("file://")
+        if raw.startswith("localhost/"):
+            raw = raw.removeprefix("localhost")
+        path = Path(unquote(raw)).expanduser()
+        if not path.is_absolute():
+            path = self.bench_root / path
+        return f"file://{path.resolve().as_posix()}"
+
+    @staticmethod
+    def _json_data_mount(mount: DataMount) -> dict[str, Any]:
+        return {
+            "uri": mount.uri,
+            "target_path": mount.target_path,
+            "read_only": mount.read_only,
+        }
+
+    @staticmethod
+    def _sandbox_spec(raw: dict[str, Any]) -> SandboxSpec:
+        sandbox = raw.get("sandbox") if isinstance(raw.get("sandbox"), dict) else {}
+        return SandboxSpec(
+            image_uri=str(sandbox.get("image_uri") or _DEFAULT_SANDBOX_IMAGE),
+            resource_limits=dict(
+                sandbox.get("resource_limits") or _DEFAULT_RESOURCE_LIMITS
+            ),
+        )
+
+    @staticmethod
+    def _prompt(raw: dict[str, Any]) -> str:
+        return str(raw.get("prompt") or raw.get("description") or "")

--- a/bench/server/run/catalog.py
+++ b/bench/server/run/catalog.py
@@ -6,8 +6,10 @@ mapping from public labels to full task_ids. v3 labels use the full task_id.
 
 import json
 import logging
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -35,10 +37,17 @@ class TaskCatalog:
     Accepts both public labels and full task_ids via :meth:`resolve`.
     """
 
-    def __init__(self, bench_root: Path):
+    def __init__(
+        self,
+        bench_root: Path,
+        *,
+        plugin_task_suites: Iterable[Any] = (),
+    ):
         self._entries: dict[str, TaskEntry] = {}  # label -> entry
         self._by_id: dict[str, TaskEntry] = {}  # task_id -> entry
         self._scan(bench_root / "tasks")
+        for suite in plugin_task_suites:
+            self._scan_plugin_suite(suite)
         logger.info(
             "TaskCatalog: %d tasks loaded (%d labels)",
             len(self._by_id),
@@ -72,26 +81,86 @@ class TaskCatalog:
                 logger.debug("TaskCatalog: no label pattern in %s", task_id)
                 continue
 
-            if label in self._entries:
-                existing = self._entries[label]
-                raise ValueError(
-                    f"TaskCatalog: duplicate public label '{label}' — "
-                    f"'{task_id}' conflicts with '{existing.task_id}'"
+            self._add_entry(
+                TaskEntry(
+                    public_label=label,
+                    task_id=task_id,
+                    category=data.get("category", ""),
+                    difficulty=data.get("difficulty", ""),
+                    persona_id=data.get("persona_id", ""),
+                    max_turns=data.get("max_turns", 30),
+                    timeout_minutes=data.get("timeout_minutes", 15),
+                    source_path=json_path,
                 )
-
-            entry = TaskEntry(
-                public_label=label,
-                task_id=task_id,
-                category=data.get("category", ""),
-                difficulty=data.get("difficulty", ""),
-                persona_id=data.get("persona_id", ""),
-                max_turns=data.get("max_turns", 30),
-                timeout_minutes=data.get("timeout_minutes", 15),
-                source_path=json_path,
             )
 
-            self._entries[label] = entry
-            self._by_id[task_id] = entry
+    def _scan_plugin_suite(self, suite: Any) -> None:
+        supported_tasks = getattr(suite, "supported_tasks", None)
+        get_task = getattr(suite, "get_task", None)
+        if not callable(supported_tasks) or not callable(get_task):
+            return
+
+        for task_id in sorted(supported_tasks()):
+            try:
+                item = get_task(task_id)
+            except Exception as exc:
+                logger.warning(
+                    "TaskCatalog: plugin task %s skipped: %s",
+                    task_id,
+                    exc,
+                )
+                continue
+
+            metadata = getattr(item, "metadata", {}) or {}
+            if (
+                not isinstance(metadata, Mapping)
+                or not metadata.get("public_run_task")
+            ):
+                continue
+
+            payload = getattr(item, "payload", {}) or {}
+            if not isinstance(payload, Mapping):
+                payload = {}
+            business_task = payload.get("impl_b_task", {})
+            if not isinstance(business_task, Mapping):
+                business_task = {}
+
+            public_label = str(
+                metadata.get("public_label")
+                or business_task.get("public_label")
+                or item.task_id
+            )
+            self._add_entry(
+                TaskEntry(
+                    public_label=public_label,
+                    task_id=str(item.task_id),
+                    category=str(
+                        metadata.get("category")
+                        or business_task.get("category")
+                        or "plugin"
+                    ),
+                    difficulty=str(
+                        metadata.get("difficulty")
+                        or business_task.get("difficulty")
+                        or "unknown"
+                    ),
+                    persona_id=str(business_task.get("persona_id") or ""),
+                    max_turns=int(business_task.get("max_turns") or 30),
+                    timeout_minutes=int(business_task.get("timeout_minutes") or 15),
+                    source_path=Path(f"<plugin:{suite.__class__.__name__}>"),
+                )
+            )
+
+    def _add_entry(self, entry: TaskEntry) -> None:
+        if entry.public_label in self._entries:
+            existing = self._entries[entry.public_label]
+            raise ValueError(
+                f"TaskCatalog: duplicate public label '{entry.public_label}' — "
+                f"'{entry.task_id}' conflicts with '{existing.task_id}'"
+            )
+
+        self._entries[entry.public_label] = entry
+        self._by_id[entry.task_id] = entry
 
     def resolve(self, label_or_id: str) -> TaskEntry | None:
         """Accept both public labels and full task_ids."""

--- a/bench/tasks/impl_b/IMPLB_CSV_01_inventory.json
+++ b/bench/tasks/impl_b/IMPLB_CSV_01_inventory.json
@@ -1,0 +1,37 @@
+{
+  "task_id": "IMPLB_CSV_01_inventory",
+  "version": "1.0",
+  "difficulty": "easy",
+  "category": "data_engineering",
+  "subcategory": "impl_b_csv",
+  "description": "Create a simple inventory CSV with required columns.",
+  "prompt": "Use the mounted reference data at /data/reference_numbers.csv if helpful. Create output/inventory.csv with columns sku, quantity, and location. Include at least three data rows.",
+  "data_mounts": [
+    {
+      "uri": "file://tasks/impl_b/fixtures/reference_numbers.csv",
+      "target_path": "/data/reference_numbers.csv",
+      "read_only": true
+    }
+  ],
+  "expected_outputs": [
+    {
+      "path": "output/inventory.csv",
+      "type": "csv",
+      "required_columns": ["sku", "quantity", "location"],
+      "min_rows": 3
+    }
+  ],
+  "required_capabilities": ["write_csv_artifact"],
+  "sandbox": {
+    "image_uri": "quant-bench-env:v3.0",
+    "resource_limits": {
+      "cpu_count": 1,
+      "memory_mb": 512,
+      "wall_timeout_seconds": 120,
+      "network_enabled": false
+    }
+  },
+  "persona_id": "double_novice",
+  "max_turns": 2,
+  "timeout_minutes": 5
+}

--- a/bench/tasks/impl_b/IMPLB_CSV_02_daily_metrics.json
+++ b/bench/tasks/impl_b/IMPLB_CSV_02_daily_metrics.json
@@ -1,0 +1,37 @@
+{
+  "task_id": "IMPLB_CSV_02_daily_metrics",
+  "version": "1.0",
+  "difficulty": "easy",
+  "category": "data_engineering",
+  "subcategory": "impl_b_csv",
+  "description": "Create a deterministic daily metrics CSV.",
+  "prompt": "Create output/daily_metrics.csv with columns date, metric, and value. Include at least five data rows.",
+  "data_mounts": [
+    {
+      "uri": "file://tasks/impl_b/fixtures/reference_numbers.csv",
+      "target_path": "/data/reference_numbers.csv",
+      "read_only": true
+    }
+  ],
+  "expected_outputs": [
+    {
+      "path": "output/daily_metrics.csv",
+      "type": "csv",
+      "required_columns": ["date", "metric", "value"],
+      "min_rows": 5
+    }
+  ],
+  "required_capabilities": ["write_csv_artifact"],
+  "sandbox": {
+    "image_uri": "quant-bench-env:v3.0",
+    "resource_limits": {
+      "cpu_count": 1,
+      "memory_mb": 512,
+      "wall_timeout_seconds": 120,
+      "network_enabled": false
+    }
+  },
+  "persona_id": "double_novice",
+  "max_turns": 2,
+  "timeout_minutes": 5
+}

--- a/bench/tasks/impl_b/IMPLB_JSON_01_summary.json
+++ b/bench/tasks/impl_b/IMPLB_JSON_01_summary.json
@@ -1,0 +1,40 @@
+{
+  "task_id": "IMPLB_JSON_01_summary",
+  "version": "1.0",
+  "difficulty": "easy",
+  "category": "data_engineering",
+  "subcategory": "impl_b_json",
+  "description": "Create a simple JSON summary artifact.",
+  "prompt": "Read /data/reference_numbers.csv if it is mounted. Create output/summary.json with keys row_count, column_count, and valid. row_count must be at least 3 and valid must be true.",
+  "data_mounts": [
+    {
+      "uri": "file://tasks/impl_b/fixtures/reference_numbers.csv",
+      "target_path": "/data/reference_numbers.csv",
+      "read_only": true
+    }
+  ],
+  "expected_outputs": [
+    {
+      "path": "output/summary.json",
+      "type": "json",
+      "required_keys": ["row_count", "column_count", "valid"],
+      "constraints": [
+        {"key": "row_count", "op": ">=", "value": 3},
+        {"key": "valid", "op": "==", "value": true}
+      ]
+    }
+  ],
+  "required_capabilities": ["write_json_artifact"],
+  "sandbox": {
+    "image_uri": "quant-bench-env:v3.0",
+    "resource_limits": {
+      "cpu_count": 1,
+      "memory_mb": 512,
+      "wall_timeout_seconds": 120,
+      "network_enabled": false
+    }
+  },
+  "persona_id": "double_novice",
+  "max_turns": 2,
+  "timeout_minutes": 5
+}

--- a/bench/tasks/impl_b/IMPLB_JSON_02_risk_flags.json
+++ b/bench/tasks/impl_b/IMPLB_JSON_02_risk_flags.json
@@ -1,0 +1,40 @@
+{
+  "task_id": "IMPLB_JSON_02_risk_flags",
+  "version": "1.0",
+  "difficulty": "easy",
+  "category": "data_engineering",
+  "subcategory": "impl_b_json",
+  "description": "Create a JSON risk flag report.",
+  "prompt": "Create output/risk_flags.json with keys risk_count, approved, and notes. risk_count must be non-negative and approved must be true.",
+  "data_mounts": [
+    {
+      "uri": "file://tasks/impl_b/fixtures/reference_numbers.csv",
+      "target_path": "/data/reference_numbers.csv",
+      "read_only": true
+    }
+  ],
+  "expected_outputs": [
+    {
+      "path": "output/risk_flags.json",
+      "type": "json",
+      "required_keys": ["risk_count", "approved", "notes"],
+      "constraints": [
+        {"key": "risk_count", "op": ">=", "value": 0},
+        {"key": "approved", "op": "==", "value": true}
+      ]
+    }
+  ],
+  "required_capabilities": ["write_json_artifact"],
+  "sandbox": {
+    "image_uri": "quant-bench-env:v3.0",
+    "resource_limits": {
+      "cpu_count": 1,
+      "memory_mb": 512,
+      "wall_timeout_seconds": 120,
+      "network_enabled": false
+    }
+  },
+  "persona_id": "double_novice",
+  "max_turns": 2,
+  "timeout_minutes": 5
+}

--- a/bench/tasks/impl_b/IMPLB_JSON_03_manifest.json
+++ b/bench/tasks/impl_b/IMPLB_JSON_03_manifest.json
@@ -1,0 +1,39 @@
+{
+  "task_id": "IMPLB_JSON_03_manifest",
+  "version": "1.0",
+  "difficulty": "easy",
+  "category": "data_engineering",
+  "subcategory": "impl_b_json",
+  "description": "Create a JSON manifest.",
+  "prompt": "Create output/manifest.json with keys source, records, and schema_version. records must be at least 3.",
+  "data_mounts": [
+    {
+      "uri": "file://tasks/impl_b/fixtures/reference_numbers.csv",
+      "target_path": "/data/reference_numbers.csv",
+      "read_only": true
+    }
+  ],
+  "expected_outputs": [
+    {
+      "path": "output/manifest.json",
+      "type": "json",
+      "required_keys": ["source", "records", "schema_version"],
+      "constraints": [
+        {"key": "records", "op": ">=", "value": 3}
+      ]
+    }
+  ],
+  "required_capabilities": ["write_json_artifact"],
+  "sandbox": {
+    "image_uri": "quant-bench-env:v3.0",
+    "resource_limits": {
+      "cpu_count": 1,
+      "memory_mb": 512,
+      "wall_timeout_seconds": 120,
+      "network_enabled": false
+    }
+  },
+  "persona_id": "double_novice",
+  "max_turns": 2,
+  "timeout_minutes": 5
+}

--- a/bench/tasks/impl_b/fixtures/reference_numbers.csv
+++ b/bench/tasks/impl_b/fixtures/reference_numbers.csv
@@ -1,0 +1,5 @@
+id,value,group
+a,1,control
+b,2,control
+c,3,treatment
+d,4,treatment

--- a/bench/tests/integration/test_bundle_roundtrip.py
+++ b/bench/tests/integration/test_bundle_roundtrip.py
@@ -1,4 +1,4 @@
-"""Bundle v1 round-trip coverage for the reference plugin contract."""
+"""Bundle v1 round-trip coverage for plugin contracts."""
 
 from __future__ import annotations
 
@@ -33,6 +33,7 @@ from platform_api.contracts import (
     TranscriptMessage,
 )
 from platform_api.plugins import PluginLoader
+from server.impl_b import load_impl_b_bundle
 from server.reference import REFERENCE_BUNDLE_CONFIG, load_reference_bundle
 
 
@@ -527,6 +528,109 @@ def test_reference_bundle_roundtrip_re_evaluates_to_same_score(
         item=reconstructed_item,
         bench_root=bench_root,
         workspace=tmp_path / "replay" / task_id / "workspace",
+    )
+    reproduced_score = fresh_bundle.evaluator.evaluate(
+        reconstructed_item,
+        reconstructed_sample,
+    )
+
+    assert stored_score.value == pytest.approx(original_score.value)
+    assert reproduced_score.value == pytest.approx(original_score.value)
+    assert reproduced_score.status == original_score.status
+    assert reproduced_score.metrics == original_score.metrics
+
+
+def _impl_b_sample_for_task(
+    *,
+    item: EvalItem,
+    tmp_path: Path,
+) -> EvalSample:
+    workspace = tmp_path / item.task_id / "workspace"
+    _write_expected_outputs(workspace, list(item.payload["expected_outputs"]))
+    return EvalSample(
+        sample_id=f"{item.task_id}-roundtrip",
+        task_id=item.task_id,
+        transcript=(
+            TranscriptMessage(role="user", content=str(item.payload["prompt"])),
+            TranscriptMessage(role="assistant", content="Artifacts are ready."),
+        ),
+        files=_file_artifacts(workspace),
+        payload={
+            "eval_model": "fake-model",
+            "workspace_path": str(workspace),
+        },
+    )
+
+
+def _impl_b_contract_bundle(
+    *,
+    item: EvalItem,
+    sample: EvalSample,
+    score: Score,
+) -> Bundle:
+    return Bundle(
+        bundle_id=sample.sample_id,
+        schema_version=SCHEMA_VERSION,
+        task_id=item.task_id,
+        timestamps=BundleTimestamps(created_at="2026-05-06T00:00:00Z"),
+        agent_id="impl-b-roundtrip-fixture",
+        sandbox_digest={
+            "image_uri": item.sandbox_spec.image_uri if item.sandbox_spec else "",
+        },
+        telemetry={"eval_model": sample.payload.get("eval_model")},
+        messages=_bundle_messages(sample),
+        tool_calls=_bundle_tool_calls(sample),
+        artifacts={
+            REFERENCE_ARTIFACT_KEY: {
+                "plugin": "impl_b_programmatic",
+                "session_id": sample.sample_id,
+                "termination_reason": "roundtrip_fixture",
+                "task_version": item.version,
+            },
+            CONTRACT_ARTIFACT_KEY: {
+                "eval_item": _eval_item_to_json(item),
+                "eval_sample": _eval_sample_to_json(sample),
+                "original_score": _score_to_json(score),
+            },
+            WORKSPACE_CONTENTS_ARTIFACT_KEY: _workspace_content_store(sample),
+        },
+        workspace=_workspace_snapshot(sample),
+    )
+
+
+def test_impl_b_bundle_roundtrip_re_evaluates_to_same_score(
+    bench_root: Path,
+    tmp_path: Path,
+):
+    task_id = "IMPLB_JSON_01_summary"
+    bundle = load_impl_b_bundle(bench_root=bench_root, eval_model="fake-model")
+    item = bundle.task_suite.get_task(task_id)
+    sample = _impl_b_sample_for_task(item=item, tmp_path=tmp_path)
+    original_score = bundle.evaluator.evaluate(item, sample)
+
+    bundle_json = bundle_io.to_json(
+        _impl_b_contract_bundle(item=item, sample=sample, score=original_score)
+    )
+    validate_bundle_dict(json.loads(bundle_json))
+
+    imported_bundle = bundle_io.from_json(bundle_json)
+    contract = imported_bundle.artifacts[CONTRACT_ARTIFACT_KEY]
+    stored_score = _score_from_json(contract["original_score"])
+
+    fresh_bundle = load_impl_b_bundle(bench_root=bench_root, eval_model="fake-model")
+    reconstructed_item = fresh_bundle.task_suite.get_task(imported_bundle.task_id)
+    replay_workspace = tmp_path / "replay" / task_id / "workspace"
+    files = _materialize_replay_workspace(imported_bundle, replay_workspace)
+    reconstructed_sample = EvalSample(
+        sample_id=imported_bundle.session_id,
+        task_id=imported_bundle.task_id,
+        transcript=_transcript_from_bundle(imported_bundle),
+        tool_logs=_tool_logs_from_bundle(imported_bundle),
+        files=files,
+        payload={
+            "eval_model": "fake-model",
+            "workspace_path": str(replay_workspace),
+        },
     )
     reproduced_score = fresh_bundle.evaluator.evaluate(
         reconstructed_item,

--- a/bench/tests/integration/test_impl_b_bundle.py
+++ b/bench/tests/integration/test_impl_b_bundle.py
@@ -1,0 +1,210 @@
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from platform_api.contracts import EvalSample, TranscriptMessage
+from platform_api.plugins import PluginLoader
+from server.impl_b import IMPL_B_BUNDLE_CONFIG, load_impl_b_bundle
+
+TASK_ID = "IMPLB_JSON_01_summary"
+
+
+def _json_payload_for(spec: dict[str, Any]) -> dict[str, Any]:
+    payload = {key: 1 for key in spec.get("required_keys", [])}
+    for constraint in spec.get("constraints", []) or []:
+        key = constraint.get("key")
+        op = constraint.get("op")
+        if not key:
+            continue
+        if "ref" in constraint:
+            ref = constraint["ref"]
+            payload.setdefault(ref, 1)
+            if op == "<":
+                payload[key], payload[ref] = 0, 1
+            elif op == ">":
+                payload[key], payload[ref] = 2, 1
+            else:
+                payload[key], payload[ref] = 1, 1
+            continue
+
+        value = constraint.get("value", 1)
+        if op == "<":
+            payload[key] = value - 1
+        elif op == "<=":
+            payload[key] = value
+        elif op == ">":
+            payload[key] = value + 1
+        elif op == ">=":
+            payload[key] = value
+        elif op == "==":
+            payload[key] = value
+        elif op == "!=":
+            payload[key] = value + 1
+    return payload
+
+
+def _write_expected_outputs(workspace: Path, expected_outputs: list[Any]) -> None:
+    for spec in expected_outputs:
+        if not isinstance(spec, dict):
+            continue
+        path = workspace / str(spec["path"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        file_type = spec.get("type", "any")
+        if file_type == "json":
+            path.write_text(json.dumps(_json_payload_for(spec)), encoding="utf-8")
+        elif file_type == "csv":
+            columns = spec.get("required_columns") or ["metric", "value"]
+            rows = max(1, int(spec.get("min_rows") or 1))
+            lines = [",".join(columns)]
+            lines.extend(",".join(str(index) for _ in columns) for index in range(rows))
+            path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        else:
+            path.write_text("artifact\n", encoding="utf-8")
+
+
+def test_impl_b_bundle_loads_from_config(bench_root):
+    bundles = PluginLoader().load_config(IMPL_B_BUNDLE_CONFIG)
+    assert len(bundles) == 1
+
+    bundle = load_impl_b_bundle(bench_root=bench_root, eval_model="fake-model")
+    supported = bundle.task_suite.supported_tasks()
+
+    assert bundle.name == "impl_b_programmatic"
+    assert len(supported) == 5
+    assert TASK_ID in supported
+    assert bundle.evaluator.metadata().capabilities == frozenset(
+        {"programmatic_l1", "no_llm_judge"}
+    )
+
+
+def test_impl_b_task_suite_declares_mounts_and_business_adapter(bench_root):
+    bundle = load_impl_b_bundle(bench_root=bench_root, eval_model="fake-model")
+
+    item = bundle.task_suite.get_task(TASK_ID)
+    task = bundle.task_suite.get_business_task(TASK_ID)
+
+    assert item.payload["expected_outputs"][0]["path"] == "output/summary.json"
+    assert item.sandbox_spec.image_uri == "quant-bench-env:v3.0"
+    assert item.data_mounts[0].uri.startswith("file://")
+    assert item.data_mounts[0].target_path == "/data/reference_numbers.csv"
+    assert (
+        bundle.task_suite._resolve_file_uri("file://localhost/tmp/reference.csv")
+        == "file:///tmp/reference.csv"
+    )
+    assert task.task_id == TASK_ID
+    assert task.ground_truth.expected_outputs == item.payload["expected_outputs"]
+
+
+def test_impl_b_trivial_npc_terminates_after_first_agent_turn(bench_root):
+    bundle = load_impl_b_bundle(bench_root=bench_root, eval_model="fake-model")
+    item = bundle.task_suite.get_task(TASK_ID)
+
+    assert "summary.json" in bundle.npc_provider.initial_message(item)
+    reply = bundle.npc_provider.respond(
+        (
+            TranscriptMessage(role="user", content=bundle.npc_provider.initial_message(item)),
+            TranscriptMessage(role="assistant", content="I wrote the file."),
+        ),
+        (),
+        {},
+        item.payload,
+    )
+
+    assert reply.message == "continue"
+    assert reply.terminate is True
+    assert reply.telemetry["llm_judge_used"] is False
+
+
+def test_impl_b_programmatic_evaluator_scores_expected_outputs(bench_root, tmp_path):
+    bundle = load_impl_b_bundle(bench_root=bench_root, eval_model="fake-model")
+    item = bundle.task_suite.get_task(TASK_ID)
+    workspace = tmp_path / "workspace"
+    _write_expected_outputs(workspace, item.payload["expected_outputs"])
+
+    score = bundle.evaluator.evaluate(
+        item,
+        EvalSample(
+            sample_id="impl-b-direct",
+            task_id=TASK_ID,
+            transcript=(
+                TranscriptMessage(role="user", content=item.payload["prompt"]),
+                TranscriptMessage(role="assistant", content="Artifacts are ready."),
+            ),
+            payload={"workspace_path": str(workspace), "eval_model": "fake-model"},
+        ),
+    )
+
+    assert score.value == 1.0
+    assert score.status == "completed_scored"
+    assert score.metrics["programmatic"]["n_passed"] == 1
+    assert score.telemetry["llm_judge_used"] is False
+
+
+@pytest.mark.asyncio
+async def test_impl_b_rest_register_complete_score_flow(bench_root):
+    from server.api.http_app import create_app
+
+    bundle = load_impl_b_bundle(bench_root=bench_root, eval_model="fake-model")
+    app = create_app(
+        use_docker=False,
+        bench_root=str(bench_root),
+        eval_model="fake-model",
+        plugin_bundle=bundle,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        start_run = await client.post("/client/runs/start", json={"task": TASK_ID})
+        assert start_run.status_code == 200, start_run.text
+        token = start_run.json()["token"]
+        assert start_run.json()["public_task_label"] == TASK_ID
+
+        register = await client.post(
+            "/session/register",
+            json={},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert register.status_code == 200, register.text
+        sid = register.json()["session_id"]
+
+        start = await client.post(f"/session/{sid}/start", json={})
+        assert start.status_code == 200, start.text
+        assert "summary.json" in start.json()["user_message"]
+
+        write = await client.post(
+            f"/session/{sid}/tool/file_write",
+            json={
+                "path": "output/summary.json",
+                "content": json.dumps(
+                    {"row_count": 4, "column_count": 3, "valid": True}
+                ),
+            },
+        )
+        assert write.status_code == 200, write.text
+        assert write.json()["success"] is True
+
+        sent = await client.post(
+            f"/session/{sid}/send",
+            json={"text": "I created output/summary.json."},
+        )
+        assert sent.status_code == 200, sent.text
+        assert sent.json()["status"] == "completed"
+
+        score_body = {}
+        for _ in range(50):
+            scores = await client.get(f"/session/{sid}/scores")
+            assert scores.status_code == 200, scores.text
+            score_body = scores.json()
+            if score_body.get("score_status") == "completed_scored":
+                break
+            await asyncio.sleep(0.02)
+
+    assert score_body["score_status"] == "completed_scored"
+    assert score_body["task_score"] == 1.0
+    assert score_body["detail"]["dimensions"][0]["name"] == "programmatic"

--- a/bench/tests/test_run_catalog.py
+++ b/bench/tests/test_run_catalog.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -82,6 +83,41 @@ class TaskCatalogTests(unittest.TestCase):
 
             self.assertEqual([{"label": "L2_ADV_01_demo"}], cat.list_labels_only())
             self.assertIsNone(cat.resolve("L1_DAT_01_demo"))
+
+    def test_public_plugin_tasks_are_available_for_run_creation(self):
+        class PublicPluginSuite:
+            def supported_tasks(self):
+                return {"IMPLB_JSON_01_summary"}
+
+            def get_task(self, task_id):
+                return SimpleNamespace(
+                    task_id=task_id,
+                    metadata={"public_run_task": True},
+                    payload={
+                        "impl_b_task": {
+                            "category": "data_engineering",
+                            "difficulty": "easy",
+                            "persona_id": "impl_b_trivial",
+                            "max_turns": 2,
+                            "timeout_minutes": 5,
+                        }
+                    },
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cat = TaskCatalog(
+                Path(tmp),
+                plugin_task_suites=(PublicPluginSuite(),),
+            )
+
+            entry = cat.resolve("IMPLB_JSON_01_summary")
+
+            self.assertIsNotNone(entry)
+            self.assertEqual("IMPLB_JSON_01_summary", entry.task_id)
+            self.assertEqual(
+                [{"label": "IMPLB_JSON_01_summary"}],
+                cat.list_labels_only(),
+            )
 
 
 if __name__ == "__main__":

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ bench/
   server/              HTTP/MCP service, run control, session storage, UI
   client/              External client adapters for MCP and REST
   orchestrator/        Legacy pre-server batch scaffolding
-  tasks/               Active task definitions in L0/, L1/, and L2/
+  tasks/               Active task definitions in L0/, L1/, L2/, and impl_b/
   personas/            User persona profiles
   data/                Market/reference data
   experiments/         Validation experiments and generated report pipelines
@@ -106,6 +106,18 @@ persona-emitted `task_end` flag.
 `ReferenceEvaluator` handles deterministic L0/L1 scoring and delegates Layer 2
 QR/QP scoring to the existing coordinator path. `server.config.prompt_config`
 remains a source-compatibility shim and performs no prompt shaping.
+
+`bench/server/impl_b/` owns the second concrete plugin bundle. It uses the same
+`PluginLoader` and platform ABCs as the reference bundle, while keeping business
+logic intentionally small: `ImplBTaskSuite` wraps deterministic JSON/CSV artifact
+tasks from `bench/tasks/impl_b/`, `TrivialNPCProvider` returns the task prompt and
+closes after one agent turn, and `ProgrammaticEvaluator` scores only structured
+`expected_outputs` through `eval.programmatic.l1_verifier`. The bundle config is
+`bench/server/impl_b/bundle.json`; it requires no LLM judge path and declares
+file-backed `DataMount` inputs plus the standard v3 sandbox image. When this
+bundle is active, its `public_run_task` metadata lets `server.run.catalog`
+publish the Impl B task IDs through the same `/client/runs/start` flow as L2
+tasks.
 
 `server.core.session.build_background()` returns a JSON-able
 `platform_background.v1` fact object for sandbox image, resource limits,


### PR DESCRIPTION
## Change

Adds the Impl B programmatic-only plugin bundle for framework swappability validation:
- `ImplBTaskSuite` over 5 deterministic JSON/CSV artifact tasks
- `TrivialNPCProvider` for prompt-only, one-turn completion
- `ProgrammaticEvaluator` backed by `eval.programmatic.l1_verifier`
- active plugin public run catalog support via `metadata.public_run_task`
- integration coverage for `/client/runs/start` through register, completion, and scoring
- Bundle round-trip coverage and architecture docs

Platform contract unchanged: `bench/platform_api/` stayed untouched.

## Verification

- `PYTHONPATH=bench pytest bench/tests/integration/test_impl_b_bundle.py bench/tests/integration/test_bundle_roundtrip.py bench/tests/test_run_catalog.py -q` -> 13 passed
- `PYTHONPATH=bench pytest bench/tests/unit/test_platform_api.py bench/tests/integration/test_reference_bundle.py -q` -> 32 passed
- Loader smoke -> `impl_b_programmatic 5 file:///home/rick/Desktop/benchmark/bench/tasks/impl_b/fixtures/reference_numbers.csv True`
- `git diff --cached --check` -> passed before commit
- Ruff check skipped: module `ruff` is absent from `.venv`

Closes #184