### PR TITLE
feat(reviews): add in-platform human review workflow

### DIFF
--- a/bench/eval/backfill/run_state_to_bundle.py
+++ b/bench/eval/backfill/run_state_to_bundle.py
@@ -38,6 +38,7 @@ from eval.contracts.bundle import (
     WorkspaceFile,
     WorkspaceSnapshot,
 )
+from eval.storage.human_reviews import export_human_reviews_for_result
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,7 @@ def backfill(
             root="agent_files",
             files=_build_workspace_manifest(run_state_path.parent / "agent_files"),
         ),
+        human_reviews=export_human_reviews_for_result(run_state_path.parent),
     )
 
     out = output or run_state_path.parent / "bundle.json"

--- a/bench/eval/contracts/bundle.py
+++ b/bench/eval/contracts/bundle.py
@@ -82,6 +82,7 @@ class Bundle:
     tool_calls: list[ToolCall] = field(default_factory=list)
     artifacts: dict[str, Any] = field(default_factory=dict)
     workspace: WorkspaceSnapshot = field(default_factory=WorkspaceSnapshot)
+    human_reviews: list[dict[str, Any]] = field(default_factory=list)
 
     @property
     def reference_artifact(self) -> dict[str, Any]:

--- a/bench/eval/contracts/bundle_io.py
+++ b/bench/eval/contracts/bundle_io.py
@@ -24,7 +24,10 @@ class BundleError(RuntimeError):
 
 def to_dict(bundle: Bundle) -> dict[str, Any]:
     """Serialize a Bundle to a plain dict suitable for JSON dumping."""
-    return asdict(bundle)
+    payload = asdict(bundle)
+    if not payload.get("human_reviews"):
+        payload.pop("human_reviews", None)
+    return payload
 
 
 def to_json(bundle: Bundle, *, indent: int = 2) -> str:
@@ -77,6 +80,9 @@ def from_dict(data: dict[str, Any]) -> Bundle:
         ],
         artifacts=_dict_or_empty(data.get("artifacts")),
         workspace=_workspace_from_dict(data.get("workspace") or {}),
+        human_reviews=[
+            item for item in (data.get("human_reviews") or []) if isinstance(item, dict)
+        ],
     )
 
 

--- a/bench/eval/contracts/bundle_v1_alpha.schema.json
+++ b/bench/eval/contracts/bundle_v1_alpha.schema.json
@@ -77,6 +77,12 @@
     },
     "workspace": {
       "$ref": "#/$defs/workspace"
+    },
+    "human_reviews": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/human_review"
+      }
     }
   },
   "additionalProperties": true,
@@ -194,6 +200,43 @@
           "type": "string"
         },
         "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "human_review": {
+      "type": "object",
+      "required": ["version", "record_type", "score_id"],
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "record_type": {
+          "type": "string",
+          "enum": ["annotation", "irr_summary"]
+        },
+        "review_id": {
+          "type": "string"
+        },
+        "score_id": {
+          "type": "string"
+        },
+        "reviewer_id": {
+          "type": "string"
+        },
+        "submitted_at": {
+          "type": "string"
+        },
+        "criteria": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "summary": {
           "type": "object",
           "additionalProperties": true
         }

--- a/bench/eval/programmatic/inter_rater_reliability.py
+++ b/bench/eval/programmatic/inter_rater_reliability.py
@@ -1,0 +1,176 @@
+"""Inter-rater reliability helpers for human review annotations."""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Any
+
+
+DEFAULT_SCORE_LABELS = (1, 2, 3, 4, 5)
+
+
+def compute_inter_rater_reliability(
+    records: list[dict[str, Any]],
+    *,
+    min_reviewers: int = 3,
+    labels: tuple[int, ...] = DEFAULT_SCORE_LABELS,
+) -> dict[str, Any]:
+    """Compute reviewer agreement for score-bound human review records.
+
+    Records are collapsed to the latest submission per reviewer. The overall
+    Cohen kappa is computed over common criterion vectors for every reviewer
+    pair. Per-criterion rows expose reviewer counts, score counts, exact
+    pairwise agreement, and an agreement-adjusted kappa on the configured score
+    scale for the single-session admin view.
+    """
+
+    latest = _latest_record_by_reviewer(records)
+    reviewer_count = len(latest)
+    if reviewer_count < min_reviewers:
+        return {
+            "status": "insufficient_reviewers",
+            "reviewer_count": reviewer_count,
+            "min_reviewers": min_reviewers,
+            "overall_cohen_kappa": None,
+            "per_criterion": [],
+        }
+
+    by_reviewer = {
+        reviewer_id: _criteria_scores(record)
+        for reviewer_id, record in latest.items()
+    }
+    criterion_ids = sorted(
+        {
+            criterion_id
+            for scores in by_reviewer.values()
+            for criterion_id in scores.keys()
+        }
+    )
+
+    per_criterion: list[dict[str, Any]] = []
+    for criterion_id in criterion_ids:
+        scores = {
+            reviewer_id: values[criterion_id]
+            for reviewer_id, values in by_reviewer.items()
+            if criterion_id in values
+        }
+        per_criterion.append(
+            _criterion_summary(criterion_id, scores, labels=labels)
+        )
+
+    pairwise: list[dict[str, Any]] = []
+    for left_id, right_id in combinations(sorted(by_reviewer), 2):
+        common = sorted(set(by_reviewer[left_id]) & set(by_reviewer[right_id]))
+        left_scores = [by_reviewer[left_id][criterion_id] for criterion_id in common]
+        right_scores = [by_reviewer[right_id][criterion_id] for criterion_id in common]
+        pairwise.append(
+            {
+                "reviewer_a": left_id,
+                "reviewer_b": right_id,
+                "common_criteria": common,
+                "cohen_kappa": cohen_kappa(left_scores, right_scores, labels=labels),
+            }
+        )
+
+    kappas = [
+        float(item["cohen_kappa"])
+        for item in pairwise
+        if isinstance(item.get("cohen_kappa"), (int, float))
+    ]
+    overall = sum(kappas) / len(kappas) if kappas else None
+    return {
+        "status": "computed",
+        "reviewer_count": reviewer_count,
+        "min_reviewers": min_reviewers,
+        "criteria_count": len(criterion_ids),
+        "overall_cohen_kappa": overall,
+        "per_criterion": per_criterion,
+        "pairwise": pairwise,
+    }
+
+
+def cohen_kappa(
+    left: list[int],
+    right: list[int],
+    *,
+    labels: tuple[int, ...] = DEFAULT_SCORE_LABELS,
+) -> float | None:
+    """Return unweighted Cohen's kappa for two aligned rating vectors."""
+
+    if len(left) != len(right) or not left:
+        return None
+
+    total = len(left)
+    observed = sum(1 for a, b in zip(left, right) if a == b) / total
+    expected = 0.0
+    for label in labels:
+        left_rate = sum(1 for score in left if score == label) / total
+        right_rate = sum(1 for score in right if score == label) / total
+        expected += left_rate * right_rate
+
+    if expected == 1.0:
+        return 1.0 if observed == 1.0 else 0.0
+    return (observed - expected) / (1.0 - expected)
+
+
+def _latest_record_by_reviewer(
+    records: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    latest: dict[str, dict[str, Any]] = {}
+    for record in records:
+        reviewer_id = str(record.get("reviewer_id") or "").strip()
+        if not reviewer_id:
+            continue
+        current = latest.get(reviewer_id)
+        if current is None or str(record.get("submitted_at") or "") >= str(
+            current.get("submitted_at") or ""
+        ):
+            latest[reviewer_id] = record
+    return latest
+
+
+def _criteria_scores(record: dict[str, Any]) -> dict[str, int]:
+    scores: dict[str, int] = {}
+    criteria = record.get("criteria") if isinstance(record, dict) else []
+    if not isinstance(criteria, list):
+        return scores
+    for item in criteria:
+        if not isinstance(item, dict):
+            continue
+        criterion_id = str(item.get("criterion_id") or "").strip()
+        if not criterion_id:
+            continue
+        try:
+            score = int(item.get("score"))
+        except (TypeError, ValueError):
+            continue
+        scores[criterion_id] = score
+    return scores
+
+
+def _criterion_summary(
+    criterion_id: str,
+    scores: dict[str, int],
+    *,
+    labels: tuple[int, ...],
+) -> dict[str, Any]:
+    counts = {str(label): 0 for label in labels}
+    for score in scores.values():
+        counts[str(score)] = counts.get(str(score), 0) + 1
+
+    pairs = list(combinations(scores.values(), 2))
+    if pairs:
+        exact = sum(1 for a, b in pairs if a == b) / len(pairs)
+        chance = 1.0 / len(labels) if labels else 0.0
+        kappa = (exact - chance) / (1.0 - chance) if chance < 1.0 else None
+    else:
+        exact = None
+        kappa = None
+
+    return {
+        "criterion_id": criterion_id,
+        "reviewer_count": len(scores),
+        "score_counts": counts,
+        "exact_pairwise_agreement": exact,
+        "cohen_kappa": kappa,
+    }

--- a/bench/eval/storage/human_reviews.py
+++ b/bench/eval/storage/human_reviews.py
@@ -1,0 +1,260 @@
+"""Score-bound human review persistence for completed evaluations."""
+
+from __future__ import annotations
+
+import json
+import re
+import secrets
+import tempfile
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from eval.programmatic.inter_rater_reliability import (
+    compute_inter_rater_reliability,
+)
+
+
+HUMAN_REVIEW_SCHEMA_VERSION = "human_review_score_v1"
+HUMAN_REVIEW_IRR_SCHEMA_VERSION = "human_review_irr_v1"
+_LOCK = threading.RLock()
+
+
+class HumanReviewStore:
+    """JSON-backed annotations stored beside automated score artifacts."""
+
+    def submit_review(
+        self,
+        result_dir: str | Path,
+        score_id: str,
+        user: Any,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        result_dir = Path(result_dir)
+        score_id = _safe_score_id(score_id)
+        score_dir = self._score_dir(result_dir, score_id)
+        self._require_completed_score(score_dir, score_id)
+
+        record = self._normalize_record(score_id, user, payload)
+        reviews_dir = score_dir / "human_reviews"
+        reviews_dir.mkdir(parents=True, exist_ok=True)
+        path = reviews_dir / f"{record['review_id']}.json"
+        with _LOCK:
+            _atomic_write_json(path, record)
+        return record
+
+    def list_reviews(
+        self,
+        result_dir: str | Path,
+        score_id: str,
+    ) -> list[dict[str, Any]]:
+        reviews_dir = self._score_dir(Path(result_dir), _safe_score_id(score_id)) / (
+            "human_reviews"
+        )
+        if not reviews_dir.is_dir():
+            return []
+        records: list[dict[str, Any]] = []
+        for path in sorted(reviews_dir.glob("*.json")):
+            payload = _read_json(path)
+            if isinstance(payload, dict) and payload.get("version"):
+                records.append(payload)
+        records.sort(key=lambda item: str(item.get("submitted_at") or ""))
+        return records
+
+    def latest_review_for_user(
+        self,
+        result_dir: str | Path,
+        score_id: str,
+        user: Any,
+    ) -> dict[str, Any] | None:
+        reviewer_id = _stable_reviewer_id(user)
+        matches = [
+            record
+            for record in self.list_reviews(result_dir, score_id)
+            if str(record.get("reviewer_id") or "") == reviewer_id
+        ]
+        return matches[-1] if matches else None
+
+    def reviewer_has_review(
+        self,
+        result_dir: str | Path,
+        score_id: str,
+        user: Any,
+    ) -> bool:
+        return self.latest_review_for_user(result_dir, score_id, user) is not None
+
+    def summary(
+        self,
+        result_dir: str | Path,
+        score_id: str,
+    ) -> dict[str, Any]:
+        records = self.list_reviews(result_dir, score_id)
+        reviewer_ids = {
+            str(record.get("reviewer_id") or "")
+            for record in records
+            if record.get("reviewer_id")
+        }
+        return {
+            "score_id": _safe_score_id(score_id),
+            "review_count": len(records),
+            "reviewer_count": len(reviewer_ids),
+            "irr": compute_inter_rater_reliability(records),
+        }
+
+    def export_records_for_result(
+        self,
+        result_dir: str | Path,
+    ) -> list[dict[str, Any]]:
+        result_dir = Path(result_dir)
+        eval_root = result_dir / "evaluations"
+        if not eval_root.is_dir():
+            return []
+
+        exported: list[dict[str, Any]] = []
+        for score_dir in sorted(eval_root.glob("score_*")):
+            if not score_dir.is_dir():
+                continue
+            score_id = score_dir.name
+            records = self.list_reviews(result_dir, score_id)
+            exported.extend(records)
+            if records:
+                exported.append(
+                    {
+                        "version": HUMAN_REVIEW_IRR_SCHEMA_VERSION,
+                        "record_type": "irr_summary",
+                        "score_id": score_id,
+                        "computed_at": _utc_now(),
+                        "summary": compute_inter_rater_reliability(records),
+                    }
+                )
+        return exported
+
+    def _score_dir(self, result_dir: Path, score_id: str) -> Path:
+        return result_dir / "evaluations" / score_id
+
+    def _normalize_record(
+        self,
+        score_id: str,
+        user: Any,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        criteria = _normalize_criteria(payload.get("criteria"))
+        if not criteria:
+            raise ValueError("At least one criterion score is required")
+
+        now = _utc_now()
+        return {
+            "version": HUMAN_REVIEW_SCHEMA_VERSION,
+            "record_type": "annotation",
+            "review_id": f"hr_{secrets.token_hex(12)}",
+            "score_id": score_id,
+            "bundle_id": str(
+                payload.get("bundle_id") or payload.get("session_id") or ""
+            ),
+            "session_id": str(
+                payload.get("session_id") or payload.get("bundle_id") or ""
+            ),
+            "task_id": str(payload.get("task_id") or ""),
+            "reviewer_id": _stable_reviewer_id(user),
+            "github_username": user.github_login,
+            "github_user_id": str(user.github_user_id or ""),
+            "reviewer_role": user.role,
+            "submitted_at": now,
+            "criteria": criteria,
+            "overall_comment": str(payload.get("overall_comment") or "").strip(),
+        }
+
+    def _require_completed_score(self, score_dir: Path, score_id: str) -> None:
+        score = _read_json(score_dir / "score.json")
+        if not isinstance(score, dict):
+            raise FileNotFoundError(f"Score not found: {score_id}")
+        status = str(score.get("score_status") or score.get("status") or "")
+        if status and not status.startswith("completed"):
+            raise ValueError(f"Score must be completed before review: {score_id}")
+
+
+def export_human_reviews_for_result(result_dir: str | Path) -> list[dict[str, Any]]:
+    return HumanReviewStore().export_records_for_result(result_dir)
+
+
+def _normalize_criteria(value: Any) -> list[dict[str, Any]]:
+    raw_items: list[Any]
+    if isinstance(value, dict):
+        raw_items = [
+            dict(item, criterion_id=criterion_id)
+            for criterion_id, item in value.items()
+            if isinstance(item, dict)
+        ]
+    elif isinstance(value, list):
+        raw_items = value
+    else:
+        raw_items = []
+
+    criteria: list[dict[str, Any]] = []
+    for raw in raw_items:
+        if not isinstance(raw, dict):
+            continue
+        criterion_id = str(raw.get("criterion_id") or "").strip()
+        if not criterion_id:
+            raise ValueError("criterion_id is required")
+        try:
+            score = int(raw.get("score"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Score for {criterion_id} must be an integer") from exc
+        if score < 1 or score > 5:
+            raise ValueError(f"Score for {criterion_id} must be between 1 and 5")
+        justification = str(raw.get("justification") or "").strip()
+        if not justification:
+            raise ValueError(f"Justification for {criterion_id} is required")
+        criteria.append(
+            {
+                "criterion_id": criterion_id,
+                "score": score,
+                "justification": justification,
+                "evidence": str(raw.get("evidence") or "").strip(),
+            }
+        )
+    return criteria
+
+
+def _safe_score_id(value: str) -> str:
+    score_id = str(value or "").strip()
+    if not re.fullmatch(r"score_[A-Za-z0-9_.-]+", score_id):
+        raise ValueError("Invalid score_id")
+    return score_id
+
+
+def _stable_reviewer_id(user: Any) -> str:
+    return str(user.github_user_id or user.user_id or user.github_login or "").strip()
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            json.dump(payload, tmp, indent=2, ensure_ascii=False)
+            tmp.write("\n")
+            tmp_path = Path(tmp.name)
+        tmp_path.replace(path)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            tmp_path.unlink()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -47,6 +47,7 @@ from server.run.jobs import (
     JOB_STATUS_RUNNING,
 )
 from server.run.models import RunStatus
+from server.api.review_api import review_api_routes
 from server.web.ui_app import extract_bearer_token, resolve_run_from_token, ui_routes
 
 from .limits import HEAVY_TOOLS, backtest_sem
@@ -2446,6 +2447,7 @@ def create_app(
         Route("/api/runs/{run_id}/resume", api_run_resume, methods=["POST"]),
         Route("/api/runs/{run_id}/replay", api_run_replay, methods=["GET"]),
         Route("/api/runs/{run_id}/state", api_run_state, methods=["GET"]),
+        *review_api_routes(manager),
         # Operator-only evaluation surface: not reachable from MCP or
         # client-facing /session tool dispatch.
         Route("/ops/session/{sid}/evaluate", ops_evaluate, methods=["POST"]),

--- a/bench/server/api/review_api.py
+++ b/bench/server/api/review_api.py
@@ -1,0 +1,169 @@
+"""Score-bound human review API routes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from eval.storage.human_reviews import HumanReviewStore
+from server.audit import record_event
+from server.auth import AuthService
+from server.web.ui_indexer import ResultIndexer
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+
+def review_api_routes(manager) -> list[Route]:
+    auth = AuthService(manager.bench_root)
+    indexer = ResultIndexer(manager.bench_root)
+    store = HumanReviewStore()
+
+    def _review_scope_flags(request: Request, user) -> tuple[bool, bool]:
+        mine = request.query_params.get("mine", "").strip().lower()
+        if mine in ("1", "true", "yes", "on"):
+            return False, False
+        scope = request.query_params.get("scope", "").strip().lower()
+        include_all = bool(getattr(user, "is_reviewer", False)) and scope in ("", "all")
+        include_org = scope == "org"
+        return include_all, include_org
+
+    async def _body(request: Request) -> dict[str, Any]:
+        if request.method == "GET":
+            return {}
+        try:
+            payload = await request.json()
+        except Exception:
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    def _session_id(request: Request, payload: dict[str, Any]) -> str:
+        return str(
+            request.query_params.get("session_id")
+            or request.query_params.get("bundle_id")
+            or payload.get("session_id")
+            or payload.get("bundle_id")
+            or ""
+        ).strip()
+
+    def _result_dir(
+        request: Request,
+        user,
+        payload: dict[str, Any],
+    ) -> tuple[Path | None, str, JSONResponse | None]:
+        session_id = _session_id(request, payload)
+        if not session_id:
+            return None, "", JSONResponse(
+                {"error": "session_id or bundle_id is required"},
+                status_code=400,
+            )
+        include_all, include_org = _review_scope_flags(request, user)
+        try:
+            result_dir = indexer.resolve_result_dir(
+                session_id,
+                user=user,
+                include_all=include_all,
+                include_org=include_org,
+            )
+        except PermissionError:
+            return None, "", JSONResponse({"error": "Bundle access denied"}, 403)
+        if result_dir is None:
+            return None, "", JSONResponse({"error": "Bundle not found"}, 404)
+        return result_dir, session_id, None
+
+    def _canonical_review_payload(
+        result_dir: Path,
+        requested_session_id: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        run_state = _read_json(result_dir / "run_state.json")
+        if not isinstance(run_state, dict):
+            run_state = {}
+        session_id = str(
+            run_state.get("session_id") or requested_session_id or result_dir.name
+        ).strip()
+        task_id = str(run_state.get("task_id") or payload.get("task_id") or "").strip()
+        canonical = dict(payload)
+        canonical["session_id"] = session_id
+        canonical["bundle_id"] = session_id
+        canonical["task_id"] = task_id
+        return canonical
+
+    async def get_reviews(request: Request) -> JSONResponse:
+        user, err = auth.require_reviewer(request)
+        if err is not None:
+            return err
+        payload = await _body(request)
+        result_dir, _, err = _result_dir(request, user, payload)
+        if err is not None:
+            return err
+        score_id = request.path_params["score_id"]
+        try:
+            reviews = store.list_reviews(result_dir, score_id)
+            summary = store.summary(result_dir, score_id)
+            current = store.latest_review_for_user(result_dir, score_id, user)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, 400)
+        return JSONResponse(
+            {
+                "score_id": score_id,
+                "reviews": reviews,
+                "summary": summary,
+                "current_user_review": current,
+            }
+        )
+
+    async def submit_review(request: Request) -> JSONResponse:
+        user, err = auth.require_reviewer(request)
+        if err is not None:
+            return err
+        payload = await _body(request)
+        if not payload:
+            return JSONResponse({"error": "Invalid JSON body"}, 400)
+        result_dir, requested_session_id, err = _result_dir(request, user, payload)
+        if err is not None:
+            return err
+        score_id = request.path_params["score_id"]
+        canonical_payload = _canonical_review_payload(
+            result_dir,
+            requested_session_id,
+            payload,
+        )
+        try:
+            record = store.submit_review(result_dir, score_id, user, canonical_payload)
+            summary = store.summary(result_dir, score_id)
+        except FileNotFoundError:
+            return JSONResponse({"error": "Score not found"}, 404)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, 400)
+
+        record_event(
+            manager.bench_root,
+            user,
+            "review.score_submit",
+            request=request,
+            session_id=str(canonical_payload.get("session_id") or ""),
+            task_id=str(canonical_payload.get("task_id") or ""),
+            payload={"score_id": score_id, "review_id": record["review_id"]},
+        )
+        return JSONResponse(
+            {
+                "score_id": score_id,
+                "review": record,
+                "summary": summary,
+            },
+            status_code=201,
+        )
+
+    return [
+        Route("/api/reviews/{score_id}", get_reviews, methods=["GET"]),
+        Route("/api/reviews/{score_id}", submit_review, methods=["POST"]),
+    ]
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None

--- a/bench/server/auth.py
+++ b/bench/server/auth.py
@@ -27,6 +27,9 @@ GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
 GITHUB_API_URL = "https://api.github.com"
 
 
+Role = Literal["admin", "reviewer", "user"]
+
+
 @dataclass(frozen=True)
 class UserContext:
     user_id: str
@@ -35,11 +38,15 @@ class UserContext:
     display_name: str
     avatar_url: str
     github_user_id: str = ""
-    role: Literal["admin", "user"] = "user"
+    role: Role = "user"
 
     @property
     def is_admin(self) -> bool:
         return self.role == "admin"
+
+    @property
+    def is_reviewer(self) -> bool:
+        return self.role in {"admin", "reviewer"}
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -53,7 +60,7 @@ class UserContext:
             email=str(data.get("email") or ""),
             display_name=str(data.get("display_name") or ""),
             avatar_url=str(data.get("avatar_url") or ""),
-            role="admin" if data.get("role") == "admin" else "user",
+            role=_normalize_role(data.get("role")),
         )
 
 
@@ -265,6 +272,16 @@ class AuthService:
         if user and user.is_admin:
             return user, None
         return None, JSONResponse({"error": "Admin access required"}, status_code=403)
+
+    def require_reviewer(
+        self, request: Request
+    ) -> tuple[UserContext | None, JSONResponse | None]:
+        user, err = self.require_user(request)
+        if err is not None:
+            return None, err
+        if user and user.is_reviewer:
+            return user, None
+        return None, JSONResponse({"error": "Reviewer access required"}, status_code=403)
 
     def resolve_client_user(
         self, request: Request
@@ -504,9 +521,14 @@ class AuthService:
         email = str(profile.get("email") or "")
         admin_logins = _csv_env("QTB_ADMIN_GITHUB_LOGINS")
         admin_emails = _csv_env("QTB_ADMIN_EMAILS")
-        role: Literal["admin", "user"] = "admin" if (
-            login.lower() in admin_logins or email.lower() in admin_emails
-        ) else "user"
+        reviewer_logins = _csv_env("QTB_REVIEWER_GITHUB_LOGINS")
+        reviewer_emails = _csv_env("QTB_REVIEWER_EMAILS")
+        if login.lower() in admin_logins or email.lower() in admin_emails:
+            role: Role = "admin"
+        elif login.lower() in reviewer_logins or email.lower() in reviewer_emails:
+            role = "reviewer"
+        else:
+            role = "user"
         return UserContext(
             user_id=f"github:{login.lower()}",
             github_login=login,
@@ -552,8 +574,8 @@ def _client_api_keys() -> dict[str, UserContext]:
     Format:
       ``key=user_id|github_login|email|role,key2=user_id2|login2``
 
-    ``github_login``, ``email``, and ``role`` are optional. Use role ``admin``
-    only for trusted automation.
+    ``github_login``, ``email``, and ``role`` are optional. Supported roles are
+    ``user``, ``reviewer``, and ``admin``.
     """
     raw = os.environ.get("QTB_CLIENT_API_KEYS", "").strip()
     if not raw:
@@ -571,7 +593,7 @@ def _client_api_keys() -> dict[str, UserContext]:
             continue
         github_login = parts[1] if len(parts) > 1 and parts[1] else user_id
         email = parts[2] if len(parts) > 2 else ""
-        role = "admin" if len(parts) > 3 and parts[3].lower() == "admin" else "user"
+        role = _normalize_role(parts[3] if len(parts) > 3 else "user")
         users[key] = UserContext(
             user_id=user_id,
             github_login=github_login,
@@ -611,6 +633,15 @@ def _bool_env(name: str, default: bool) -> bool:
     if raw in {"0", "false", "no", "off"}:
         return False
     return default
+
+
+def _normalize_role(value: object) -> Role:
+    role = str(value or "user").strip().lower()
+    if role == "admin":
+        return "admin"
+    if role == "reviewer":
+        return "reviewer"
+    return "user"
 
 
 def _sanitize_next_url(next_url: str) -> str:

--- a/bench/server/web/README.md
+++ b/bench/server/web/README.md
@@ -30,6 +30,9 @@ Current routes:
 - `GET /ui/results/{session_id}/workspace`
 - `GET /ui/results/{session_id}/workspace/preview/{path:path}`
 - `GET /ui/results/{session_id}/files/{path:path}`
+- `GET /ui/review/bundles`
+- `GET /ui/review/bundles/{bundle_id}`
+- `POST /api/reviews/{score_id}`
 - `GET /skill.md`
 - `GET /skills/quanttutorbench-rest-agent`
 - `GET /skills/quanttutorbench-rest-agent/raw`

--- a/bench/server/web/review_store.py
+++ b/bench/server/web/review_store.py
@@ -10,6 +10,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from eval.rubrics.registry import load_rubric_registry
+from eval.storage.human_reviews import HumanReviewStore
 from server.auth import UserContext
 
 
@@ -33,6 +35,7 @@ class ReviewStore:
         self.bench_root = Path(bench_root)
         self.indexer = indexer
         self.review_root = self.bench_root / "experiments" / "human_review"
+        self.human_reviews = HumanReviewStore()
         self._lock = threading.Lock()
 
     def list_bundles(
@@ -57,12 +60,35 @@ class ReviewStore:
             review_count = (
                 len(list(review_dir.glob("*.json"))) if review_dir.is_dir() else 0
             )
+            score_review_summary = self._score_review_summary(bundle_id)
+            score_reviewed = False
+            if user and item.get("score_id"):
+                result_dir = self.indexer.resolve_result_dir(
+                    bundle_id,
+                    user=user,
+                    include_all=include_all,
+                    include_org=include_org,
+                )
+                if result_dir is not None:
+                    score_reviewed = self.human_reviews.reviewer_has_review(
+                        result_dir,
+                        str(item.get("score_id") or ""),
+                        user,
+                    )
             row = dict(item)
             row["bundle_id"] = bundle_id
             row["review_count"] = review_count
+            row["score_review_count"] = score_review_summary.get("review_count", 0)
+            row["score_reviewer_count"] = score_review_summary.get("reviewer_count", 0)
             row["reviewed_by_current_user"] = (
-                self._review_file(bundle_id, user).exists() if user else False
+                (
+                    self._review_file(bundle_id, user).exists()
+                    or score_reviewed
+                )
+                if user
+                else False
             )
+            row["score_reviewed_by_current_user"] = score_reviewed
             bundles.append(row)
         return bundles
 
@@ -105,6 +131,13 @@ class ReviewStore:
                 "judge_eval": self._build_judge_eval_layer(detail, score_json),
             },
             "review": self.load_review(canonical_id, user),
+            "human_review": self._build_human_review_payload(
+                canonical_id,
+                detail,
+                user,
+                include_all=include_all,
+                include_org=include_org,
+            ),
         }
 
     def load_review(
@@ -426,6 +459,89 @@ class ReviewStore:
             if isinstance(detail, dict):
                 rows.extend(self._extract_detail_rows(track, detail))
         return rows
+
+    def _build_human_review_payload(
+        self,
+        bundle_id: str,
+        detail: dict[str, Any],
+        user: UserContext | None,
+        *,
+        include_all: bool = False,
+        include_org: bool = False,
+    ) -> dict[str, Any]:
+        score_json = detail.get("score_json")
+        score_id = str((score_json or {}).get("score_id") or detail.get("score_id") or "")
+        rubric = self._human_review_rubric()
+        payload: dict[str, Any] = {
+            "score_id": score_id,
+            "rubric": rubric,
+            "summary": {
+                "score_id": score_id,
+                "review_count": 0,
+                "reviewer_count": 0,
+                "irr": {},
+            },
+            "current_user_review": None,
+        }
+        if not score_id or user is None:
+            return payload
+
+        try:
+            result_dir = self.indexer.resolve_result_dir(
+                bundle_id,
+                user=user,
+                include_all=include_all,
+                include_org=include_org,
+            )
+        except PermissionError:
+            raise
+        if result_dir is None:
+            return payload
+
+        payload["summary"] = self.human_reviews.summary(result_dir, score_id)
+        payload["current_user_review"] = self.human_reviews.latest_review_for_user(
+            result_dir,
+            score_id,
+            user,
+        )
+        return payload
+
+    def _human_review_rubric(self) -> dict[str, Any]:
+        registry = load_rubric_registry()
+        return {
+            "version": str(registry.get("version") or ""),
+            "score_scale": registry.get("score_scale") or {"min": 1, "max": 5},
+            "criteria": [
+                {
+                    "criterion_id": str(entry.get("rubric_id") or ""),
+                    "dimension": str(entry.get("dimension") or ""),
+                    "version": str(entry.get("version") or ""),
+                    "score_anchors": entry.get("score_anchors") or {},
+                    "required_evidence": entry.get("required_evidence") or [],
+                    "common_failure_cases": entry.get("common_failure_cases") or [],
+                    "mapped_judge_dimensions": entry.get("mapped_judge_dimensions")
+                    or [],
+                }
+                for entry in registry.get("rubrics", [])
+                if isinstance(entry, dict) and entry.get("rubric_id")
+            ],
+        }
+
+    def _score_review_summary(self, bundle_id: str) -> dict[str, Any]:
+        try:
+            detail = self.indexer.get_detail(bundle_id)
+            if not isinstance(detail, dict):
+                return {}
+            score_json = detail.get("score_json")
+            score_id = str((score_json or {}).get("score_id") or "")
+            if not score_id:
+                return {}
+            result_dir = self.indexer.resolve_result_dir(bundle_id)
+            if result_dir is None:
+                return {}
+            return self.human_reviews.summary(result_dir, score_id)
+        except Exception:
+            return {}
 
     def _extract_detail_rows(
         self, track: str, detail: dict[str, Any]

--- a/bench/server/web/static/css/styles.css
+++ b/bench/server/web/static/css/styles.css
@@ -3853,6 +3853,16 @@ h1 {
   background: rgba(255, 250, 243, 0.72);
 }
 
+.review-score-editor {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 14px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 250, 243, 0.82);
+}
+
 .review-editor-title h3 {
   margin: 2px 0 0;
   font-size: 15px;
@@ -3907,9 +3917,38 @@ h1 {
 }
 
 .review-opinion-form,
+.review-score-form,
 .review-form-grid {
   display: grid;
   gap: 14px;
+}
+
+.review-score-criterion {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--border-light);
+  border-left: 3px solid var(--accent-strong);
+  border-radius: var(--radius-sm);
+  background: rgba(240, 229, 215, 0.42);
+}
+
+.review-score-criterion .filter-select {
+  width: 82px;
+  flex: 0 0 auto;
+}
+
+.review-anchor-list {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.review-anchor-list li + li {
+  margin-top: 4px;
 }
 
 .review-form-grid {

--- a/bench/server/web/static/js/app.js
+++ b/bench/server/web/static/js/app.js
@@ -167,6 +167,7 @@
     var target = document.getElementById('nav-user');
     if (!target) return;
     var user = state.auth.user;
+    renderNavAccess();
     if (!user) {
       if (state.auth.authMode === 'github') {
         target.innerHTML = '<a class="btn btn-secondary btn-small" href="' + loginUrl() + '">Log in</a>';
@@ -201,6 +202,17 @@
         });
       });
     }
+  }
+
+  function canAccessReview() {
+    if (state.auth.authMode === 'disabled') return true;
+    var user = state.auth.user || {};
+    return user.role === 'admin' || user.role === 'reviewer';
+  }
+
+  function renderNavAccess() {
+    var reviewLink = document.querySelector('.nav-link[data-route="review"]');
+    if (reviewLink) reviewLink.hidden = !canAccessReview();
   }
 
   function formatDuration(value) {
@@ -1563,7 +1575,7 @@
           '<div class="page-title-wrap">' +
             '<p class="eyebrow">Human Review</p>' +
             '<h1>Human reviewer console.</h1>' +
-            '<p class="subtitle">Inspect archived session bundles across task, conversation, tool, workspace, and judge layers. Opinion cards are stored as structured JSON per bundle and GitHub reviewer.</p>' +
+            '<p class="subtitle">Score completed sessions against the review rubric, inspect evidence layers, and add structured opinion cards for audit context.</p>' +
           '</div>' +
           '<div class="summary-strip">' +
             buildSummaryPill('Bundles', String(bundles.length)) +
@@ -1624,6 +1636,7 @@
         '<div class="session-meta-row">' +
           '<span class="meta-chip">' + escapeHtml((item.turn_count || 0) + ' turns') + '</span>' +
           '<span class="meta-chip">' + escapeHtml((item.tool_count || 0) + ' tools') + '</span>' +
+          '<span class="meta-chip">' + escapeHtml((item.score_review_count || 0) + ' rubric review(s)') + '</span>' +
           '<span class="meta-chip">' + escapeHtml((item.review_count || 0) + ' review file(s)') + '</span>' +
           reviewed +
         '</div>' +
@@ -2012,6 +2025,7 @@
             '<h2>Structured Feedback</h2>' +
           '</div>' +
         '</header>' +
+        renderHumanReviewScoringForm(bundle) +
         renderReviewOpinionForm() +
         '<label class="filter-field">' +
           '<span class="filter-label">Section Filter</span>' +
@@ -2021,6 +2035,120 @@
           (visible.length ? visible.map(renderReviewOpinionCard).join('') : '<p class="detail-empty-note">Cards for the selected section will appear here.</p>') +
         '</div>' +
       '</aside>';
+  }
+
+  function renderHumanReviewScoringForm(bundle) {
+    var human = bundle.human_review || {};
+    var scoreId = human.score_id || '';
+    var summary = human.summary || {};
+    var current = human.current_user_review || {};
+    var criteria = humanReviewCriteria(bundle);
+    var latest = latestCriterionMap(current);
+    var irr = (summary.irr || {});
+    var irrText = irr.status === 'computed'
+      ? formatScore(irr.overall_cohen_kappa)
+      : titleCase(irr.status || 'pending');
+
+    if (!scoreId) {
+      return '' +
+        '<section class="review-score-editor">' +
+          '<div class="review-editor-title">' +
+            '<p class="eyebrow">Rubric Scores</p>' +
+            '<h3>Evaluation Pending</h3>' +
+          '</div>' +
+          '<p class="detail-empty-note">Automated score context must exist before rubric annotations can be submitted.</p>' +
+        '</section>';
+    }
+
+    return '' +
+      '<section class="review-score-editor">' +
+        '<div class="review-editor-title">' +
+          '<p class="eyebrow">Rubric Scores</p>' +
+          '<h3>Score Annotation</h3>' +
+        '</div>' +
+        '<div class="detail-chip-list">' +
+          '<span class="detail-chip">Score ' + escapeHtml(scoreId) + '</span>' +
+          '<span class="detail-chip">' + escapeHtml(String(summary.reviewer_count || 0)) + ' reviewer(s)</span>' +
+          '<span class="detail-chip">IRR ' + escapeHtml(irrText) + '</span>' +
+        '</div>' +
+        '<form id="human-review-form" class="review-score-form">' +
+          criteria.map(function (criterion) {
+            var existing = latest[criterion.criterion_id] || {};
+            return renderHumanReviewCriterion(criterion, existing);
+          }).join('') +
+          '<label class="filter-field">' +
+            '<span class="filter-label">Overall Comment</span>' +
+            '<textarea id="human-review-overall-comment" class="run-textarea" rows="3">' + escapeHtml(current.overall_comment || '') + '</textarea>' +
+          '</label>' +
+          '<div id="human-review-error" class="run-error" hidden></div>' +
+          '<div class="run-actions">' +
+            '<button class="btn btn-primary" type="submit">Submit Scores</button>' +
+          '</div>' +
+        '</form>' +
+      '</section>';
+  }
+
+  function humanReviewCriteria(bundle) {
+    var human = bundle.human_review || {};
+    var rubric = human.rubric || {};
+    var criteria = rubric.criteria || [];
+    if (criteria.length) return criteria;
+    return [
+      {criterion_id: 'task_completion.v1', dimension: 'task_completion', score_anchors: {}, required_evidence: []},
+      {criterion_id: 'quant_correctness.v1', dimension: 'quant_correctness', score_anchors: {}, required_evidence: []}
+    ];
+  }
+
+  function latestCriterionMap(review) {
+    var map = {};
+    (review.criteria || []).forEach(function (item) {
+      if (item && item.criterion_id) map[item.criterion_id] = item;
+    });
+    return map;
+  }
+
+  function renderHumanReviewCriterion(criterion, existing) {
+    var id = criterion.criterion_id || criterion.dimension || '';
+    var anchors = criterion.score_anchors || {};
+    var evidence = criterion.required_evidence || [];
+    var selected = existing.score == null ? '' : String(existing.score);
+    var anchorHtml = Object.keys(anchors).sort().map(function (key) {
+      return '<li><strong>' + escapeHtml(key) + '</strong> ' + escapeHtml(anchors[key]) + '</li>';
+    }).join('');
+    var evidenceHtml = evidence.length
+      ? '<p class="detail-empty-note">Evidence: ' + escapeHtml(evidence.join(', ')) + '</p>'
+      : '';
+    return '' +
+      '<article class="review-score-criterion" data-criterion-id="' + escapeHtml(id) + '">' +
+        '<header class="review-row-head">' +
+          '<div>' +
+            '<strong>' + escapeHtml(titleCase(criterion.dimension || id)) + '</strong>' +
+            '<span class="meta-chip">' + escapeHtml(id) + '</span>' +
+          '</div>' +
+          '<select class="filter-select human-review-score" data-criterion-id="' + escapeHtml(id) + '" required>' +
+            renderScoreOptions(selected) +
+          '</select>' +
+        '</header>' +
+        evidenceHtml +
+        (anchorHtml ? '<details><summary>Score Anchors</summary><ul class="review-anchor-list">' + anchorHtml + '</ul></details>' : '') +
+        '<label class="filter-field">' +
+          '<span class="filter-label">Justification</span>' +
+          '<textarea class="run-textarea human-review-justification" data-criterion-id="' + escapeHtml(id) + '" rows="3" required>' + escapeHtml(existing.justification || '') + '</textarea>' +
+        '</label>' +
+        '<label class="filter-field">' +
+          '<span class="filter-label">Evidence Notes</span>' +
+          '<textarea class="run-textarea human-review-evidence" data-criterion-id="' + escapeHtml(id) + '" rows="2">' + escapeHtml(existing.evidence || '') + '</textarea>' +
+        '</label>' +
+      '</article>';
+  }
+
+  function renderScoreOptions(selected) {
+    var html = '<option value="">Score</option>';
+    [1, 2, 3, 4, 5].forEach(function (score) {
+      var value = String(score);
+      html += '<option value="' + value + '"' + (selected === value ? ' selected' : '') + '>' + value + '</option>';
+    });
+    return html;
   }
 
   function renderReviewOpinionForm() {
@@ -2197,6 +2325,7 @@
       });
     }
     bindReviewOpinionForm(bundle);
+    bindHumanReviewForm(bundle);
   }
 
   function truncateReviewOption(value, limit) {
@@ -2330,6 +2459,58 @@
       if (errorEl) {
         errorEl.hidden = false;
         errorEl.textContent = error && error.message ? error.message : String(error || 'Unable to save card');
+      }
+    });
+  }
+
+  function bindHumanReviewForm(bundle) {
+    var form = document.getElementById('human-review-form');
+    if (!form) return;
+    form.addEventListener('submit', function (event) {
+      event.preventDefault();
+      submitHumanReviewScores(bundle);
+    });
+  }
+
+  function submitHumanReviewScores(bundle) {
+    var human = bundle.human_review || {};
+    var scoreId = human.score_id || '';
+    var errorEl = document.getElementById('human-review-error');
+    if (!scoreId) return;
+    var rows = Array.prototype.slice.call(document.querySelectorAll('.review-score-criterion'));
+    var criteria = rows.map(function (row) {
+      var criterionId = row.getAttribute('data-criterion-id') || '';
+      var score = row.querySelector('.human-review-score');
+      var justification = row.querySelector('.human-review-justification');
+      var evidence = row.querySelector('.human-review-evidence');
+      return {
+        criterion_id: criterionId,
+        score: score ? score.value : '',
+        justification: justification ? justification.value.trim() : '',
+        evidence: evidence ? evidence.value.trim() : ''
+      };
+    });
+    var comment = document.getElementById('human-review-overall-comment');
+    var payload = {
+      session_id: bundle.bundle_id,
+      bundle_id: bundle.bundle_id,
+      task_id: (bundle.detail || {}).task_id || '',
+      criteria: criteria,
+      overall_comment: comment ? comment.value.trim() : ''
+    };
+
+    restApi('/api/reviews/' + encodeURIComponent(scoreId) + '?session_id=' + encodeURIComponent(bundle.bundle_id), {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    }).then(function () {
+      state.review.bundles = null;
+      return ensureReviewBundle(bundle.bundle_id, true);
+    }).then(function (updated) {
+      renderReviewBundlePage(updated);
+    }).catch(function (error) {
+      if (errorEl) {
+        errorEl.hidden = false;
+        errorEl.textContent = error && error.message ? error.message : String(error || 'Unable to submit scores');
       }
     });
   }

--- a/bench/server/web/templates/index.html
+++ b/bench/server/web/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>QuantTutorBench Isolated UI</title>
-  <link rel="stylesheet" href="/static/css/styles.css?v=20260505a">
+  <link rel="stylesheet" href="/static/css/styles.css?v=20260506a">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
@@ -31,6 +31,6 @@
   <script src="/static/js/tools.js?v=20260421a"></script>
   <script src="/static/js/run-agent.js?v=20260505a"></script>
   <script src="/static/js/flow-demo.js?v=20260501g"></script>
-  <script src="/static/js/app.js?v=20260505a"></script>
+  <script src="/static/js/app.js?v=20260506a"></script>
 </body>
 </html>

--- a/bench/server/web/ui_app.py
+++ b/bench/server/web/ui_app.py
@@ -178,6 +178,14 @@ def ui_routes(manager) -> list[Route]:
         include_org = scope == "org"
         return include_all, include_org
 
+    def _review_scope_flags(request: Request, user) -> tuple[bool, bool]:
+        if _mine_scope_requested(request):
+            return False, False
+        scope = request.query_params.get("scope", "").strip().lower()
+        include_all = bool(getattr(user, "is_reviewer", False)) and scope in ("", "all")
+        include_org = scope == "org"
+        return include_all, include_org
+
     def _run_access_from_cookie(run_service, run_id: str, user):
         if user is None:
             return None
@@ -509,10 +517,10 @@ def ui_routes(manager) -> list[Route]:
     # -----------------------------------------------------------------------
 
     async def list_review_bundles(request: Request) -> JSONResponse:
-        user, err = auth.require_user(request)
+        user, err = auth.require_reviewer(request)
         if err is not None:
             return err
-        include_all, include_org = _scope_flags(request, user)
+        include_all, include_org = _review_scope_flags(request, user)
         return JSONResponse(
             _sanitize_for_json(
                 {
@@ -526,11 +534,11 @@ def ui_routes(manager) -> list[Route]:
         )
 
     async def get_review_bundle(request: Request) -> JSONResponse:
-        user, err = auth.require_user(request)
+        user, err = auth.require_reviewer(request)
         if err is not None:
             return err
         bundle_id = request.path_params["bundle_id"]
-        include_all, include_org = _scope_flags(request, user)
+        include_all, include_org = _review_scope_flags(request, user)
         try:
             payload = review_store.get_bundle(
                 bundle_id,
@@ -552,11 +560,11 @@ def ui_routes(manager) -> list[Route]:
         return JSONResponse(_sanitize_for_json(payload))
 
     async def append_review_opinion(request: Request) -> JSONResponse:
-        user, err = auth.require_user(request)
+        user, err = auth.require_reviewer(request)
         if err is not None:
             return err
         bundle_id = request.path_params["bundle_id"]
-        include_all, include_org = _scope_flags(request, user)
+        include_all, include_org = _review_scope_flags(request, user)
         try:
             existing = review_store.get_bundle(
                 bundle_id,
@@ -606,11 +614,11 @@ def ui_routes(manager) -> list[Route]:
         return JSONResponse(_sanitize_for_json(payload))
 
     async def replace_review_opinions(request: Request) -> JSONResponse:
-        user, err = auth.require_user(request)
+        user, err = auth.require_reviewer(request)
         if err is not None:
             return err
         bundle_id = request.path_params["bundle_id"]
-        include_all, include_org = _scope_flags(request, user)
+        include_all, include_org = _review_scope_flags(request, user)
         try:
             existing = review_store.get_bundle(
                 bundle_id,
@@ -648,6 +656,33 @@ def ui_routes(manager) -> list[Route]:
             include_org=include_org,
         )
         return JSONResponse(_sanitize_for_json(payload or {"bundle_id": bundle_id}))
+
+    async def admin_review_irr(request: Request) -> JSONResponse:
+        user, err = auth.require_admin(request)
+        if err is not None:
+            return err
+        rows = []
+        for item in review_store.list_bundles(user, include_all=True):
+            bundle_id = str(item.get("bundle_id") or "")
+            if not bundle_id:
+                continue
+            bundle = review_store.get_bundle(bundle_id, user, include_all=True)
+            if not isinstance(bundle, dict):
+                continue
+            human_review = bundle.get("human_review") or {}
+            summary = human_review.get("summary") if isinstance(human_review, dict) else {}
+            irr = summary.get("irr") if isinstance(summary, dict) else {}
+            rows.append(
+                {
+                    "bundle_id": bundle_id,
+                    "task_id": item.get("task_id"),
+                    "score_id": human_review.get("score_id"),
+                    "review_count": summary.get("review_count"),
+                    "reviewer_count": summary.get("reviewer_count"),
+                    "irr": irr,
+                }
+            )
+        return JSONResponse(_sanitize_for_json({"sessions": rows}))
 
     # -----------------------------------------------------------------------
     # New: /ui/runs/*
@@ -1211,6 +1246,7 @@ def ui_routes(manager) -> list[Route]:
         Route("/ui/tasks/catalog", task_catalog, methods=["GET"]),
         Route("/ui/tasks/catalog/labels", task_catalog_labels, methods=["GET"]),
         # New: human review console
+        Route("/ui/review/admin/irr", admin_review_irr, methods=["GET"]),
         Route("/ui/review/bundles", list_review_bundles, methods=["GET"]),
         Route("/ui/review/bundles/{bundle_id}", get_review_bundle, methods=["GET"]),
         Route(

--- a/bench/server/web/ui_indexer.py
+++ b/bench/server/web/ui_indexer.py
@@ -209,6 +209,7 @@ class ResultIndexer:
             "agent_name": self._extract_agent_name(model),
             "timestamp": timestamp_text,
             "evaluation_status": self._resolve_evaluation_status(latest_score),
+            "score_id": latest_score_id or "",
             "overall_score": self._extract_overall_score(latest_score),
             "has_client_trace": client_trace is not None,
             "has_content_blocks": self._has_content_blocks(client_trace, conversation),
@@ -243,6 +244,26 @@ class ResultIndexer:
             "max_turns": task_meta.get("max_turns"),
         }
         return detail
+
+    def resolve_result_dir(
+        self,
+        session_id: str,
+        *,
+        user: Any | None = None,
+        include_all: bool = False,
+        include_org: bool = False,
+    ) -> Path | None:
+        result_dir = self._find_result_dir(session_id)
+        if result_dir is None:
+            return None
+        run_state = self._load_json(result_dir / "run_state.json")
+        if not isinstance(run_state, dict):
+            return None
+        if not self._run_state_visible(
+            run_state, user=user, include_all=include_all, include_org=include_org
+        ):
+            raise PermissionError("Result access denied")
+        return result_dir
 
     def resolve_agent_file(
         self,
@@ -566,6 +587,7 @@ class ResultIndexer:
                 run_state.get("step_count"), default=len(raw_tool_logs)
             ),
             "evaluation_status": self._resolve_evaluation_status(latest_score),
+            "score_id": latest_score_id or "",
             "overall_score": self._extract_overall_score(latest_score),
             "has_client_trace": client_trace is not None,
             "has_content_blocks": self._has_content_blocks(client_trace, conversation),

--- a/bench/tests/test_github_oauth_auth.py
+++ b/bench/tests/test_github_oauth_auth.py
@@ -191,6 +191,25 @@ class GithubOAuthAuthTests(unittest.TestCase):
                 self.assertEqual(user.role, "admin")
                 self.assertEqual(user.github_user_id, "12345")
 
+    def test_reviewer_role_can_match_login(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {"QTB_REVIEWER_GITHUB_LOGINS": "reviewer-one"},
+                clear=False,
+            ):
+                auth = AuthService(Path(tmp))
+                user = auth._build_user(
+                    {
+                        "id": 23456,
+                        "login": "reviewer-one",
+                        "email": "reviewer@example.com",
+                        "name": "Reviewer",
+                    }
+                )
+                self.assertEqual(user.role, "reviewer")
+                self.assertTrue(user.is_reviewer)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/bench/tests/test_server_web_ui.py
+++ b/bench/tests/test_server_web_ui.py
@@ -11,6 +11,7 @@ from starlette.testclient import TestClient
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from server.api.http_app import create_app
+from server.api.review_api import review_api_routes
 from server.auth import AuthService, SESSION_COOKIE, UserContext
 from server.web.ui_app import ui_routes
 from server.web.ui_indexer import ResultIndexer
@@ -514,6 +515,38 @@ class UiRoutesTests(unittest.TestCase):
                     ],
                 },
             )
+            _write_json(
+                result_dir / "evaluations" / "index.json",
+                {
+                    "version": "2.0",
+                    "next_score_number": 2,
+                    "latest_completed_score_id": "score_1",
+                    "scores": [
+                        {
+                            "score_id": "score_1",
+                            "status": "completed_scored",
+                            "eval_mode": "full",
+                            "eval_model": "judge-a",
+                            "created_at": "2026-01-01T01:01:01Z",
+                            "completed_at": "2026-01-01T01:01:02Z",
+                            "overall_score": 0.82,
+                            "score_path": "score_1/score.json",
+                            "cost_path": "score_1/cost.json",
+                        }
+                    ],
+                },
+            )
+            _write_json(
+                result_dir / "evaluations" / "score_1" / "score.json",
+                {
+                    "version": "2.0",
+                    "score_id": "score_1",
+                    "score_status": "completed_scored",
+                    "overall_score": 0.82,
+                    "qr": {"track": "qr", "score": 0.8, "status": "success"},
+                    "qp": {"track": "qp", "score": 0.84, "status": "success"},
+                },
+            )
             file_path = result_dir / "agent_files" / "artifacts" / "report.md"
             file_path.parent.mkdir(parents=True, exist_ok=True)
             file_path.write_text("report", encoding="utf-8")
@@ -524,7 +557,10 @@ class UiRoutesTests(unittest.TestCase):
             csv_path.parent.mkdir(parents=True, exist_ok=True)
             csv_path.write_text("col_a,col_b\n1,2\n3,4\n", encoding="utf-8")
 
-            app = Starlette(routes=ui_routes(_Manager(root)))
+            manager = _Manager(root)
+            app = Starlette(
+                routes=[*ui_routes(manager), *review_api_routes(manager)]
+            )
             client = TestClient(app)
 
             tasks_response = client.get("/ui/tasks")
@@ -583,6 +619,33 @@ class UiRoutesTests(unittest.TestCase):
                 f"/ui/review/bundles/{session_prefix}"
             )
             review_list_after_response = client.get("/ui/review/bundles")
+            score_review_response = client.post(
+                f"/api/reviews/score_1?session_id={session_id}",
+                json={
+                    "session_id": "wrong-session",
+                    "bundle_id": "wrong-bundle",
+                    "task_id": "wrong-task",
+                    "criteria": [
+                        {
+                            "criterion_id": "task_completion.v1",
+                            "score": 4,
+                            "justification": "The final answer addresses the task.",
+                        },
+                        {
+                            "criterion_id": "quant_correctness.v1",
+                            "score": 3,
+                            "justification": "The quant reasoning is adequate.",
+                        },
+                    ],
+                    "overall_comment": "Usable session.",
+                },
+            )
+            score_review_get_response = client.get(
+                f"/api/reviews/score_1?session_id={session_id}"
+            )
+            score_review_bundle_response = client.get(
+                f"/ui/review/bundles/{session_id}"
+            )
 
             self.assertEqual(tasks_response.status_code, 200)
             self.assertEqual(results_response.status_code, 200)
@@ -603,6 +666,9 @@ class UiRoutesTests(unittest.TestCase):
             self.assertEqual(review_prefix_post_response.status_code, 200)
             self.assertEqual(review_prefix_reload_response.status_code, 200)
             self.assertEqual(review_list_after_response.status_code, 200)
+            self.assertEqual(score_review_response.status_code, 201)
+            self.assertEqual(score_review_get_response.status_code, 200)
+            self.assertEqual(score_review_bundle_response.status_code, 200)
             self.assertEqual(file_response.text, "report")
             self.assertIn("QuantTutorBench REST Agent", skill_response.text)
             self.assertIn("POST /client/runs/start", skill_response.text)
@@ -718,6 +784,31 @@ class UiRoutesTests(unittest.TestCase):
                 / "local-dev.json"
             )
             self.assertFalse(alias_review_file.exists())
+            score_review_payload = score_review_response.json()
+            self.assertEqual(score_review_payload["review"]["score_id"], "score_1")
+            self.assertEqual(score_review_payload["review"]["session_id"], session_id)
+            self.assertEqual(score_review_payload["review"]["bundle_id"], session_id)
+            self.assertEqual(
+                score_review_payload["review"]["task_id"], "L2_DAT_01_demo"
+            )
+            self.assertEqual(
+                score_review_payload["review"]["criteria"][0]["score"], 4
+            )
+            score_review_files = list(
+                (result_dir / "evaluations" / "score_1" / "human_reviews").glob(
+                    "*.json"
+                )
+            )
+            self.assertEqual(len(score_review_files), 1)
+            self.assertEqual(
+                score_review_get_response.json()["summary"]["review_count"], 1
+            )
+            self.assertEqual(
+                score_review_bundle_response.json()["human_review"]["summary"][
+                    "review_count"
+                ],
+                1,
+            )
 
     def test_review_route_resolves_archives_without_session_id_file(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -761,7 +852,71 @@ class UiRoutesTests(unittest.TestCase):
             self.assertEqual(detail_response.json()["bundle_id"], session_id)
             self.assertEqual(prefix_response.json()["bundle_id"], session_id)
 
-    def test_review_routes_preserve_private_result_visibility(self):
+    def test_review_list_marks_score_only_reviewed_sessions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            session_id = "score-only-session-001"
+            result_dir = _make_server_result_dir(
+                root, "L2_DAT_01_demo", "beginner_persona", session_id
+            )
+            _write_json(
+                result_dir / "run_state.json",
+                {
+                    "session_id": session_id,
+                    "task_id": "L2_DAT_01_demo",
+                    "persona_id": "beginner_persona",
+                    "conversation": [{"role": "assistant", "content": "Answer"}],
+                    "tool_logs": [],
+                    "workspace_files": [],
+                },
+            )
+            _write_json(
+                result_dir / "evaluations" / "index.json",
+                {
+                    "version": "2.0",
+                    "latest_completed_score_id": "score_1",
+                    "scores": [{"score_id": "score_1", "status": "completed_scored"}],
+                },
+            )
+            _write_json(
+                result_dir / "evaluations" / "score_1" / "score.json",
+                {
+                    "score_id": "score_1",
+                    "score_status": "completed_scored",
+                    "overall_score": 0.8,
+                },
+            )
+
+            manager = _Manager(root)
+            app = Starlette(
+                routes=[*ui_routes(manager), *review_api_routes(manager)]
+            )
+            client = TestClient(app)
+            response = client.post(
+                f"/api/reviews/score_1?session_id={session_id}",
+                json={
+                    "session_id": session_id,
+                    "task_id": "L2_DAT_01_demo",
+                    "criteria": [
+                        {
+                            "criterion_id": "task_completion.v1",
+                            "score": 4,
+                            "justification": "The session completes the task.",
+                        }
+                    ],
+                },
+            )
+            list_response = client.get("/ui/review/bundles")
+
+            self.assertEqual(response.status_code, 201)
+            self.assertEqual(list_response.status_code, 200)
+            row = list_response.json()["bundles"][0]
+            self.assertTrue(row["reviewed_by_current_user"])
+            self.assertTrue(row["score_reviewed_by_current_user"])
+            self.assertEqual(row["score_review_count"], 1)
+            self.assertEqual(row["review_count"], 0)
+
+    def test_review_routes_require_reviewer_role(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             _write_json(
@@ -805,7 +960,7 @@ class UiRoutesTests(unittest.TestCase):
             with patch.dict("os.environ", {"QTB_AUTH_MODE": "github"}, clear=False):
                 app = Starlette(routes=ui_routes(_Manager(root)))
                 auth = AuthService(root)
-                alice_session = auth.store.create_session(
+                plain_session = auth.store.create_session(
                     UserContext(
                         user_id="github:alice",
                         github_login="alice",
@@ -813,6 +968,17 @@ class UiRoutesTests(unittest.TestCase):
                         display_name="Alice",
                         avatar_url="",
                         github_user_id="101",
+                    )
+                )
+                reviewer_session = auth.store.create_session(
+                    UserContext(
+                        user_id="github:reviewer",
+                        github_login="reviewer",
+                        email="reviewer@example.com",
+                        display_name="Reviewer",
+                        avatar_url="",
+                        github_user_id="202",
+                        role="reviewer",
                     )
                 )
                 admin_session = auth.store.create_session(
@@ -827,12 +993,20 @@ class UiRoutesTests(unittest.TestCase):
                     )
                 )
 
-                alice_client = TestClient(app)
-                alice_client.cookies.set(SESSION_COOKIE, alice_session)
-                alice_list = alice_client.get("/ui/review/bundles")
-                alice_own = alice_client.get("/ui/review/bundles/alice-session-001")
-                alice_bob = alice_client.get("/ui/review/bundles/bob-session-001")
-                alice_bob_post = alice_client.post(
+                plain_client = TestClient(app)
+                plain_client.cookies.set(SESSION_COOKIE, plain_session)
+                plain_list = plain_client.get("/ui/review/bundles")
+
+                reviewer_client = TestClient(app)
+                reviewer_client.cookies.set(SESSION_COOKIE, reviewer_session)
+                reviewer_list = reviewer_client.get("/ui/review/bundles")
+                reviewer_own = reviewer_client.get(
+                    "/ui/review/bundles/alice-session-001"
+                )
+                reviewer_bob = reviewer_client.get(
+                    "/ui/review/bundles/bob-session-001"
+                )
+                reviewer_bob_post = reviewer_client.post(
                     "/ui/review/bundles/bob-session-001/opinions",
                     json={
                         "opinion": {
@@ -846,13 +1020,14 @@ class UiRoutesTests(unittest.TestCase):
                 admin_client.cookies.set(SESSION_COOKIE, admin_session)
                 admin_list = admin_client.get("/ui/review/bundles")
 
-            self.assertEqual(alice_list.status_code, 200)
-            self.assertEqual(alice_own.status_code, 200)
-            self.assertEqual(alice_bob.status_code, 403)
-            self.assertEqual(alice_bob_post.status_code, 403)
+            self.assertEqual(plain_list.status_code, 403)
+            self.assertEqual(reviewer_list.status_code, 200)
+            self.assertEqual(reviewer_own.status_code, 200)
+            self.assertEqual(reviewer_bob.status_code, 200)
+            self.assertEqual(reviewer_bob_post.status_code, 200)
             self.assertEqual(
-                {item["bundle_id"] for item in alice_list.json()["bundles"]},
-                {"alice-session-001"},
+                {item["bundle_id"] for item in reviewer_list.json()["bundles"]},
+                {"alice-session-001", "bob-session-001"},
             )
             self.assertEqual(admin_list.status_code, 200)
             self.assertEqual(

--- a/bench/tests/unit/test_bundle.py
+++ b/bench/tests/unit/test_bundle.py
@@ -91,6 +91,21 @@ def _make_bundle() -> Bundle:
 
 def test_bundle_roundtrip_preserves_all_fields():
     b = _make_bundle()
+    b.human_reviews = [
+        {
+            "version": "human_review_score_v1",
+            "record_type": "annotation",
+            "score_id": "score_1",
+            "reviewer_id": "reviewer-1",
+            "criteria": [
+                {
+                    "criterion_id": "task_completion.v1",
+                    "score": 4,
+                    "justification": "Complete.",
+                }
+            ],
+        }
+    ]
     s = bundle_io.to_json(b)
     b2 = bundle_io.from_json(s)
     assert b2 == b

--- a/bench/tests/unit/test_human_reviews.py
+++ b/bench/tests/unit/test_human_reviews.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from eval.backfill.run_state_to_bundle import backfill
+from eval.contracts import bundle_io
+from eval.storage.human_reviews import HumanReviewStore
+from server.auth import UserContext
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _user(n: int) -> UserContext:
+    return UserContext(
+        user_id=f"github:reviewer-{n}",
+        github_login=f"reviewer-{n}",
+        github_user_id=str(1000 + n),
+        email=f"reviewer-{n}@example.com",
+        display_name=f"Reviewer {n}",
+        avatar_url="",
+        role="reviewer",
+    )
+
+
+def _payload(session_id: str, task_id: str, score_a: int, score_b: int) -> dict:
+    return {
+        "session_id": session_id,
+        "bundle_id": session_id,
+        "task_id": task_id,
+        "criteria": [
+            {
+                "criterion_id": "task_completion.v1",
+                "score": score_a,
+                "justification": "Task completion evidence is present.",
+            },
+            {
+                "criterion_id": "quant_correctness.v1",
+                "score": score_b,
+                "justification": "Quant reasoning evidence is present.",
+            },
+        ],
+    }
+
+
+def test_human_reviews_compute_irr_and_export_with_bundle(tmp_path):
+    result_dir = tmp_path / "results" / "server" / "L1_DEMO" / "persona" / "run"
+    session_id = "sess-human-review"
+    task_id = "L1_DEMO"
+    _write_json(
+        result_dir / "run_state.json",
+        {
+            "session_id": session_id,
+            "task_id": task_id,
+            "persona_id": "persona",
+            "timestamp": "2026-05-06T01:00:00Z",
+            "conversation": [{"role": "assistant", "content": "Done"}],
+            "tool_logs": [],
+        },
+    )
+    _write_json(
+        result_dir / "evaluations" / "index.json",
+        {
+            "version": "2.0",
+            "latest_completed_score_id": "score_1",
+            "scores": [{"score_id": "score_1", "status": "completed_scored"}],
+        },
+    )
+    _write_json(
+        result_dir / "evaluations" / "score_1" / "score.json",
+        {
+            "score_id": "score_1",
+            "score_status": "completed_scored",
+            "overall_score": 0.8,
+        },
+    )
+
+    store = HumanReviewStore()
+    store.submit_review(result_dir, "score_1", _user(1), _payload(session_id, task_id, 4, 3))
+    store.submit_review(result_dir, "score_1", _user(2), _payload(session_id, task_id, 4, 3))
+    store.submit_review(result_dir, "score_1", _user(3), _payload(session_id, task_id, 5, 3))
+
+    summary = store.summary(result_dir, "score_1")
+    assert summary["review_count"] == 3
+    assert summary["reviewer_count"] == 3
+    assert summary["irr"]["status"] == "computed"
+    assert len(summary["irr"]["per_criterion"]) == 2
+
+    bundle_path = backfill(result_dir / "run_state.json", bench_root=tmp_path)
+    raw = json.loads(bundle_path.read_text(encoding="utf-8"))
+    assert "human_reviews" in raw
+    assert len(raw["human_reviews"]) == 4
+    assert all("result_dir" not in item for item in raw["human_reviews"])
+    assert raw["human_reviews"][-1]["record_type"] == "irr_summary"
+
+    bundle = bundle_io.read(bundle_path)
+    assert len(bundle.human_reviews) == 4
+
+
+def test_human_review_requires_completed_score_json(tmp_path):
+    result_dir = tmp_path / "results" / "server" / "L1_DEMO" / "persona" / "run"
+    (result_dir / "evaluations" / "score_1").mkdir(parents=True)
+
+    store = HumanReviewStore()
+    try:
+        store.submit_review(
+            result_dir,
+            "score_1",
+            _user(1),
+            _payload("session", "task", 4, 3),
+        )
+    except FileNotFoundError:
+        pass
+    else:
+        raise AssertionError("review write accepted a score directory without score.json")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -484,6 +484,8 @@ inspection through `/ui/review/*`. The Vercel-facing shell serves `/review` and
 `/review/{bundle_id}` as SPA routes backed by the existing GitHub OAuth cookie.
 Any authenticated GitHub reviewer can inspect the task spec, transcript, tutor
 tool log, workspace tree, and judge evaluation for a completed bundle.
+Reviewer access is a distinct `reviewer` role; admins inherit reviewer access,
+and ordinary authenticated users stay on the run/results surfaces.
 
 The isolated frontend treats Session Flow as the live run monitor and Human
 Review as the archive-facing session view: active runs render their full
@@ -502,6 +504,22 @@ cards with `section`, optional `target`, `severity`, `comment`, `tags`, reviewer
 metadata, and optional judge-disagreement scores. Overlapping fields such as
 `sample_id`, `reviewer_id`, `label_version`, and `timestamp` are preserved for
 downstream joins with `judge_validation/human_labels*.json`.
+
+Score-bound rubric annotations live beside automated score artifacts:
+
+```text
+bench/results/server/{task_id}/{persona_id}/{run_dir}/evaluations/{score_id}/human_reviews/{review_id}.json
+```
+
+Each record follows `human_review_score_v1`, carries 1-5 scores plus
+justifications per rubric criterion, and is tied to the score id that provided
+the automated judge context. `POST /api/reviews/{score_id}` writes these
+records after reviewer auth. `bench/eval/storage/human_reviews.py` reads the
+records and `bench/eval/programmatic/inter_rater_reliability.py` computes the
+admin IRR summary surfaced through `/ui/review/admin/irr` and bundle detail.
+Bundle v1 alpha exports include a top-level `human_reviews` array when these
+annotations exist, with annotation records followed by an IRR summary record
+per scored evaluation.
 
 ## Public Reads
 
@@ -547,7 +565,9 @@ in-bundle `evaluations/index.json` plus `score_n/score.json` and `cost.json`.
 It also applies owner filtering for private/org/admin views.
 `bench/server/web/review_store.py` builds the review read model from the same
 result indexer and writes per-reviewer opinion files under
-`bench/experiments/human_review/`.
+`bench/experiments/human_review/`. Score-bound rubric annotations use
+`eval/storage/human_reviews.py` and stay under each evaluation's `score_n`
+directory.
 
 ## Tests
 

--- a/docs/bundle_v1_schema.md
+++ b/docs/bundle_v1_schema.md
@@ -96,6 +96,7 @@ Top-level fields in `1.0.0-alpha`:
 | `tool_calls` | array | Generic tool calls with arbitrary args/result JSON. |
 | `artifacts` | object | Producer-specific payloads keyed by namespace. |
 | `workspace` | object | Workspace file tree snapshot. |
+| `human_reviews` | array | Optional score-bound human annotations and IRR summaries. Present when review records exist beside `evaluations/{score_id}`. |
 
 ## Message Shape
 
@@ -144,6 +145,16 @@ changing the envelope.
 optional `content_ref`, and metadata. The Stage 1 policy is path plus sha256 plus
 size. Inline content belongs in namespaced `artifacts` for alpha fixtures. Stage
 2 will decide long-term inline payload and external-reference rules.
+
+## Human Reviews
+
+`human_reviews[]` is optional. Backfill/export populates it from
+`evaluations/{score_id}/human_reviews/*.json` when quant reviewers submit rubric
+annotations through `/api/reviews/{score_id}`. Annotation records use
+`human_review_score_v1` and carry `score_id`, reviewer metadata, per-criterion
+1-5 scores, justifications, and evidence notes. Export also appends one
+`human_review_irr_v1` summary record per scored evaluation with available
+review annotations.
 
 ## TBD Decisions Resolved For Stage 1
 


### PR DESCRIPTION
Closes #186

## Shipped
- Adds reviewer role support and reviewer-gated review routes.
- Adds score-bound human review API/storage for completed automated scores.
- Adds IRR summaries and bundle export/backfill support.
- Adds review UI scoring controls, review badges, and current-user state.
- Updates docs and focused coverage for auth, UI, storage, IRR, bundle IO, and backfill.

## Verification
- .venv/bin/python -m py_compile bench/eval/storage/human_reviews.py bench/server/web/ui_indexer.py bench/server/api/review_api.py
- node --check bench/server/web/static/js/app.js
- pytest bench/tests/test_server_web_ui.py bench/tests/unit/test_human_reviews.py bench/tests/test_github_oauth_auth.py bench/tests/unit/test_bundle.py
- pytest bench/tests/api/test_eval_flow.py bench/tests/unit/test_backfill.py bench/tests/integration/test_bundle_roundtrip.py
- pytest bench/tests/unit/test_eval_architecture_contracts.py bench/tests/api/test_permissions.py
- git diff --cached --check

## Review
- Codex review round 1: fixed completed-score enforcement, path-free export records, and score-only reviewed state.
- Codex review round 2: fixed canonical review metadata for prefix/mismatched requests.

## Next
- Product dogfood with quant reviewers on this branch.