### PR TITLE
Route reviewers by GitHub org membership

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,7 +11,7 @@ QTB_GITHUB_ALLOW_ALL=false
 # Empty allowlist vars allow any GitHub account through OAuth.
 # Set QTB_GITHUB_ALLOW_ALL=true for public GitHub OAuth.
 # Set allowlist vars for invite-only access.
-# Public OAuth requests only GitHub identity/email scopes; org/team gates request read:org.
+# Org/team reviewer routing requests read:org so members can receive reviewer role.
 QTB_GITHUB_ALLOWED_LOGINS=
 QTB_GITHUB_ALLOWED_ORGS=
 QTB_GITHUB_ALLOWED_TEAMS=
@@ -19,4 +19,13 @@ QTB_GITHUB_ALLOWED_TEAMS=
 # Admin users still need an explicit login or email match.
 QTB_ADMIN_GITHUB_LOGINS=
 QTB_ADMIN_EMAILS=
+
+# Reviewer users can be explicit logins/emails or members of orgs/teams.
+# Reviewer team values use org/slug form, for example varsity-tech-product/reviewers.
+# When both reviewer org/team vars are empty, QTB_GITHUB_ALLOWED_ORGS/TEAMS
+# provide the default reviewer membership groups.
+QTB_REVIEWER_GITHUB_LOGINS=
+QTB_REVIEWER_EMAILS=
+QTB_REVIEWER_GITHUB_ORGS=
+QTB_REVIEWER_GITHUB_TEAMS=
 QTB_COOKIE_SECURE=

--- a/bench/server/auth.py
+++ b/bench/server/auth.py
@@ -365,7 +365,7 @@ class AuthService:
         if not self._is_allowed(profile, token):
             return JSONResponse({"error": "GitHub account is outside allowlist"}, 403)
 
-        user = self._build_user(profile)
+        user = self._build_user(profile, token)
         session_id = self.store.create_session(user)
         response = RedirectResponse(next_url, status_code=302)
         self._set_session_cookie(request, response, session_id)
@@ -510,13 +510,12 @@ class AuthService:
     def _github_oauth_scope(self) -> str:
         scopes = ["read:user", "user:email"]
         _, allowed_orgs, allowed_teams = self._github_allowlists()
-        if not _bool_env("QTB_GITHUB_ALLOW_ALL", False) and (
-            allowed_orgs or allowed_teams
-        ):
+        reviewer_orgs, reviewer_teams = self._github_reviewer_membership_allowlists()
+        if allowed_orgs or allowed_teams or reviewer_orgs or reviewer_teams:
             scopes.append("read:org")
         return " ".join(scopes)
 
-    def _build_user(self, profile: dict) -> UserContext:
+    def _build_user(self, profile: dict, token: str = "") -> UserContext:
         login = str(profile.get("login") or "")
         email = str(profile.get("email") or "")
         admin_logins = _csv_env("QTB_ADMIN_GITHUB_LOGINS")
@@ -525,7 +524,11 @@ class AuthService:
         reviewer_emails = _csv_env("QTB_REVIEWER_EMAILS")
         if login.lower() in admin_logins or email.lower() in admin_emails:
             role: Role = "admin"
-        elif login.lower() in reviewer_logins or email.lower() in reviewer_emails:
+        elif (
+            login.lower() in reviewer_logins
+            or email.lower() in reviewer_emails
+            or self._is_reviewer_member(token)
+        ):
             role = "reviewer"
         else:
             role = "user"
@@ -538,6 +541,43 @@ class AuthService:
             avatar_url=str(profile.get("avatar_url") or ""),
             role=role,
         )
+
+    def _github_reviewer_membership_allowlists(self) -> tuple[set[str], set[str]]:
+        reviewer_orgs = _csv_env("QTB_REVIEWER_GITHUB_ORGS")
+        reviewer_teams = _csv_env("QTB_REVIEWER_GITHUB_TEAMS")
+        if reviewer_orgs or reviewer_teams:
+            return reviewer_orgs, reviewer_teams
+        return _csv_env("QTB_GITHUB_ALLOWED_ORGS"), _csv_env(
+            "QTB_GITHUB_ALLOWED_TEAMS"
+        )
+
+    def _is_reviewer_member(self, token: str) -> bool:
+        if not token:
+            return False
+
+        reviewer_orgs, reviewer_teams = self._github_reviewer_membership_allowlists()
+        if reviewer_orgs:
+            orgs = self._github_get(token, "/user/orgs")
+            org_logins = {
+                str(org.get("login") or "").lower()
+                for org in orgs
+                if isinstance(org, dict)
+            }
+            if org_logins & reviewer_orgs:
+                return True
+
+        if reviewer_teams:
+            teams = self._github_get(token, "/user/teams")
+            for team in teams if isinstance(teams, list) else []:
+                if not isinstance(team, dict):
+                    continue
+                slug = str(team.get("slug") or "").lower()
+                org = team.get("organization") or {}
+                org_login = str(org.get("login") or "").lower()
+                if f"{org_login}/{slug}" in reviewer_teams:
+                    return True
+
+        return False
 
     def _callback_url(self, request: Request) -> str:
         public_base = os.environ.get("QTB_PUBLIC_BASE_URL", "").strip().rstrip("/")

--- a/bench/tests/test_github_oauth_auth.py
+++ b/bench/tests/test_github_oauth_auth.py
@@ -64,7 +64,7 @@ class GithubOAuthAuthTests(unittest.TestCase):
                 self.assertEqual(user.github_user_id, "12345")
                 self.assertEqual(user.role, "admin")
 
-    def test_public_login_does_not_request_org_scope(self):
+    def test_public_login_requests_org_scope_for_org_reviewer_split(self):
         with tempfile.TemporaryDirectory() as tmp:
             with patch.dict(
                 "os.environ",
@@ -86,7 +86,7 @@ class GithubOAuthAuthTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 302)
         query = parse_qs(urlparse(response.headers["location"]).query)
-        self.assertEqual(query["scope"], ["read:user user:email"])
+        self.assertEqual(query["scope"], ["read:user user:email read:org"])
 
     def test_invite_only_org_login_requests_org_scope(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -207,6 +207,162 @@ class GithubOAuthAuthTests(unittest.TestCase):
                         "name": "Reviewer",
                     }
                 )
+                self.assertEqual(user.role, "reviewer")
+                self.assertTrue(user.is_reviewer)
+
+    def test_allowed_org_member_gets_reviewer_role(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_GITHUB_ALLOW_ALL": "true",
+                    "QTB_GITHUB_ALLOWED_ORGS": "varsity-tech-product",
+                },
+                clear=True,
+            ):
+                auth = AuthService(Path(tmp))
+                with patch.object(
+                    auth,
+                    "_github_get",
+                    return_value=[{"login": "varsity-tech-product"}],
+                ):
+                    user = auth._build_user(
+                        {
+                            "id": 34567,
+                            "login": "org-member",
+                            "email": "member@example.com",
+                            "name": "Org Member",
+                        },
+                        "tok",
+                    )
+                self.assertEqual(user.role, "reviewer")
+                self.assertTrue(user.is_reviewer)
+
+    def test_external_public_user_keeps_user_role(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_GITHUB_ALLOW_ALL": "true",
+                    "QTB_GITHUB_ALLOWED_ORGS": "varsity-tech-product",
+                },
+                clear=True,
+            ):
+                auth = AuthService(Path(tmp))
+                with patch.object(
+                    auth,
+                    "_github_get",
+                    return_value=[{"login": "external-org"}],
+                ):
+                    user = auth._build_user(
+                        {
+                            "id": 45678,
+                            "login": "external",
+                            "email": "external@example.com",
+                            "name": "External",
+                        },
+                        "tok",
+                    )
+                self.assertEqual(user.role, "user")
+                self.assertFalse(user.is_reviewer)
+
+    def test_explicit_reviewer_team_suppresses_allowed_org_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_GITHUB_ALLOW_ALL": "true",
+                    "QTB_GITHUB_ALLOWED_ORGS": "varsity-tech-product",
+                    "QTB_REVIEWER_GITHUB_TEAMS": "varsity-tech-product/reviewers",
+                },
+                clear=True,
+            ):
+                auth = AuthService(Path(tmp))
+                with patch.object(
+                    auth,
+                    "_github_get",
+                    return_value=[
+                        {
+                            "slug": "engineering",
+                            "organization": {"login": "varsity-tech-product"},
+                        }
+                    ],
+                ):
+                    user = auth._build_user(
+                        {
+                            "id": 56789,
+                            "login": "engineer",
+                            "email": "engineer@example.com",
+                            "name": "Engineer",
+                        },
+                        "tok",
+                    )
+                self.assertEqual(user.role, "user")
+                self.assertFalse(user.is_reviewer)
+
+    def test_reviewer_team_requires_org_qualified_match(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_GITHUB_ALLOW_ALL": "true",
+                    "QTB_REVIEWER_GITHUB_TEAMS": "reviewers",
+                },
+                clear=True,
+            ):
+                auth = AuthService(Path(tmp))
+                with patch.object(
+                    auth,
+                    "_github_get",
+                    return_value=[
+                        {
+                            "slug": "reviewers",
+                            "organization": {"login": "external-org"},
+                        }
+                    ],
+                ):
+                    user = auth._build_user(
+                        {
+                            "id": 67890,
+                            "login": "external-reviewer",
+                            "email": "external-reviewer@example.com",
+                            "name": "External Reviewer",
+                        },
+                        "tok",
+                    )
+                self.assertEqual(user.role, "user")
+                self.assertFalse(user.is_reviewer)
+
+    def test_org_qualified_reviewer_team_gets_reviewer_role(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(
+                "os.environ",
+                {
+                    "QTB_GITHUB_ALLOW_ALL": "true",
+                    "QTB_REVIEWER_GITHUB_TEAMS": "varsity-tech-product/reviewers",
+                },
+                clear=True,
+            ):
+                auth = AuthService(Path(tmp))
+                with patch.object(
+                    auth,
+                    "_github_get",
+                    return_value=[
+                        {
+                            "slug": "reviewers",
+                            "organization": {"login": "varsity-tech-product"},
+                        }
+                    ],
+                ):
+                    user = auth._build_user(
+                        {
+                            "id": 78901,
+                            "login": "team-reviewer",
+                            "email": "team-reviewer@example.com",
+                            "name": "Team Reviewer",
+                        },
+                        "tok",
+                    )
                 self.assertEqual(user.role, "reviewer")
                 self.assertTrue(user.is_reviewer)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -498,6 +498,12 @@ Any authenticated GitHub reviewer can inspect the task spec, transcript, tutor
 tool log, workspace tree, and judge evaluation for a completed bundle.
 Reviewer access is a distinct `reviewer` role; admins inherit reviewer access,
 and ordinary authenticated users stay on the run/results surfaces.
+Reviewer role assignment accepts explicit `QTB_REVIEWER_GITHUB_LOGINS` and
+`QTB_REVIEWER_EMAILS` matches, plus org/team membership through
+`QTB_REVIEWER_GITHUB_ORGS` and `QTB_REVIEWER_GITHUB_TEAMS`. Reviewer team
+values use org-qualified `org/slug` form. When both reviewer org/team variables
+are empty, `QTB_GITHUB_ALLOWED_ORGS` and `QTB_GITHUB_ALLOWED_TEAMS` are the
+default reviewer membership groups.
 
 The isolated frontend treats Session Flow as the live run monitor and Human
 Review as the archive-facing session view: active runs render their full


### PR DESCRIPTION
## Summary
- assign reviewer role from GitHub org/team membership during OAuth callback
- request read:org when org/team reviewer routing is configured
- document reviewer env vars and org-qualified team values

## Verification
- .venv/bin/python -m py_compile bench/server/auth.py bench/tests/test_github_oauth_auth.py
- pytest bench/tests/test_github_oauth_auth.py bench/tests/test_server_web_ui.py

## Review
- Codex review round 1 found generic allowed-org fallback with explicit reviewer team configs; fixed.
- Codex review round 2 found bare team slug cross-org reviewer grants; fixed with org/slug-only reviewer team matching.