### PR TITLE
docs: decouple platform skill from Impl A wording

### DIFF
--- a/docs/agent_in_loop.md
+++ b/docs/agent_in_loop.md
@@ -13,7 +13,7 @@ working in this repo also see a thin invocation shim at
 
 This repo intentionally does not provide a runnable auto-driver that emits
 tutor messages. Agent-in-the-loop runs are evaluated as live tutoring
-conversations: the tutor must read each `student_message` and decide the next
+conversations: the tutor must read each `user_message` and decide the next
 reply from that message.
 
 Issue #57 captures the design decisions and the empirical evidence behind
@@ -64,7 +64,7 @@ This is **not** the right reference for:
 ```
 POST /client/runs/start    → run_id, token
 POST /session/register     → session_id     (Authorization: Bearer <token>)
-POST /session/{sid}/start  → background, opening student_message
+POST /session/{sid}/start  → background, opening user_message
 POST /session/{sid}/send   → student reply, status, reason     (loop)
 ```
 
@@ -86,13 +86,13 @@ SID=$(curl -sS -X POST "$BASE/session/register" \
         -d "{\"persona_id\":\"$PERSONA\"}" | jq -r .session_id)
 
 START=$(curl -sS -X POST "$BASE/session/$SID/start")
-OPENER=$(echo "$START" | jq -r .student_message)
+OPENER=$(echo "$START" | jq -r .user_message)
 # ... loop send_message until terminal ...
 ```
 
 This guide gives the protocol lifecycle only. Do not wrap it in a static
 reply queue. If you build a client, its reply function must call a live tutor
-model or a human operator on every turn using the latest `student_message`.
+model or a human operator on every turn using the latest `user_message`.
 
 ---
 
@@ -100,14 +100,14 @@ model or a human operator on every turn using the latest `student_message`.
 
 Each turn:
 
-1. You have the most recent `student_message` (from `/start` on turn 1, or
+1. You have the most recent `user_message` (from `/start` on turn 1, or
    from the previous `/send` response on subsequent turns).
 2. **You read it carefully and compose the next reply based on what the
    student actually said.** Not a preset list. Not a template. Address the
    specific question or concern in their last message.
 3. POST to `/session/{sid}/send` with `{"text": "<your reply>"}`.
 4. Response shape (verified against `bench/server/core/session.py::TutoringSession._result`):
-   `{"student_message": "...", "status": "active|completed|failed", "reason": "...", "sim_error": {...}?, "current_phase": "...", "next_allowed": [...]}`.
+   `{"user_message": "...", "status": "active|completed|failed", "reason": "...", "sim_error": {...}?, "current_phase": "...", "next_allowed": [...]}`.
    `reason` is omitted on `active`; `sim_error` only appears on
    `student_sim_error:*` failures. There is **no** `tool_calls` field —
    the student persona has no tools to call.
@@ -190,7 +190,7 @@ Each one is grounded in a live failure mode (sessions `01e84317` and
    pre-written messages indexed by turn number will eventually emit the
    same closing line three times in a row. The server's repeat-detector
    fires `reason=agent_stuck` and the session ends `failed`. Always
-   compose each reply from the actual `student_message` you just received.
+   compose each reply from the actual `user_message` you just received.
 
 2. **`/session/{sid}/send` can take 5–15 seconds** per call (student-sim
    LLM round-trip). Use a generous client timeout — `--max-time 900` or
@@ -275,7 +275,7 @@ Before driving a non-trivial session, confirm:
       you chose is in that task's `persona_ids`.
 - [ ] Your reply strategy calls a live LLM or human operator on every turn.
       If you're an LLM doing this in-session, the strategy is "read
-      `student_message`, think, respond".
+      `user_message`, think, respond".
 - [ ] HTTP client timeout ≥ 900 s on `/send`.
 - [ ] You're prepared for the session to take many turns (15 for I01,
       higher for E-series). Don't bail early.

--- a/docs/skills/quanttutorbench-rest-agent/SKILL.md
+++ b/docs/skills/quanttutorbench-rest-agent/SKILL.md
@@ -1,14 +1,19 @@
 ---
 name: quanttutorbench-rest-agent
-description: "Use when an external AI agent needs to join QuantTutorBench, complete benchmark sessions through MCP or REST, call allowed tools, answer the user, monitor progress, and hand off terminal runs."
+description: "Use when an external AI agent needs to join QuantAgentBench, complete benchmark sessions through MCP or REST, call allowed tools, reply to the user message, monitor progress, and hand off terminal runs."
 ---
 
-# QuantTutorBench Agent Onboarding
+# QuantAgentBench Agent Onboarding
 
-Use this guide to connect an external tutor agent to QuantTutorBench and finish
-each assigned benchmark run end to end. The platform provides the user
-messages, task-visible background, available tools, and run state. Your job is
-to keep working through the API until the session reaches a terminal status.
+Use this guide to connect an external agent to QuantAgentBench and finish each
+assigned benchmark run end to end. The platform provides the user messages,
+task-visible background, available tools, and run state. Your job is to keep
+working through the API until the session reaches a terminal status.
+
+The role you play in any given run — what to produce, who you are talking to,
+what counts as success — is described by the active task bundle through
+`background` and the `user_message` you receive. Read those two before you
+decide your first action.
 
 ## Operating Rule
 
@@ -29,7 +34,7 @@ Use the operator-provided `BASE`. Production:
 BASE="https://benchmark-liard.vercel.app"
 ```
 
-Use long request timeouts. User simulation and tool calls can take minutes.
+Use long request timeouts. Server-side actors and tool calls can take minutes.
 A 900 second timeout is a practical default.
 
 ## Connection Modes
@@ -42,7 +47,7 @@ run/session lifecycle applies in both modes:
 3. Register and start a session.
 4. Read the user message.
 5. Call allowed tools when useful.
-6. Send the tutor reply.
+6. Send the reply.
 7. Repeat until the server returns `completed` or `failed`.
 8. Return the run summary to the operator.
 
@@ -73,8 +78,8 @@ tools are:
 
 After connecting, call `register_session` with `{}` or an operator-provided
 `persona_id`, then call `start_session`. Use `list_tools` to read the task tool
-catalog. Call task tools when their schemas match the current user need.
-Call `send_message` to deliver each tutor reply.
+catalog. Call task tools when their schemas match the current user need. Call
+`send_message` to deliver each reply.
 
 If a tool call happens outside the current phase, the response includes guidance
 such as `current_phase` and `next_allowed`. Follow that guidance and continue
@@ -174,8 +179,9 @@ Content-Type: application/json
 {}
 ```
 
-Use `{}` for persona auto-selection. Include `persona_id` only when the operator
-explicitly provides one. Save `session_id`.
+Use `{}` for default registration. Include `persona_id` only when the operator
+explicitly provides one; bundles that do not consume `persona_id` ignore it.
+Save `session_id`.
 
 ### 2. Start
 
@@ -187,7 +193,8 @@ Content-Type: application/json
 {}
 ```
 
-Save the first `user_message`. Save `background` when present.
+Save the first `user_message`. Save `background` when present. The
+`background` describes what the active bundle expects of you for this run.
 
 ### 3. Discover Tools
 
@@ -217,7 +224,7 @@ Authorization: Bearer <token>
 ```
 
 Continue polling until `status` is `completed` or `failed`. Use completed tool
-outputs to decide the next tutor message or tool call.
+outputs to decide the next reply or tool call.
 
 ### 4. Work Until Done
 
@@ -226,19 +233,19 @@ without asking the operator for step-by-step instructions. Continue until the
 server returns a terminal session status.
 
 The external agent owns the full loop for every assigned run: read, decide,
-call tools, answer the user, and repeat until terminal status.
+call tools, reply, and repeat until terminal status.
 
 Recommended loop:
 
 1. Read the latest `user_message` and visible `background`.
 2. Inspect available tools when tool use may help answer or produce artifacts.
 3. Call allowed tools and wait for results.
-4. Send a tutor reply that directly helps the user.
+4. Send a reply that directly addresses the latest `user_message`.
 5. Read the response status.
 6. If `active`, save the next `user_message` and continue.
 7. If `completed` or `failed`, stop the loop and hand off the run summary.
 
-Send a tutor reply:
+Send a reply:
 
 ```http
 POST /session/{session_id}/send
@@ -262,7 +269,7 @@ Handle the response:
 - `status: "completed"`: record `reason`, stop the session loop, and hand off.
 - `status: "failed"`: record `reason` or `error`, stop the session loop, and hand off.
 
-Every reply should reflect the latest user message. Repeated identical tutor
+Every reply should reflect the latest user message. Repeated identical reply
 text can trigger `agent_stuck`.
 
 ## Monitoring
@@ -353,19 +360,7 @@ Authorization: Bearer <token>
   "score_status": "completed_scored",
   "task_score": 0.93,
   "task_pass": null,
-  "detail": {
-    "dimensions": [
-      {"name": "result_judge", "track": "qr", "score": 5,    "status": "success"},
-      {"name": "task_planning", "track": "qp", "score": 4,   "status": "success"},
-      {"name": "tool_usage",    "track": "qp", "score": 0.85, "status": "success"}
-    ],
-    "tracks": {
-      "qr": {"score": 1.0,    "status": "success", "blockers": []},
-      "qp": {"score": 0.825, "status": "success", "blockers": []}
-    },
-    "judge_reliability": {},
-    "blocking_missing": []
-  }
+  "detail": { "...": "bundle-specific contents" }
 }
 ```
 
@@ -374,8 +369,9 @@ Public contract: `schema_version`, `score_id`, `score_status`, `task_score`,
 `pending | running | completed_scored | completed_not_computable | failed |
 interrupted`. Pending/running responses carry the same fields with
 `task_score` and `task_pass` set to `null`. Everything inside `detail` is
-opaque — depending on the dimension list or per-track shape is a beta
-dependency.
+opaque and bundle-defined: the `dimensions` list, per-track aggregates, and any
+reliability metadata are owned by the active evaluator. Depending on a specific
+shape inside `detail` is a beta dependency.
 
 `task_pass` is `null` until baseline calibration lands. Treat
 `task_score` as a diagnostic float during this window — the server will
@@ -426,8 +422,8 @@ with httpx.Client(base_url=BASE, timeout=TIMEOUT) as client:
 
     while True:
         tools = get_json(client, f"/session/{sid}/tools", token)["tools"]
-        tutor_text = compose_reply(latest_user, background, tools)
-        reply = post_json(client, f"/session/{sid}/send", {"text": tutor_text}, token)
+        reply_text = compose_reply(latest_user, background, tools)
+        reply = post_json(client, f"/session/{sid}/send", {"text": reply_text}, token)
         if reply.get("status") != "active":
             print({
                 "run_id": run["run_id"],


### PR DESCRIPTION
Closes #195.

## Summary

- Rewrite `docs/skills/quanttutorbench-rest-agent/SKILL.md` (served at `/skill.md`) as a bundle-agnostic platform onboarding doc: title → QuantAgentBench Agent Onboarding; tutor wording stripped; persona_id documented as bundle-optional; the `/scores` example replaced with a bundle-agnostic placeholder and the surrounding paragraph clarifies that `detail.dimensions[]` and per-track shape are bundle-defined.
- Align `docs/agent_in_loop.md` to use the actual wire field `user_message` (`bench/server/core/session.py:450, 812`); tutor framing in that file is intentional since it is the tutor-in-the-loop guide for Impl A sessions.

Lifecycle endpoints, token model, async 202+poll pattern, score envelope contract (`schema_version`, `score_status`, `task_score`, `task_pass`, `detail`), and the `/#/review/{session_id}` URL all stay — all platform-level.

## Test plan

- [ ] `curl https://benchmark-liard.vercel.app/skill.md` after deploy — confirm new title and no `tutor`/`result_judge` strings.
- [ ] `grep -E "tutor reply|tutor agent|QuantTutorBench|result_judge" docs/skills/quanttutorbench-rest-agent/SKILL.md` — expect no matches.
- [ ] `grep student_message docs/agent_in_loop.md` — expect no matches.
- [ ] Spot-check a fresh AUT run against the new skill page to confirm no behavioral regression in the lifecycle.

## Codex review

Round 1: only finding was a P2 on unrelated untracked judge-validation JSON files (`human_labels_round2_reviewer2.json`, `human_labels_round2_combined.json`) — rejected under filter rule 2 (scope creep, files predate this branch and belong to a different track). No findings on the docs edits.