### PR TITLE
feat(platform): add bundle-authored agent_brief channel

### DIFF
--- a/bench/platform_api/contracts/models.py
+++ b/bench/platform_api/contracts/models.py
@@ -82,6 +82,7 @@ class EvalItem:
     metadata: JsonObject = field(default_factory=dict)
     data_mounts: tuple[DataMount, ...] = ()
     sandbox_spec: SandboxSpec | None = None
+    agent_brief: str | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "data_mounts", tuple(self.data_mounts))

--- a/bench/server/api/session_api.py
+++ b/bench/server/api/session_api.py
@@ -1316,7 +1316,14 @@ class SessionState:
         if name == "get_background":
             from server.core.session import build_background
 
-            bg = build_background(self.task) if self.task else ""
+            bg = (
+                build_background(
+                    self.task,
+                    agent_brief=getattr(self.eval_item, "agent_brief", None),
+                )
+                if self.task
+                else ""
+            )
             return [TextContent(type="text", text=json.dumps(bg))]
 
         if name == "send_message":

--- a/bench/server/core/session.py
+++ b/bench/server/core/session.py
@@ -124,8 +124,12 @@ def _data_mount_fact(item: Any) -> dict[str, Any]:
     return fact
 
 
-def build_background(task) -> dict[str, Any]:
-    """Build JSON-able platform facts for the session environment."""
+def build_background(task, *, agent_brief: str | None = None) -> dict[str, Any]:
+    """Build JSON-able platform facts for the session environment.
+
+    ``agent_brief`` is an optional bundle-authored framing string surfaced
+    verbatim under ``background.agent_brief`` for the AUT.
+    """
     env = _field(task, "environment")
     sandbox_image = _sandbox_image(env)
     data_files = [str(item) for item in _as_list(_field(env, "data_files"))]
@@ -167,7 +171,7 @@ def build_background(task) -> dict[str, Any]:
             }
         )
 
-    return {
+    background: dict[str, Any] = {
         "schema_version": "platform_background.v1",
         "domain": "quantitative_finance",
         "sandbox": {
@@ -196,6 +200,11 @@ def build_background(task) -> dict[str, Any]:
             "schema_source": "Tool inputSchema returned by MCP list_tools",
         },
     }
+
+    if agent_brief:
+        background["agent_brief"] = str(agent_brief)
+
+    return background
 
 
 # ---------------------------------------------------------------------------
@@ -443,7 +452,10 @@ class Session:
         )
         self._session_info_called = True
 
-        background = build_background(self._task)
+        background = build_background(
+            self._task,
+            agent_brief=getattr(self._eval_item, "agent_brief", None),
+        )
         return json.dumps(
             {
                 "background": background,

--- a/docs/skills/quanttutorbench-rest-agent/SKILL.md
+++ b/docs/skills/quanttutorbench-rest-agent/SKILL.md
@@ -196,6 +196,12 @@ Content-Type: application/json
 Save the first `user_message`. Save `background` when present. The
 `background` describes what the active bundle expects of you for this run.
 
+If `background.agent_brief` is present, treat it as authoritative
+bundle-authored framing for this run — the active bundle uses it to tell
+you what role you are playing, what counts as success, and any constraints
+beyond the platform contract. When it is absent, infer the role from
+`background` and the first `user_message`.
+
 ### 3. Discover Tools
 
 ```http


### PR DESCRIPTION
Closes #197.

## Summary

- Add opt-in `EvalItem.agent_brief: str | None = None` so bundles can author agent-facing framing without depending on the NPC opener channel.
- Extend `build_background(task, *, agent_brief=None)` to surface `background.agent_brief` when set; both call sites (`bench/server/core/session.py:446`, `bench/server/api/session_api.py:1319`) forward it from the active `EvalItem`.
- Add one paragraph to `docs/skills/quanttutorbench-rest-agent/SKILL.md` telling the AUT to honour `background.agent_brief` as authoritative bundle-authored framing when present.

Platform owns the mechanism; bundles and task-case designers own the decision and content. No bundle adoption in this PR — reference and impl_b keep shipping empty briefs.

## Test plan

- [x] `pytest bench/tests/unit/` — 308 passed.
- [x] `pytest bench/tests/integration/` — 41 passed, 1 skipped (sandbox UID, environmental).
- [x] `pytest bench/tests/test_server_session_runtime.py bench/tests/test_server_web_ui.py bench/tests/test_run_state_transitions.py bench/tests/test_health.py bench/tests/test_user_delegation_framing.py` — 54 passed.
- [ ] After deploy: `curl -s "$BASE/skill.md" | grep agent_brief` — expect the new paragraph.
- [ ] Smoke an Impl A run and confirm `background.agent_brief` is absent (no bundle adoption yet); set a one-off brief on a debug task to confirm it surfaces verbatim.

## Codex review

Round 1 ran clean on the actual edits ("the runtime agent_brief wiring looks coherent"). The three returned P2 findings target unrelated untracked judge-validation JSON artefacts (`human_labels_round2_*.json`) that predate this branch — rejected under filter rule 2 (scope creep). Those should land under a separate judge-validation issue.