### PR TITLE
feat(reference): populate default agent brief

### DIFF
--- a/bench/server/reference/task_suite.py
+++ b/bench/server/reference/task_suite.py
@@ -27,6 +27,13 @@ _CODE_CATEGORIES = {
 _V3_LEAN_CATEGORIES = {"implementation"}
 _TASK_LAYERS = ("L0", "L1", "L2")
 _TASK_PREFIXES = tuple(f"{layer}_" for layer in _TASK_LAYERS)
+DEFAULT_AGENT_BRIEF = (
+    "You are a tutoring agent. The user is a learner working on a "
+    "quantitative-finance task. Teach the concept and guide the learner "
+    "through the answer. Tool errors are diagnostic signals. When a tool "
+    "returns an error (PermissionError, missing path, timeout), explain "
+    "the constraint to the user and adjust your approach."
+)
 
 
 def _default_bench_root() -> Path:
@@ -84,6 +91,7 @@ class ReferenceTaskSuite(TaskSuite):
             metadata=metadata,
             data_mounts=self._translate_environment_mounts(env, task=task),
             sandbox_spec=self._sandbox_spec_for_task(task),
+            agent_brief=DEFAULT_AGENT_BRIEF,
         )
 
     def get_business_task(self, task_id: str) -> QuantTutorTask:

--- a/bench/tests/api/test_session_lifecycle.py
+++ b/bench/tests/api/test_session_lifecycle.py
@@ -75,6 +75,17 @@ class TestStart:
         assert len(body["user_message"]) > 0
 
     @pytest.mark.asyncio
+    async def test_start_returns_reference_agent_brief_for_l2_task(self, client):
+        sid = await register_session(client)
+        body = await start_session(client, sid)
+
+        brief = body["background"]["agent_brief"]
+        assert "You are a tutoring agent" in brief
+        assert "Tool errors are diagnostic signals" in brief
+        assert "PermissionError" in brief
+        assert "adjust your approach" in brief
+
+    @pytest.mark.asyncio
     async def test_start_before_register_fails(self, client):
         resp = await client.post("/session/nonexistent/start", json={})
         assert resp.status_code == 404

--- a/bench/tests/integration/test_reference_bundle.py
+++ b/bench/tests/integration/test_reference_bundle.py
@@ -112,6 +112,19 @@ def test_reference_task_suite_bridges_v3_task(bench_root):
     }
 
 
+def test_reference_task_suite_populates_agent_brief(bench_root):
+    bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
+
+    item = bundle.task_suite.get_task(V3_L2_TASK)
+
+    assert item.agent_brief is not None
+    assert "You are a tutoring agent" in item.agent_brief
+    assert "learner working on a quantitative-finance task" in item.agent_brief
+    assert "Tool errors are diagnostic signals" in item.agent_brief
+    assert "PermissionError" in item.agent_brief
+    assert "adjust your approach" in item.agent_brief
+
+
 def test_reference_task_suite_emits_hf_uri_without_local_cache(bench_root):
     bundle = load_reference_bundle(bench_root=bench_root, eval_model="fake-model")
 


### PR DESCRIPTION
Closes #200

## What changed
- Adds a reference-wide DEFAULT_AGENT_BRIEF to EvalItem construction.
- Covers bundle construction and REST POST /session/{sid}/start background propagation.

## Verification
- pytest bench/tests/integration/test_reference_bundle.py::test_reference_task_suite_populates_agent_brief bench/tests/api/test_session_lifecycle.py::TestStart::test_start_returns_reference_agent_brief_for_l2_task
- pytest bench/tests/integration/test_reference_bundle.py bench/tests/api/test_session_lifecycle.py
- codex exec review --uncommitted