### PR TITLE
Fix category-aware programmatic rubrics

### DIFF
--- a/bench/eval/contracts/schemas.py
+++ b/bench/eval/contracts/schemas.py
@@ -166,6 +166,7 @@ class QuantTutorTask(BaseModel):
     difficulty: Optional[Difficulty] = None  # L0 knowledge primitives have no difficulty notion
     category: TaskCategory
     subcategory: Optional[str] = None
+    rubric_profile: Optional[str] = None
     task_type: TaskType = TaskType.MULTI_TURN
     description: str = ""  # L0 uses ``question`` instead
     # v3.0 L0 — single-turn knowledge Q&A

--- a/bench/eval/judges/process_metrics.py
+++ b/bench/eval/judges/process_metrics.py
@@ -16,6 +16,7 @@ import threading
 import time as _time
 from typing import Optional
 
+from eval.rubrics.task_profiles import qp_dimension_weights
 from eval.tool_filters import NON_SUBSTANTIVE_TOOLS
 
 
@@ -330,10 +331,18 @@ def evaluate_programmatic_process_metrics(
     tool_usage_result: Optional[dict] = None,
     task_requires_code: bool = False,
     required_tools: Optional[list[str]] = None,
+    rubric_profile: str = "",
 ) -> dict:
     """Run QP dimensions that do not require an LLM judge."""
 
     results: dict = {}
+    dimension_weights = qp_dimension_weights(
+        _QP_DIMENSION_WEIGHTS,
+        category=category,
+        task_requires_code_value=task_requires_code,
+        rubric_profile=rubric_profile,
+    )
+    results["_dimension_weights"] = dimension_weights
 
     coverage = compute_required_tool_coverage(
         proxy_logs=proxy_logs,
@@ -346,9 +355,7 @@ def evaluate_programmatic_process_metrics(
     results["action_economy"] = ae_result
     print(f"      action_economy: {ae_result['score']}")
 
-    if category not in ("conceptual_qa",) and not (
-        is_adversarial and not task_requires_code
-    ):
+    if "code_lifecycle" in dimension_weights:
         try:
             from eval.programmatic.code_process import (
                 evaluate_code_lifecycle,
@@ -372,13 +379,7 @@ def evaluate_programmatic_process_metrics(
                 "error": str(e),
             }
     else:
-        results["code_lifecycle"] = {
-            "score": None,
-            "status": "skipped",
-            "skip_reason": "not_applicable",
-            "required_for_track_score": False,
-            "reason": "Code lifecycle is not applicable for this task.",
-        }
+        print("      code_lifecycle: not_applicable")
 
     if tool_usage_result is not None:
         results["tool_usage"] = _dimension_status(tool_usage_result, required=True)
@@ -397,9 +398,15 @@ def evaluate_programmatic_process_metrics(
 def finalize_process_metrics(results: dict) -> dict:
     """Attach aggregate, blocking, weights, and total cost to QP results."""
 
+    dimension_weights = dict(
+        results.pop(
+            "_dimension_weights",
+            results.get("_weights_used", _QP_DIMENSION_WEIGHTS),
+        )
+    )
     available_dims: dict[str, float] = {}
     blocking_missing: list[dict] = []
-    for dim in _QP_DIMENSION_WEIGHTS:
+    for dim in dimension_weights:
         v = results.get(dim)
         if not isinstance(v, dict):
             blocking_missing.append(
@@ -429,13 +436,13 @@ def finalize_process_metrics(results: dict) -> dict:
         aggregate = None
         effective_weights: dict[str, float] = {}
     elif available_dims:
-        total_weight = sum(_QP_DIMENSION_WEIGHTS[d] for d in available_dims)
+        total_weight = sum(dimension_weights[d] for d in available_dims)
         aggregate = sum(
-            _QP_DIMENSION_WEIGHTS[d] * available_dims[d] / total_weight
+            dimension_weights[d] * available_dims[d] / total_weight
             for d in available_dims
         )
         effective_weights = {
-            dim: round(_QP_DIMENSION_WEIGHTS[dim] / total_weight, 4)
+            dim: round(dimension_weights[dim] / total_weight, 4)
             for dim in available_dims
         }
     else:
@@ -446,7 +453,7 @@ def finalize_process_metrics(results: dict) -> dict:
         round(aggregate, 4) if aggregate is not None else None
     )
     results["_blocking_missing"] = blocking_missing
-    results["_weights_used"] = dict(_QP_DIMENSION_WEIGHTS)
+    results["_weights_used"] = dimension_weights
     results["_weights_effective"] = effective_weights
     print(f"      aggregate_process_score: {results['aggregate_process_score']}")
 
@@ -478,6 +485,7 @@ def evaluate_all_process_metrics(
     enriched_conversation: Optional[list[dict]] = None,
     required_capabilities: Optional[list[str]] = None,
     required_tools: Optional[list[str]] = None,
+    rubric_profile: str = "",
 ) -> dict:
     """Run all process-level metrics and return consolidated results.
 
@@ -523,6 +531,7 @@ def evaluate_all_process_metrics(
         tool_usage_result=tool_usage_result,
         task_requires_code=task_requires_code,
         required_tools=required_tools,
+        rubric_profile=rubric_profile,
     )
 
     # ── LLM: task_planning + problem_solving ──

--- a/bench/eval/rubrics/task_profiles.py
+++ b/bench/eval/rubrics/task_profiles.py
@@ -1,0 +1,108 @@
+"""Task deliverable profiles used to select applicable evaluator checks."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Mapping
+
+
+class RubricProfile(str, Enum):
+    SAFETY = "safety"
+    DIAGNOSIS = "diagnosis"
+    CONVERSATIONAL = "conversational"
+    CODE_IMPLEMENTATION = "code_implementation"
+    GENERAL = "general"
+
+
+_CODE_CATEGORIES = {
+    "alpha_research",
+    "backtest",
+    "backtest_engine",
+    "code_debugging",
+    "code_generation",
+    "data_analysis",
+    "data_engineering",
+    "debug",
+    "implementation",
+    "strategy",
+}
+
+
+def enum_value(value: Any) -> str:
+    return str(getattr(value, "value", value) or "")
+
+
+def category_value(task: Any) -> str:
+    return enum_value(getattr(task, "category", ""))
+
+
+def task_requires_code(task: Any) -> bool:
+    return bool(getattr(task, "requires_code", False))
+
+
+def rubric_profile_for_task(task: Any) -> str:
+    explicit = enum_value(getattr(task, "rubric_profile", ""))
+    if explicit:
+        return explicit
+
+    return rubric_profile_for_category(
+        category=category_value(task),
+        requires_code=task_requires_code(task),
+    )
+
+
+def rubric_profile_for_category(*, category: str, requires_code: bool) -> str:
+    if category == "adversarial":
+        return RubricProfile.SAFETY.value
+    if category == "diagnostic":
+        return RubricProfile.DIAGNOSIS.value
+    if category == "end_to_end" and not requires_code:
+        return RubricProfile.CONVERSATIONAL.value
+    if requires_code or category in _CODE_CATEGORIES:
+        return RubricProfile.CODE_IMPLEMENTATION.value
+    return RubricProfile.GENERAL.value
+
+
+def should_apply_data_source_check(task: Any) -> bool:
+    profile = rubric_profile_for_task(task)
+    if profile == RubricProfile.CONVERSATIONAL.value:
+        return False
+    if profile == RubricProfile.SAFETY.value and not task_requires_code(task):
+        return False
+    return True
+
+
+def should_evaluate_code_lifecycle(task: Any) -> bool:
+    profile = rubric_profile_for_task(task)
+    return task_requires_code(task) or profile == RubricProfile.CODE_IMPLEMENTATION.value
+
+
+def qp_dimension_weights(
+    base_weights: Mapping[str, float],
+    *,
+    task: Any | None = None,
+    category: str = "",
+    task_requires_code_value: bool | None = None,
+    rubric_profile: str = "",
+) -> dict[str, float]:
+    weights = dict(base_weights)
+    if task is not None:
+        include_code_lifecycle = should_evaluate_code_lifecycle(task)
+    else:
+        category_value_text = category
+        requires_code = bool(task_requires_code_value)
+        profile = rubric_profile
+        if not profile:
+            profile = rubric_profile_for_category(
+                category=category_value_text,
+                requires_code=requires_code,
+            )
+        include_code_lifecycle = (
+            requires_code or profile == RubricProfile.CODE_IMPLEMENTATION.value
+        )
+        if profile == RubricProfile.CONVERSATIONAL.value:
+            include_code_lifecycle = False
+
+    if not include_code_lifecycle:
+        weights.pop("code_lifecycle", None)
+    return weights

--- a/bench/eval/tracks/qp.py
+++ b/bench/eval/tracks/qp.py
@@ -6,6 +6,7 @@ import threading
 from typing import Any
 
 from eval.contracts.output import TrackResult
+from eval.rubrics.task_profiles import rubric_profile_for_task
 from eval.tracks.common import (
     check_cancel,
     cost_by_model_from,
@@ -46,6 +47,7 @@ def evaluate(
     )
     tool_usage_result = None
     tool_usage_error = None
+    rubric_profile = rubric_profile_for_task(task)
 
     try:
         from eval.programmatic.tool_usage import evaluate_tool_usage
@@ -84,6 +86,7 @@ def evaluate(
             required_tools=(
                 task.ground_truth.expected_mcp_tools if task.ground_truth else []
             ),
+            rubric_profile=rubric_profile,
         )
         process["task_planning"] = {
             "score": None,
@@ -140,6 +143,7 @@ def evaluate(
                     if task.ground_truth
                     else None
                 ),
+                rubric_profile=rubric_profile,
             )
         except (
             Exception
@@ -162,7 +166,8 @@ def evaluate(
 
             finalize_process_metrics(process)
 
-    for dim in _QP_DIMS:
+    selected_dims = tuple((process.get("_weights_used") or {}).keys()) or _QP_DIMS
+    for dim in selected_dims:
         data = process.get(dim)
         if data is None:
             blockers.append(

--- a/bench/eval/tracks/qr.py
+++ b/bench/eval/tracks/qr.py
@@ -9,6 +9,12 @@ from pathlib import Path
 from typing import Any
 
 from eval.contracts.output import TrackResult
+from eval.rubrics.task_profiles import (
+    rubric_profile_for_task,
+    should_apply_data_source_check,
+    should_evaluate_code_lifecycle,
+    task_requires_code,
+)
 from eval.tracks.common import (
     check_cancel,
     cost_by_model_from,
@@ -33,6 +39,82 @@ def _resolve_eval_script(gt: Any) -> str | None:
         return v3
     quant_validation = getattr(gt, "quant_validation", None)
     return getattr(quant_validation, "eval_script", None)
+
+
+def _checklist_item_value(item: dict[str, Any]) -> float:
+    if "score" in item:
+        try:
+            return float(item.get("score") or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+    return 1.0 if item.get("passed") else 0.0
+
+
+def _apply_rubric_profile_to_programmatic_result(
+    result: dict[str, Any],
+    *,
+    task: Any,
+) -> dict[str, Any]:
+    profile = rubric_profile_for_task(task)
+    data_source_applicable = should_apply_data_source_check(task)
+    code_lifecycle_applicable = should_evaluate_code_lifecycle(task)
+    result["_rubric_profile"] = profile
+    result["_data_source_check_applicable"] = data_source_applicable
+    result["_code_lifecycle_applicable"] = code_lifecycle_applicable
+
+    if not data_source_applicable:
+        result.pop("data_source_verified", None)
+        result.pop("data_source_fraction", None)
+
+    checklist = result.get("_checklist")
+    if not isinstance(checklist, list):
+        return result
+
+    removed_items: list[str] = []
+    selected: list[dict[str, Any]] = []
+    for raw_item in checklist:
+        if not isinstance(raw_item, dict):
+            selected.append(raw_item)
+            continue
+        item_name = str(raw_item.get("item") or "")
+        if item_name == "code_saved_to_file" and not task_requires_code(task):
+            removed_items.append(item_name)
+            continue
+        if item_name == "code_lifecycle" and not code_lifecycle_applicable:
+            removed_items.append(item_name)
+            continue
+        if item_name == "data_source_verified" and not data_source_applicable:
+            removed_items.append(item_name)
+            continue
+        selected.append(raw_item)
+
+    if not removed_items:
+        return result
+
+    total_weight = sum(
+        float(item.get("weight") or 0.0) for item in selected if isinstance(item, dict)
+    )
+    if total_weight <= 0:
+        result["_checklist"] = selected
+        result["_removed_checklist_items"] = sorted(set(removed_items))
+        return result
+
+    normalized: list[dict[str, Any]] = []
+    score = 0.0
+    for item in selected:
+        if not isinstance(item, dict):
+            normalized.append(item)
+            continue
+        normalized_item = dict(item)
+        weight = float(normalized_item.get("weight") or 0.0) / total_weight
+        normalized_item["weight"] = round(weight, 4)
+        score += weight * _checklist_item_value(normalized_item)
+        normalized.append(normalized_item)
+
+    result["_checklist"] = normalized
+    result["_removed_checklist_items"] = sorted(set(removed_items))
+    result["score"] = round(score, 4)
+    return result
 
 
 def _programmatic_eval(
@@ -76,7 +158,7 @@ def _programmatic_eval(
         spec.loader.exec_module(module)
         sig = inspect.signature(module.evaluate)
         kwargs: dict[str, Any] = {}
-        if "data_files" in sig.parameters:
+        if "data_files" in sig.parameters and should_apply_data_source_check(task):
             kwargs["data_files"] = (
                 task.environment.data_files if task.environment else []
             )
@@ -87,6 +169,7 @@ def _programmatic_eval(
         result = module.evaluate(workspace_path, tool_logs, conversation, **kwargs)
         if not isinstance(result, dict):
             raise RuntimeError("eval_script.evaluate() must return a dict")
+        result = _apply_rubric_profile_to_programmatic_result(result, task=task)
         result.setdefault("status", "success")
         result.setdefault("required_for_track_score", True)
         return result, None

--- a/bench/server/reference/task_suite.py
+++ b/bench/server/reference/task_suite.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from config.benchmark_config import BENCH_IMAGE_V3, BENCH_IMAGE_V3_LEAN
 from eval.contracts.schemas import QuantTutorTask
+from eval.rubrics.task_profiles import rubric_profile_for_task
 from platform_api.contracts import DataMount, EvalItem, SandboxSpec, TaskSuite
 from server.config.benchmark_config import DATASET_REPO_ID, DATASET_REVISION
 
@@ -80,6 +81,7 @@ class ReferenceTaskSuite(TaskSuite):
             "business_schema": "QuantTutorTask",
             "difficulty": _enum_value(task.difficulty),
             "category": _enum_value(task.category),
+            "rubric_profile": rubric_profile_for_task(task),
             "requires_code": bool(task.requires_code),
             "requires_tool": bool(task.requires_tool),
         }

--- a/bench/server/storage/eval_writer.py
+++ b/bench/server/storage/eval_writer.py
@@ -190,13 +190,14 @@ def _make_qp_track(eval_results: dict, duration: float) -> TrackResult:
                     "reason": str(eval_results[key]),
                 }
             )
-    for dim in (
+    selected_dims = tuple((process.get("_weights_used") or {}).keys()) or (
         "tool_usage",
         "action_economy",
         "code_lifecycle",
         "task_planning",
         "problem_solving",
-    ):
+    )
+    for dim in selected_dims:
         data = process.get(dim)
         if data is None:
             blockers.append(

--- a/bench/tests/unit/test_eval_architecture_contracts.py
+++ b/bench/tests/unit/test_eval_architecture_contracts.py
@@ -178,6 +178,191 @@ def test_qp_model_unavailable_preserves_programmatic_dimensions(monkeypatch):
     assert result.detail["_weights_effective"] == {}
 
 
+def test_qp_conversational_profile_drops_code_lifecycle(monkeypatch):
+    from eval.tracks import qp
+
+    monkeypatch.setattr(
+        "eval.programmatic.tool_usage.evaluate_tool_usage",
+        lambda **kwargs: {"score": 1.0, "status": "success", "reason": "ok"},
+    )
+    task = SimpleNamespace(
+        description="Discuss production readiness.",
+        category="end_to_end",
+        requires_code=False,
+        ground_truth=SimpleNamespace(
+            expected_mcp_tools=[],
+            convenient_tools=[],
+            required_capabilities=[],
+        ),
+    )
+
+    result = qp.evaluate(
+        task=task,
+        conversation=[{"role": "assistant", "content": "Use a phased rollout."}],
+        enriched_conversation=[],
+        tool_logs=[],
+        distractor_names=[],
+        eval_model=None,
+        preflight={
+            "track_blockers": {
+                "qp": [
+                    {
+                        "code": "eval_model_unavailable",
+                        "track": "qp",
+                        "reason": "missing key",
+                    }
+                ]
+            }
+        },
+    )
+
+    assert "code_lifecycle" not in result.detail
+    assert "code_lifecycle" not in result.detail["_weights_used"]
+    assert all(
+        blocker.get("dimension") != "code_lifecycle"
+        for blocker in result.blocking_missing
+    )
+
+
+def test_qp_conversational_profile_survives_tool_usage_failure(monkeypatch):
+    from eval.tracks import qp
+
+    def fail_tool_usage(**_kwargs):
+        raise RuntimeError("tool usage failed")
+
+    monkeypatch.setattr(
+        "eval.programmatic.tool_usage.evaluate_tool_usage",
+        fail_tool_usage,
+    )
+    task = SimpleNamespace(
+        description="Discuss production readiness.",
+        category="end_to_end",
+        requires_code=False,
+        ground_truth=SimpleNamespace(
+            expected_mcp_tools=[],
+            convenient_tools=[],
+            required_capabilities=[],
+        ),
+    )
+
+    result = qp.evaluate(
+        task=task,
+        conversation=[{"role": "assistant", "content": "Use a phased rollout."}],
+        enriched_conversation=[],
+        tool_logs=[],
+        distractor_names=[],
+        eval_model=None,
+        preflight={
+            "track_blockers": {
+                "qp": [
+                    {
+                        "code": "eval_model_unavailable",
+                        "track": "qp",
+                        "reason": "missing key",
+                    }
+                ]
+            }
+        },
+    )
+
+    assert "code_lifecycle" not in result.detail["_weights_used"]
+    assert all(
+        blocker.get("dimension") != "code_lifecycle"
+        for blocker in result.blocking_missing
+    )
+
+
+def test_qp_code_category_retains_code_lifecycle_without_requires_code(monkeypatch):
+    from eval.tracks import qp
+
+    monkeypatch.setattr(
+        "eval.programmatic.tool_usage.evaluate_tool_usage",
+        lambda **kwargs: {"score": 1.0, "status": "success", "reason": "ok"},
+    )
+    monkeypatch.setattr(
+        "eval.programmatic.code_process.evaluate_code_lifecycle",
+        lambda logs: {"score": 0.7, "status": "success", "reason": "code used"},
+    )
+    task = SimpleNamespace(
+        description="Implement a strategy.",
+        category="implementation",
+        requires_code=False,
+        ground_truth=SimpleNamespace(
+            expected_mcp_tools=[],
+            convenient_tools=[],
+            required_capabilities=[],
+        ),
+    )
+
+    result = qp.evaluate(
+        task=task,
+        conversation=[{"role": "assistant", "content": "I wrote code."}],
+        enriched_conversation=[],
+        tool_logs=[],
+        distractor_names=[],
+        eval_model=None,
+        preflight={
+            "track_blockers": {
+                "qp": [
+                    {
+                        "code": "eval_model_unavailable",
+                        "track": "qp",
+                        "reason": "missing key",
+                    }
+                ]
+            }
+        },
+    )
+
+    assert result.detail["code_lifecycle"]["score"] == 0.7
+    assert result.detail["_weights_used"]["code_lifecycle"] == 0.15
+
+
+def test_qr_conversational_profile_omits_data_source_check(tmp_path):
+    from eval.tracks.qr import _programmatic_eval
+
+    script = tmp_path / "fake_eval.py"
+    script.write_text(
+        "\n".join(
+            [
+                "def evaluate(workspace_path, tool_logs=None, conversation=None, *, data_files=None):",
+                "    return {",
+                "        'score': 0.5,",
+                "        'data_source_verified': False,",
+                "        'data_source_fraction': 0.0,",
+                "        '_checklist': [",
+                "            {'item': 'data_source_verified', 'weight': 0.5, 'passed': False},",
+                "            {'item': 'readiness_plan', 'weight': 0.5, 'passed': True},",
+                "        ],",
+                "        'data_files_were_passed': data_files is not None,",
+                "    }",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    task = SimpleNamespace(
+        category="end_to_end",
+        requires_code=False,
+        environment=SimpleNamespace(data_files=["AAPL_2018_2024.csv"]),
+        ground_truth=SimpleNamespace(verification_script="fake_eval.py"),
+    )
+
+    result, error = _programmatic_eval(
+        task=task,
+        bench_root=tmp_path,
+        workspace_path=str(tmp_path),
+        conversation=[],
+        tool_logs=[],
+    )
+
+    assert error is None
+    assert result["score"] == 1.0
+    assert result["data_files_were_passed"] is False
+    assert "data_source_verified" not in result
+    assert result["_data_source_check_applicable"] is False
+    assert result["_removed_checklist_items"] == ["data_source_verified"]
+
+
 def test_required_tool_coverage_is_post_hoc_programmatic():
     from eval.judges.process_metrics import compute_required_tool_coverage
 

--- a/bench/tests/unit/test_process_metrics_model_keys.py
+++ b/bench/tests/unit/test_process_metrics_model_keys.py
@@ -38,10 +38,10 @@ def test_qp_metrics_accept_injected_client_object():
     assert result["_weights_used"] == {
         "tool_usage": 0.20,
         "action_economy": 0.15,
-        "code_lifecycle": 0.15,
         "task_planning": 0.25,
         "problem_solving": 0.25,
     }
+    assert "code_lifecycle" not in result
     assert result["_weights_effective"] == {
         "tool_usage": 0.3333,
         "action_economy": 0.25,


### PR DESCRIPTION
Closes #199

## What changed

- Added rubric profile resolution from `task.rubric_profile`, task category, and code requirements.
- Propagated `rubric_profile` into reference task metadata.
- Made QR programmatic checklist selection profile-aware and renormalized scores after removing inapplicable checklist items.
- Made QP process metric weights profile-aware so conversational and safety tasks use the applicable dimension set.
- Updated storage validation to honor the selected QP dimensions in `_weights_used`.
- Added regression coverage for conversational profiles, tool-usage failure re-finalization, code-category lifecycle retention, and QR data-source omission.

## Verification

- `.venv/bin/python -m pytest bench/tests/unit/test_eval_architecture_contracts.py bench/tests/unit/test_process_metrics_model_keys.py`
- `.venv/bin/python -m pytest bench/tests/integration/test_reference_bundle.py bench/tests/integration/test_bundle_roundtrip.py`
- `.venv/bin/python -m compileall bench/eval/rubrics/task_profiles.py bench/eval/tracks/qr.py bench/eval/tracks/qp.py bench/eval/judges/process_metrics.py bench/server/reference/task_suite.py bench/eval/contracts/schemas.py bench/server/storage/eval_writer.py`
- `git diff --check`

`ruff` is unavailable in the local virtualenv. The 19-session rescore requires the server-side session artifacts or a bench-vl deployment with this branch.
