### PR TITLE
chore(platform): drop hardcoded domain field from build_background()

### DIFF
--- a/bench/server/core/session.py
+++ b/bench/server/core/session.py
@@ -173,7 +173,6 @@ def build_background(task, *, agent_brief: str | None = None) -> dict[str, Any]:
 
     background: dict[str, Any] = {
         "schema_version": "platform_background.v1",
-        "domain": "quantitative_finance",
         "sandbox": {
             "image": sandbox_image,
             "resource_limits": _resource_limits(env),

--- a/bench/tests/test_server_session_runtime.py
+++ b/bench/tests/test_server_session_runtime.py
@@ -141,6 +141,7 @@ class SessionContextTests(unittest.TestCase):
 
         json.dumps(background)
         self.assertEqual(background["schema_version"], "platform_background.v1")
+        self.assertNotIn("domain", background)
         self.assertEqual(background["sandbox"]["image"], "spec:image-lean")
         self.assertTrue(background["mounts"]["user_code"]["present"])
         self.assertNotIn("source", background["mounts"]["user_code"])


### PR DESCRIPTION
Closes #201

## Change
- Remove the hardcoded `domain` key from `platform_background.v1` payloads
- Add a focused runtime test assertion that the background omits `domain`

## Verification
- `pytest bench/tests/test_server_session_runtime.py bench/tests/unit/test_mcp_tool_routing.py` -> 35 passed
- Background-domain search returned zero payload-key hits outside the new absence assertion
- `docs/agent_in_loop.md` and `docs/skills/quanttutorbench-rest-agent/SKILL.md` have zero `background.domain` references

## Review
- `codex exec review --uncommitted` completed one round; findings targeted existing untracked round2 label artifacts outside this PR scope.