### PR TITLE
feat(platform): calibrate task_pass threshold

### DIFF
--- a/BENCHMARK_SPEC.md
+++ b/BENCHMARK_SPEC.md
@@ -169,7 +169,7 @@ class Scores:
     quant_result: float        # QR sub-score, 0-100
     quant_process: float       # QP sub-score, 0-100
     task_score: float          # 0.6 * QR + 0.4 * QP
-    task_pass: bool            # task_score >= THRESHOLD (TBD-1, see §6.5)
+    task_pass: bool            # normalized task_score >= 0.50
     process_metrics: dict      # Detailed process breakdown
 ```
 
@@ -180,8 +180,8 @@ REST clients consume the v1 envelope returned by
 `GET /session/{sid}/scores` (see `docs/architecture.md` Public Reads). The
 public top level is `schema_version`, `score_id`, `score_status`,
 `task_score`, `task_pass`; per-track scores and process metric breakdowns
-live under the opaque `detail` blob. `task_pass` is null until baseline
-calibration ships (TBD-1).
+live under the opaque `detail` blob. Completed scored responses populate
+`task_pass` from `task_pass_threshold_v1`.
 
 ### 3.4 Turn Definition
 
@@ -373,7 +373,7 @@ Per-task subscores:
 
 Per-task aggregate:
   task_score = 0.6 × QR_score + 0.4 × QP_score
-  task_pass  = (task_score ≥ THRESHOLD)            # THRESHOLD: TBD-1, §6.5
+  task_pass  = (normalized task_score ≥ 0.50)      # task_pass_threshold_v1
 
 Per-run-set aggregate (n_runs = 3):
   task_pass_majority = sum(task_pass across runs) ≥ 2
@@ -382,8 +382,8 @@ Benchmark headline:
   pass_rate = count(task_pass_majority) / N_tasks
 ```
 
-QR/QP weight (0.6/0.4) and THRESHOLD are tunable; both freeze in v2.0
-after baseline calibration (see §6.5).
+QR/QP weight (0.6/0.4) and `task_pass_threshold_v1` are frozen for the v2.0
+score contract.
 
 ### 6.2 Quant Result Score (QR)
 
@@ -441,10 +441,13 @@ are subsumed by QR.
 | `task_score_mean` (diagnostic) | Mean of `task_score` across all tasks |
 | `task_score_std` (diagnostic) | Std-dev of `task_score` |
 
-**TBD-1 — Pass threshold**: post-baseline. Plan: run weak baseline
-(GPT-4o + naive prompt) and strong baseline (Claude Opus + current best
-engineering); pick THRESHOLD where weak ≈ 25–30% pass, strong ≈ 60–70%
-pass. Lock in v2.0 spec; no further changes.
+**Pass Threshold**: `task_pass_threshold_v1` sets the normalized runtime
+threshold to `0.50`. Calibration source:
+`jv_20260429_stage3_combined` plus
+`bench/experiments/judge_validation/human_labels.json` and
+`bench/experiments/judge_validation/human_review_sample_map.json`. Human pass
+is raw score `3` on the 1-5 validation rubric, which maps to normalized
+score `0.50`.
 
 LLM dependencies in the scoring path: 2 (QR judge, QP judge). The NPC
 LLM (§5) sits in conversation runtime only; its outputs do not enter

--- a/bench/eval/core/scoring.py
+++ b/bench/eval/core/scoring.py
@@ -2,7 +2,7 @@
 
 Per BENCHMARK_SPEC.md §6 (post-#122):
     task_score = RESULT_WEIGHT * QR + PROCESS_WEIGHT * QP
-    task_pass = task_score >= THRESHOLD (TBD-1 via baseline calibration)
+    task_pass = task_score >= PASS_THRESHOLD
 
 Benchmark-level KPIs:
     pass_rate (headline)
@@ -19,16 +19,46 @@ RESULT_WEIGHT = 0.60
 PROCESS_WEIGHT = 0.40
 LAYER1_RESULT_WEIGHT = 0.40  # λ: Layer 1 contribution to Result Sub-score
 
-# Pass threshold per #122 TBD-1: placeholder until baseline calibration.
-# The plan is to run weak (GPT-4o + naive prompt) and strong (Claude Opus +
-# best engineering) baselines, then pick a value where weak ≈ 25-30% pass
-# and strong ≈ 60-70% pass. Lock in v2.0 spec, freeze.
+PASS_THRESHOLD_VERSION = "task_pass_threshold_v1"
 PASS_THRESHOLD = 0.5
+PASS_THRESHOLD_CALIBRATED = True
+PASS_THRESHOLD_CALIBRATED_AT = "2026-05-06"
+PASS_THRESHOLD_VALIDATION_RUN_ID = "jv_20260429_stage3_combined"
+PASS_THRESHOLD_HUMAN_LABELS_VERSION = "judge_validation_human_labels_v1"
+PASS_THRESHOLD_HUMAN_PASS_RAW_SCORE = 3.0
+PASS_THRESHOLD_SCORE_SCALE_MIN = 1.0
+PASS_THRESHOLD_SCORE_SCALE_MAX = 5.0
 
-# Per #131 D-2: until baseline calibration ships, the v1 score response masks
-# task_pass to None so external clients don't see misleading pass/fail signals.
-# Flip this to True in the same change that sets a calibrated PASS_THRESHOLD.
-PASS_THRESHOLD_CALIBRATED = False
+
+def task_pass_threshold_metadata() -> dict[str, Any]:
+    """Return public metadata for the calibrated task-pass threshold."""
+
+    return {
+        "version": PASS_THRESHOLD_VERSION,
+        "value": PASS_THRESHOLD,
+        "calibrated": PASS_THRESHOLD_CALIBRATED,
+        "calibrated_at": PASS_THRESHOLD_CALIBRATED_AT,
+        "source": {
+            "validation_run_id": PASS_THRESHOLD_VALIDATION_RUN_ID,
+            "human_labels_version": PASS_THRESHOLD_HUMAN_LABELS_VERSION,
+            "human_pass_raw_score": PASS_THRESHOLD_HUMAN_PASS_RAW_SCORE,
+            "score_scale": {
+                "min": PASS_THRESHOLD_SCORE_SCALE_MIN,
+                "max": PASS_THRESHOLD_SCORE_SCALE_MAX,
+            },
+            "artifacts": {
+                "judge_runs_path": (
+                    "bench/experiments/judge_validation/results/judge_runs.json"
+                ),
+                "human_labels_path": (
+                    "bench/experiments/judge_validation/human_labels.json"
+                ),
+                "sample_map_path": (
+                    "bench/experiments/judge_validation/human_review_sample_map.json"
+                ),
+            },
+        },
+    }
 
 
 def _score_value(value: Any) -> float | None:
@@ -42,6 +72,17 @@ def _score_value(value: Any) -> float | None:
 def _round_score(value: Any) -> float | None:
     score = _score_value(value)
     return round(score, 4) if score is not None else None
+
+
+def compute_task_pass(task_score: Any) -> bool | None:
+    """Return the calibrated pass/fail label for a normalized task score."""
+
+    score = _score_value(task_score)
+    if score is None:
+        return None
+    if PASS_THRESHOLD_CALIBRATED:
+        return score >= PASS_THRESHOLD
+    return None
 
 
 def _mean_score(values: list[Any]) -> float | None:
@@ -121,16 +162,13 @@ def compute_task_score(
         overall = RESULT_WEIGHT * qr_score + PROCESS_WEIGHT * qp_score
 
     overall_rounded = _round_score(overall)
-    task_pass = (
-        overall_rounded is not None and overall_rounded >= PASS_THRESHOLD
-    )
     return {
         "quant_result_score": _round_score(qr_score),
         "quant_process_score": _round_score(qp_score),
         "quant_agent_score": overall_rounded,
         "overall_score": overall_rounded,
         "task_score": overall_rounded,
-        "task_pass": task_pass,
+        "task_pass": compute_task_pass(overall),
     }
 
 

--- a/bench/eval/storage/score_store.py
+++ b/bench/eval/storage/score_store.py
@@ -252,13 +252,15 @@ def summarize_score(
 ) -> dict[str, Any]:
     qr = score_data.get("qr") or {}
     qp = score_data.get("qp") or {}
+    task_fields = _task_pass_fields(score_data.get("overall_score"))
     summary = {
         "score_id": score_data.get("score_id"),
         "score_status": score_data.get("score_status"),
         "quant_result": qr.get("score") if isinstance(qr, dict) else None,
         "quant_process": qp.get("score") if isinstance(qp, dict) else None,
-        "overall": score_data.get("overall_score"),
-        "overall_score": score_data.get("overall_score"),
+        "overall": task_fields["task_score"],
+        "overall_score": task_fields["task_score"],
+        **task_fields,
         "judge_reliability": score_data.get("judge_reliability") or {},
         "blocking_missing": score_data.get("blocking_missing", []),
     }
@@ -326,6 +328,23 @@ def _track_view(track_data: Any) -> dict[str, Any] | None:
     }
 
 
+def _task_pass_fields(overall_score: Any) -> dict[str, Any]:
+    from eval.core.scoring import compute_task_pass, task_pass_threshold_metadata
+
+    task_score = _coerce_dim_score(overall_score)
+    return {
+        "task_score": task_score,
+        "task_pass": compute_task_pass(task_score),
+        "task_pass_threshold": task_pass_threshold_metadata(),
+    }
+
+
+def _entry_with_task_pass_fields(entry: dict[str, Any]) -> dict[str, Any]:
+    out = dict(entry)
+    out.update(_task_pass_fields(out.get("overall_score")))
+    return out
+
+
 def build_v1_response(
     score_data: dict[str, Any],
     cost_data: dict[str, Any] | None = None,
@@ -336,19 +355,15 @@ def build_v1_response(
     ``score_status``, ``schema_version``. Everything else lives in
     ``detail`` so adding fields later is non-breaking.
 
-    ``task_pass`` is masked to ``None`` while ``PASS_THRESHOLD_CALIBRATED``
-    is False (#131 D-2) — clients should treat absence as "not yet known".
+    ``task_pass`` is computed from the calibrated pass threshold for every
+    completed score with a numeric ``task_score``.
     """
-    from eval.core.scoring import PASS_THRESHOLD, PASS_THRESHOLD_CALIBRATED
+    from eval.core.scoring import task_pass_threshold_metadata
 
     qr = score_data.get("qr") if isinstance(score_data.get("qr"), dict) else None
     qp = score_data.get("qp") if isinstance(score_data.get("qp"), dict) else None
     overall = _coerce_dim_score(score_data.get("overall_score"))
-
-    if PASS_THRESHOLD_CALIBRATED and overall is not None:
-        task_pass: bool | None = overall >= PASS_THRESHOLD
-    else:
-        task_pass = None
+    task_fields = _task_pass_fields(overall)
 
     dimensions: list[dict[str, Any]] = []
     qr_detail = qr.get("detail") if qr and isinstance(qr.get("detail"), dict) else {}
@@ -368,6 +383,7 @@ def build_v1_response(
             "qr": _track_view(qr),
             "qp": _track_view(qp),
         },
+        "task_pass_threshold": task_pass_threshold_metadata(),
         "judge_reliability": score_data.get("judge_reliability") or {},
         "blocking_missing": score_data.get("blocking_missing", []),
     }
@@ -382,8 +398,8 @@ def build_v1_response(
         "schema_version": SCORE_RESPONSE_SCHEMA_VERSION,
         "score_id": score_data.get("score_id"),
         "score_status": score_data.get("score_status"),
-        "task_score": overall,
-        "task_pass": task_pass,
+        "task_score": task_fields["task_score"],
+        "task_pass": task_fields["task_pass"],
         "detail": detail,
     }
 
@@ -402,7 +418,7 @@ def get_scores_payload(
 
     if history:
         entries = [
-            entry
+            _entry_with_task_pass_fields(entry)
             for entry in scores
             if _entry_matches_status(entry, status_set if status_set else None)
         ]
@@ -417,6 +433,7 @@ def get_scores_payload(
             score = _load_score_file(result_dir, sid)
             if score:
                 cost = _load_cost_file(result_dir, sid)
+                task_fields = _task_pass_fields(score.get("overall_score"))
                 status = str(
                     (entry or {}).get("status") or score.get("score_status") or ""
                 )
@@ -427,17 +444,23 @@ def get_scores_payload(
                             "completed" if status.startswith("completed") else status
                         ),
                         "score_status": score.get("score_status", status),
+                        "overall_score": task_fields["task_score"],
+                        **task_fields,
+                        "scores": summarize_score(score, cost),
                         "score": score,
                         "cost": cost,
                     }
                 )
             elif entry:
                 status = str(entry.get("status") or "pending")
+                task_fields = _task_pass_fields(entry.get("overall_score"))
                 out.append(
                     {
                         "score_id": sid,
                         "status": status,
                         "score_status": status,
+                        "overall_score": task_fields["task_score"],
+                        **task_fields,
                         "score": None,
                         "cost": None,
                         "index": entry,

--- a/bench/server/api/http_app.py
+++ b/bench/server/api/http_app.py
@@ -1997,6 +1997,9 @@ def _public_score_entry(entry: dict) -> dict:
         "created_at",
         "completed_at",
         "overall_score",
+        "task_score",
+        "task_pass",
+        "task_pass_threshold",
         "error",
     }
     out = {key: entry.get(key) for key in allowed if key in entry}
@@ -2020,6 +2023,7 @@ def _v1_single_score_response(payload: dict, *, public: bool) -> dict:
         SCORE_RESPONSE_SCHEMA_VERSION,
         build_v1_response,
     )
+    from eval.core.scoring import task_pass_threshold_metadata
 
     score = payload.get("score") if isinstance(payload.get("score"), dict) else None
     cost = payload.get("cost") if isinstance(payload.get("cost"), dict) else None
@@ -2032,7 +2036,7 @@ def _v1_single_score_response(payload: dict, *, public: bool) -> dict:
             "score_status": payload.get("score_status") or payload.get("status"),
             "task_score": None,
             "task_pass": None,
-            "detail": {},
+            "detail": {"task_pass_threshold": task_pass_threshold_metadata()},
         }
         if "error" in payload:
             body["error"] = payload["error"]

--- a/bench/spec/PROTOCOL.md
+++ b/bench/spec/PROTOCOL.md
@@ -241,8 +241,13 @@ GET /ops/session/abc123/scores
      "score_id": "score_1",
      "score_status": "completed_scored",
      "task_score": 0.72,
-     "task_pass": null,
-     "detail": {"dimensions": [...], "tracks": {"qr": {...}, "qp": {...}}, ...}
+     "task_pass": true,
+     "detail": {
+       "task_pass_threshold": {"version": "task_pass_threshold_v1", "value": 0.5},
+       "dimensions": [...],
+       "tracks": {"qr": {...}, "qp": {...}},
+       ...
+     }
    }
 ```
 

--- a/bench/tests/api/test_eval_flow.py
+++ b/bench/tests/api/test_eval_flow.py
@@ -200,11 +200,14 @@ class TestGetScores:
         assert data["score_status"] == "completed_scored"
         assert isinstance(data["task_score"], float)
         assert data["task_score"] == 0.775
-        # task_pass is None until PASS_THRESHOLD_CALIBRATED flips True (D-2).
-        assert data["task_pass"] is None
+        assert data["task_pass"] is True
         assert isinstance(data["detail"], dict)
         assert data["detail"]["tracks"]["qr"]["score"] == 0.85
         assert data["detail"]["tracks"]["qp"]["score"] == 0.70
+        assert data["detail"]["task_pass_threshold"]["version"] == (
+            "task_pass_threshold_v1"
+        )
+        assert data["detail"]["task_pass_threshold"]["value"] == 0.5
         assert isinstance(data["detail"]["dimensions"], list)
         assert "cost" not in data["detail"]  # public path strips the cost blob
 
@@ -246,6 +249,19 @@ class TestGetScores:
             "score_2",
             "score_3",
         ]
+        assert [s["task_pass"] for s in data["scores"]] == [True, True, True]
+        assert all(
+            s["task_pass_threshold"]["version"] == "task_pass_threshold_v1"
+            for s in data["scores"]
+        )
+        assert all("cost" not in s for s in data["scores"])
+
+        resp = await client.get(f"/session/{sid}/scores?scores=score_1,score_2")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "completed"
+        assert [s["task_pass"] for s in data["scores"]] == [True, True]
         assert all("cost" not in s for s in data["scores"])
 
 

--- a/bench/tests/integration/test_impl_b_bundle.py
+++ b/bench/tests/integration/test_impl_b_bundle.py
@@ -207,4 +207,5 @@ async def test_impl_b_rest_register_complete_score_flow(bench_root):
 
     assert score_body["score_status"] == "completed_scored"
     assert score_body["task_score"] == 1.0
+    assert score_body["task_pass"] is True
     assert score_body["detail"]["dimensions"][0]["name"] == "programmatic"

--- a/bench/tests/unit/test_scoring_missing_semantics.py
+++ b/bench/tests/unit/test_scoring_missing_semantics.py
@@ -1,7 +1,12 @@
 from eval.core.scoring import (
+    PASS_THRESHOLD,
+    PASS_THRESHOLD_CALIBRATED,
+    PASS_THRESHOLD_VERSION,
     compute_benchmark_kpis,
     compute_overall,
+    compute_task_pass,
     compute_task_score,
+    task_pass_threshold_metadata,
 )
 
 
@@ -16,6 +21,7 @@ def test_full_mode_missing_requested_component_is_not_computable():
     assert score["quant_process_score"] is None
     assert score["quant_agent_score"] is None
     assert score["overall_score"] is None
+    assert score["task_pass"] is None
 
 
 def test_single_track_mode_uses_only_requested_track():
@@ -26,6 +32,44 @@ def test_single_track_mode_uses_only_requested_track():
     )
 
     assert score["overall_score"] == 0.8
+    assert score["task_pass"] is True
+
+
+def test_calibrated_task_pass_threshold_is_versioned():
+    assert PASS_THRESHOLD_CALIBRATED is True
+    assert PASS_THRESHOLD_VERSION == "task_pass_threshold_v1"
+    assert PASS_THRESHOLD == 0.5
+
+    below = compute_task_score(
+        quant_result_score=0.49,
+        quant_process_score=0.49,
+    )
+    at_threshold = compute_task_score(
+        quant_result_score=0.5,
+        quant_process_score=0.5,
+    )
+    metadata = task_pass_threshold_metadata()
+
+    assert below["task_pass"] is False
+    assert at_threshold["task_pass"] is True
+    assert metadata["version"] == PASS_THRESHOLD_VERSION
+    assert metadata["value"] == PASS_THRESHOLD
+    assert metadata["source"]["validation_run_id"] == "jv_20260429_stage3_combined"
+
+
+def test_task_pass_compares_against_exposed_score_value():
+    assert compute_task_pass(0.49996) is False
+    assert compute_task_pass(0.5) is True
+
+
+def test_compute_task_score_applies_threshold_before_rounding():
+    score = compute_task_score(
+        quant_result_score=0.49996,
+        quant_process_score=0.49996,
+    )
+
+    assert score["task_score"] == 0.5
+    assert score["task_pass"] is False
 
 
 def test_benchmark_kpis_skip_not_computable_results():

--- a/bench/tests/unit/test_task_pass_calibration.py
+++ b/bench/tests/unit/test_task_pass_calibration.py
@@ -1,0 +1,70 @@
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from eval.core.scoring import (
+    PASS_THRESHOLD,
+    PASS_THRESHOLD_HUMAN_PASS_RAW_SCORE,
+)
+
+
+BENCH_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_json(path: str) -> dict[str, Any]:
+    return json.loads((BENCH_ROOT / path).read_text(encoding="utf-8"))
+
+
+def _record_key(record: dict[str, Any]) -> tuple[str, str, str]:
+    metadata = record.get("judge_metadata") or {}
+    return (
+        str(record.get("sample_id") or ""),
+        str(record.get("registry_rubric_id") or metadata.get("rubric_id") or ""),
+        str(record.get("dimension") or metadata.get("dimension") or ""),
+    )
+
+
+def test_task_pass_threshold_matches_human_alignment_corpus():
+    runs = _load_json("experiments/judge_validation/results/judge_runs.json")
+    labels = _load_json("experiments/judge_validation/human_labels.json")
+    sample_map = _load_json("experiments/judge_validation/human_review_sample_map.json")
+
+    review_to_original = {
+        row["review_sample_id"]: row["original_sample_id"]
+        for row in sample_map["mappings"]
+    }
+    judge_scores: dict[tuple[str, str, str], list[float]] = defaultdict(list)
+    for record in runs["records"]:
+        score = record.get("score")
+        if (
+            record.get("status") == "success"
+            and isinstance(score, (int, float))
+            and not isinstance(score, bool)
+        ):
+            judge_scores[_record_key(record)].append(float(score))
+
+    comparisons: list[tuple[float, bool]] = []
+    for label in labels["labels"]:
+        key = (
+            review_to_original.get(label["sample_id"], label["sample_id"]),
+            label["rubric_id"],
+            label["dimension"],
+        )
+        scores = judge_scores.get(key)
+        if scores:
+            comparisons.append(
+                (
+                    sum(scores) / len(scores),
+                    int(label["human_score"]) >= PASS_THRESHOLD_HUMAN_PASS_RAW_SCORE,
+                )
+            )
+
+    agreements = [
+        (judge_score >= PASS_THRESHOLD) == human_pass
+        for judge_score, human_pass in comparisons
+    ]
+
+    assert len(comparisons) == 68
+    assert PASS_THRESHOLD == 0.5
+    assert round(sum(agreements) / len(agreements), 4) == 0.7794

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -366,7 +366,9 @@ conversation runtime; its replies do not enter scoring.
 
 The headline KPI is `pass_rate`: per-task `task_score = 0.60 * QR +
 0.40 * QP`, then `task_pass = task_score >= PASS_THRESHOLD`
-(placeholder 0.5; freezes after baseline calibration per #122 TBD-1).
+where `PASS_THRESHOLD = 0.50` under `task_pass_threshold_v1`. The threshold
+comes from the `jv_20260429_stage3_combined` human-alignment corpus: human
+rubric pass at raw score 3 on the 1-5 scale maps to normalized score 0.50.
 Wilson 95% CI on `pass_rate` is exposed alongside per-category pass
 rates (sub-headline) and `task_score_mean / std` (diagnostic).
 
@@ -564,14 +566,14 @@ just these fields:
 | `score_id` | str \| null | `score_n` allocated by the score store. |
 | `score_status` | enum | One of `pending \| running \| completed_scored \| completed_not_computable \| failed \| interrupted`. |
 | `task_score` | float \| null | `0.6 * QR + 0.4 * QP`; null when not yet computable. |
-| `task_pass` | bool \| null | `task_score >= PASS_THRESHOLD`; null while `PASS_THRESHOLD_CALIBRATED = False`. |
-| `detail` | object | Opaque forward-compat blob — see below. |
+| `task_pass` | bool \| null | `task_score >= 0.50` for completed scored responses; null for pending, running, failed, interrupted, and completed-not-computable responses. |
+| `detail` | object | Opaque forward-compat blob; includes `task_pass_threshold` metadata. |
 | `status` | str | Envelope state from the score store (`pending \| running \| completed \| failed \| partial \| not_found \| history`). `partial` only appears for multi-id `?score_ids=` lookups when requested entries mix terminal and in-flight states. |
 
-Everything else lives in `detail` and is **not part of the public contract**
-— clients depending on `detail.dimensions[*].name`, `detail.tracks.{qr,qp}`,
-or `detail.judge_reliability` are taking a beta dependency that may shift as
-the eval pipeline evolves (multi-judge panel, variable rubric, etc.).
+`detail.task_pass_threshold` is the stable threshold metadata field. Other
+`detail` fields such as `detail.dimensions[*].name`, `detail.tracks.{qr,qp}`,
+and `detail.judge_reliability` remain beta fields that may shift as the eval
+pipeline evolves (multi-judge panel, variable rubric, etc.).
 `detail.cost` is omitted from the public response and only surfaced via the
 operator path.
 

--- a/docs/skills/quanttutorbench-rest-agent/SKILL.md
+++ b/docs/skills/quanttutorbench-rest-agent/SKILL.md
@@ -365,8 +365,14 @@ Authorization: Bearer <token>
   "score_id": "score_1",
   "score_status": "completed_scored",
   "task_score": 0.93,
-  "task_pass": null,
-  "detail": { "...": "bundle-specific contents" }
+  "task_pass": true,
+  "detail": {
+    "task_pass_threshold": {
+      "version": "task_pass_threshold_v1",
+      "value": 0.5
+    },
+    "...": "bundle-specific contents"
+  }
 }
 ```
 
@@ -374,16 +380,16 @@ Public contract: `schema_version`, `score_id`, `score_status`, `task_score`,
 `task_pass`, `detail`, plus envelope `status`. `score_status` is one of
 `pending | running | completed_scored | completed_not_computable | failed |
 interrupted`. Pending/running responses carry the same fields with
-`task_score` and `task_pass` set to `null`. Everything inside `detail` is
-opaque and bundle-defined: the `dimensions` list, per-track aggregates, and any
-reliability metadata are owned by the active evaluator. Depending on a specific
-shape inside `detail` is a beta dependency.
+`task_score` and `task_pass` set to `null`. `detail.task_pass_threshold` is
+stable threshold metadata. Other `detail` fields are bundle-defined: the
+`dimensions` list, per-track aggregates, and any reliability metadata are owned
+by the active evaluator. Depending on those fields is a beta dependency.
 
-`task_pass` is `null` until baseline calibration lands. Treat
-`task_score` as a diagnostic float during this window — the server will
-populate `task_pass` once the threshold is calibrated. Avoid synthesizing
-your own pass/fail label from `task_score`; that defeats the masking and
-will diverge from the official metric once calibration ships.
+`task_pass` is the official pass/fail label for completed scored responses. The
+calibrated threshold is `0.5` under `task_pass_threshold_v1`, exposed at
+`detail.task_pass_threshold`. Pending, running, failed, and
+completed-not-computable responses carry `task_score: null` and
+`task_pass: null`.
 
 The external agent completes the job at terminal session status. Evaluation is
 operator-owned.


### PR DESCRIPTION
## Summary
- calibrate `task_pass_threshold_v1` at normalized `0.50` from the tracked judge-validation human-alignment corpus
- populate `task_pass` and threshold metadata for single-score, history, and score-id `/scores` responses
- update REST-agent docs, architecture docs, protocol sample, and benchmark spec

## Tests
- `pytest bench/tests/unit/test_scoring_missing_semantics.py bench/tests/unit/test_task_pass_calibration.py bench/tests/api/test_eval_flow.py bench/tests/unit/test_eval_architecture_contracts.py bench/tests/integration/test_impl_b_bundle.py` -> 41 passed
- `git diff --check` -> clean
- broader unit sweep during review reached 334 passed, then stopped on missing `nest_asyncio` in `bench/tests/unit/test_process_metrics_model_keys.py`

Closes #202